### PR TITLE
feat: add --pause-on-failure flag with retry/abort commands

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -28,6 +28,26 @@ import { pruneOrphanedDockerResources } from "./docker/shutdown.js";
 import { parseJobDependencies, topoSort } from "./workflow/job-scheduler.js";
 import { printSummary, type JobResult } from "./output/reporter.js";
 
+// ─── Signal helpers for retry / abort commands ────────────────────────────────
+
+function findSignalsDir(runnerName: string): string | null {
+  const workDir = getWorkingDirectory();
+  const runsDir = path.resolve(workDir, "runs");
+  if (!fs.existsSync(runsDir)) {
+    return null;
+  }
+  // Walk run dirs looking for a directory whose name ends with the runner name
+  for (const entry of fs.readdirSync(runsDir)) {
+    if (entry === runnerName || entry.endsWith(runnerName)) {
+      const signalsDir = path.join(runsDir, entry, "signals");
+      if (fs.existsSync(signalsDir)) {
+        return signalsDir;
+      }
+    }
+  }
+  return null;
+}
+
 async function run() {
   const args = process.argv.slice(2);
   const command = args[0];
@@ -36,11 +56,14 @@ async function run() {
     // Basic argument parsing
     let sha: string | undefined;
     let workflow: string | undefined;
+    let pauseOnFailure = false;
 
     for (let i = 1; i < args.length; i++) {
       if ((args[i] === "--workflow" || args[i] === "-w") && args[i + 1]) {
         workflow = args[i + 1];
         i++;
+      } else if (args[i] === "--pause-on-failure" || args[i] === "-p") {
+        pauseOnFailure = true;
       } else if (!args[i].startsWith("-")) {
         sha = args[i];
       }
@@ -61,8 +84,53 @@ async function run() {
       process.exit(1);
     }
 
-    await handleRun({ sha, workflow });
+    await handleRun({ sha, workflow, pauseOnFailure });
 
+    process.exit(0);
+  } else if (command === "retry" || command === "abort") {
+    // retry / abort: write a signal file to the runner's signals dir
+    let runnerName: string | undefined;
+    for (let i = 1; i < args.length; i++) {
+      if (args[i] === "--runner" && args[i + 1]) {
+        runnerName = args[i + 1];
+        i++;
+      }
+    }
+    if (!runnerName) {
+      console.error(`[Machinen] Error: --runner <name> is required for '${command}'`);
+      process.exit(1);
+    }
+    const signalsDir = findSignalsDir(runnerName);
+    if (!signalsDir) {
+      console.error(
+        `[Machinen] Error: No runner '${runnerName}' found. It may have already exited.`,
+      );
+      process.exit(1);
+    }
+    const pausedFile = path.join(signalsDir, "paused");
+    if (!fs.existsSync(pausedFile)) {
+      fs.rmSync(signalsDir, { recursive: true, force: true });
+      console.error(
+        `[Machinen] Error: Runner '${runnerName}' is not currently paused. It may have already exited.`,
+      );
+      process.exit(1);
+    }
+    // Verify the container is still running
+    try {
+      const { execSync } = await import("node:child_process");
+      const status = execSync(`docker inspect -f '{{.State.Running}}' ${runnerName} 2>/dev/null`, {
+        encoding: "utf-8",
+      }).trim();
+      if (status !== "true") {
+        throw new Error("not running");
+      }
+    } catch {
+      fs.rmSync(signalsDir, { recursive: true, force: true });
+      console.error(`[Machinen] Error: Runner '${runnerName}' is no longer running.`);
+      process.exit(1);
+    }
+    fs.writeFileSync(path.join(signalsDir, command), "");
+    console.log(`[Machinen] Sent '${command}' signal to ${runnerName}`);
     process.exit(0);
   } else {
     printUsage();
@@ -74,10 +142,13 @@ function printUsage() {
   console.log("Usage: machinen <command> [args]");
   console.log("");
   console.log("Commands:");
-  console.log("  run [sha] --workflow <path>: Run all jobs in a workflow file (defaults to HEAD)");
+  console.log("  run [sha] --workflow <path>   Run all jobs in a workflow file (defaults to HEAD)");
+  console.log("  retry --runner <name>         Send retry signal to a paused runner");
+  console.log("  abort --runner <name>         Send abort signal to a paused runner");
   console.log("");
   console.log("Options:");
-  console.log("  -w, --workflow <path>  Path to the workflow file");
+  console.log("  -w, --workflow <path>         Path to the workflow file");
+  console.log("  -p, --pause-on-failure        Pause on step failure and wait for retry");
 }
 
 function resolveRepoRoot() {
@@ -113,8 +184,8 @@ function resolveHeadSha(repoRoot: string, sha: string) {
   }
 }
 
-async function handleRun(options: { sha?: string; workflow?: string }) {
-  const { sha } = options;
+async function handleRun(options: { sha?: string; workflow?: string; pauseOnFailure?: boolean }) {
+  const { sha, pauseOnFailure } = options;
   let workflow = options.workflow;
 
   try {
@@ -240,9 +311,12 @@ async function handleRun(options: { sha?: string; workflow?: string }) {
         taskId: ej.taskName,
       };
 
-      const result = await executeLocalJob(job);
+      const result = await executeLocalJob(job, { pauseOnFailure });
       printSummary([result]);
       if (!result.succeeded) {
+        if (pauseOnFailure) {
+          process.stdout.write(`\n  To retry: machinen retry --runner ${result.name}\n\n`);
+        }
         process.exit(1);
       }
       return;
@@ -329,7 +403,7 @@ async function handleRun(options: { sha?: string; workflow?: string }) {
       job.services = services;
       job.container = container ?? undefined;
 
-      const result = await executeLocalJob(job);
+      const result = await executeLocalJob(job, { pauseOnFailure });
       return result;
     };
 

--- a/cli/src/docker/container-config.test.ts
+++ b/cli/src/docker/container-config.test.ts
@@ -145,3 +145,31 @@ describe("resolveDockerApiUrl", () => {
     );
   });
 });
+
+// ── signalsDir bind-mount ─────────────────────────────────────────────────────
+
+describe("buildContainerBinds with signalsDir", () => {
+  const baseOpts = {
+    hostWorkDir: "/tmp/work",
+    shimsDir: "/tmp/shims",
+    diagDir: "/tmp/diag",
+    toolCacheDir: "/tmp/toolcache",
+    pnpmStoreDir: "/tmp/pnpm",
+    playwrightCacheDir: "/tmp/playwright",
+    warmModulesDir: "/tmp/warm",
+    hostRunnerDir: "/tmp/runner",
+    useDirectContainer: false,
+  };
+
+  it("includes signals bind-mount when signalsDir is provided", async () => {
+    const { buildContainerBinds } = await import("./container-config.js");
+    const binds = buildContainerBinds({ ...baseOpts, signalsDir: "/tmp/signals" });
+    expect(binds).toContain("/tmp/signals:/tmp/machinen-signals");
+  });
+
+  it("omits signals bind-mount when signalsDir is undefined", async () => {
+    const { buildContainerBinds } = await import("./container-config.js");
+    const binds = buildContainerBinds(baseOpts);
+    expect(binds.some((b) => b.includes("machinen-signals"))).toBe(false);
+  });
+});

--- a/cli/src/docker/container-config.ts
+++ b/cli/src/docker/container-config.ts
@@ -12,6 +12,7 @@ export interface ContainerEnvOpts {
 export interface ContainerBindsOpts {
   hostWorkDir: string;
   shimsDir: string;
+  signalsDir?: string;
   diagDir: string;
   toolCacheDir: string;
   pnpmStoreDir: string;
@@ -78,6 +79,7 @@ export function buildContainerBinds(opts: ContainerBindsOpts): string[] {
   const {
     hostWorkDir,
     shimsDir,
+    signalsDir,
     diagDir,
     toolCacheDir,
     pnpmStoreDir,
@@ -93,6 +95,8 @@ export function buildContainerBinds(opts: ContainerBindsOpts): string[] {
     `${hostWorkDir}:/home/runner/_work`,
     "/var/run/docker.sock:/var/run/docker.sock",
     `${shimsDir}:/tmp/machinen-shims`,
+    // Pause-on-failure IPC: signal files (paused, retry, abort)
+    ...(signalsDir ? [`${signalsDir}:/tmp/machinen-signals`] : []),
     `${diagDir}:/home/runner/_diag`,
     `${toolCacheDir}:/opt/hostedtoolcache`,
     `${pnpmStoreDir}:/home/runner/_work/.pnpm-store`,

--- a/cli/src/output/reporter.ts
+++ b/cli/src/output/reporter.ts
@@ -20,6 +20,8 @@ export interface JobResult {
   failedStepLogPath?: string;
   failedExitCode?: number;
   lastOutputLines?: string[];
+  /** Number of attempts (only set when > 1, i.e. retried) */
+  attempt?: number;
 }
 
 // ─── Formatting helpers ───────────────────────────────────────────────────────

--- a/cli/src/runner/directory-setup.ts
+++ b/cli/src/runner/directory-setup.ts
@@ -11,6 +11,7 @@ import { debugRunner } from "../output/debug.js";
 export interface RunDirectories {
   containerWorkDir: string;
   shimsDir: string;
+  signalsDir: string;
   diagDir: string;
   toolCacheDir: string;
   pnpmStoreDir: string;
@@ -41,6 +42,7 @@ export function createRunDirectories(opts: CreateRunDirectoriesOpts): RunDirecto
   // Per-run dirs
   const containerWorkDir = path.resolve(runDir, "work");
   const shimsDir = path.resolve(runDir, "shims");
+  const signalsDir = path.resolve(runDir, "signals");
   const diagDir = path.resolve(runDir, "diag");
 
   // Shared caches
@@ -70,6 +72,7 @@ export function createRunDirectories(opts: CreateRunDirectoriesOpts): RunDirecto
     workspaceDir,
     containerWorkDir,
     shimsDir,
+    signalsDir,
     diagDir,
     toolCacheDir,
     pnpmStoreDir,
@@ -92,6 +95,7 @@ export function createRunDirectories(opts: CreateRunDirectoriesOpts): RunDirecto
   return {
     containerWorkDir,
     shimsDir,
+    signalsDir,
     diagDir,
     toolCacheDir,
     pnpmStoreDir,

--- a/cli/src/runner/local-job.ts
+++ b/cli/src/runner/local-job.ts
@@ -32,6 +32,7 @@ import {
   resolveDockerApiUrl,
 } from "../docker/container-config.js";
 import { buildJobResult } from "./result-builder.js";
+import { wrapJobSteps } from "./step-wrapper.js";
 
 // ─── Docker setup ─────────────────────────────────────────────────────────────
 
@@ -100,7 +101,11 @@ function writeRunnerCredentials(runnerDir: string, runnerName: string, serverUrl
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
-export async function executeLocalJob(job: Job): Promise<JobResult> {
+export async function executeLocalJob(
+  job: Job,
+  options?: { pauseOnFailure?: boolean },
+): Promise<JobResult> {
+  const pauseOnFailure = options?.pauseOnFailure ?? false;
   const startTime = Date.now();
 
   // ── Pre-flight: verify Docker is reachable ────────────────────────────────
@@ -192,7 +197,7 @@ export async function executeLocalJob(job: Job): Promise<JobResult> {
   const signalCleanup = () => {
     // Force-kill Docker containers (sync so it works in signal handlers)
     killRunnerContainers(containerName);
-    for (const d of [dirs.containerWorkDir, dirs.shimsDir, dirs.diagDir]) {
+    for (const d of [dirs.containerWorkDir, dirs.shimsDir, dirs.signalsDir, dirs.diagDir]) {
       try {
         fs.rmSync(d, { recursive: true, force: true });
       } catch {}
@@ -216,6 +221,9 @@ export async function executeLocalJob(job: Job): Promise<JobResult> {
         }
       : job.repository;
 
+    // Wrap run: steps in the pause-on-failure retry loop before seeding
+    const seededSteps = pauseOnFailure ? wrapJobSteps(job.steps ?? [], true) : job.steps;
+
     const seedResponse = await fetch(`${dtuUrl}/_dtu/seed`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -225,6 +233,7 @@ export async function executeLocalJob(job: Job): Promise<JobResult> {
         status: "queued",
         localPath: dirs.workspaceDir,
         ...job,
+        steps: seededSteps,
         // Override repository with the git-remote-resolved repo (takes precedence over ...job spread)
         repository: overriddenRepository,
       }),
@@ -387,6 +396,7 @@ export async function executeLocalJob(job: Job): Promise<JobResult> {
     const containerBinds = buildContainerBinds({
       hostWorkDir,
       shimsDir: dirs.shimsDir,
+      signalsDir: pauseOnFailure ? dirs.signalsDir : undefined,
       diagDir: dirs.diagDir,
       toolCacheDir: dirs.toolCacheDir,
       pnpmStoreDir: dirs.pnpmStoreDir,
@@ -434,12 +444,37 @@ export async function executeLocalJob(job: Job): Promise<JobResult> {
     // This captures the full startup time including .NET cold-start inside
     // the container.
 
+    // ANSI color helpers
+    const YELLOW = `${String.fromCharCode(27)}[33m`;
+    const RESET = `${String.fromCharCode(27)}[0m`;
+
     let tailDone = false;
     let lastFailedStep: string | null = null;
+    let isPaused = false;
+    let pausedStepName: string | null = null;
+    let pausedAtMs: number | null = null;
+    let lastSeenAttempt = 0;
     const timelinePath = path.join(logDir, "timeline.json");
+    const pausedSignalPath = path.join(dirs.signalsDir, "paused");
 
     const checkTimeline = () => {
       try {
+        // ── Pause-on-failure: check for paused signal ───────────────────────────
+        if (pauseOnFailure && fs.existsSync(pausedSignalPath)) {
+          const content = fs.readFileSync(pausedSignalPath, "utf-8").trim();
+          const lines = content.split("\n");
+          pausedStepName = lines[0] || null;
+          const attempt = parseInt(lines[1] || "1", 10);
+          if (attempt !== lastSeenAttempt) {
+            lastSeenAttempt = attempt;
+            isPaused = true;
+            pausedAtMs = Date.now();
+          }
+        } else if (isPaused && !fs.existsSync(pausedSignalPath)) {
+          // File completely gone (abort cleaned it up)
+          isPaused = false;
+          pausedAtMs = null;
+        }
         if (!fs.existsSync(timelinePath)) {
           return;
         }
@@ -487,7 +522,22 @@ export async function executeLocalJob(job: Job): Promise<JobResult> {
             if (r.startTime) {
               const stepElapsed = Math.round((Date.now() - new Date(r.startTime).getTime()) / 1000);
               const frame = spinnerFrames[spinnerIdx % spinnerFrames.length];
-              stepNodes.push({ label: `${frame} ${stepName} (${stepElapsed}s...)` });
+              if (isPaused && pausedStepName === stepName) {
+                // Paused: show ⏸ icon with frozen timer, add a yellow child leaf
+                const frozenElapsed = pausedAtMs
+                  ? Math.round((pausedAtMs - new Date(r.startTime).getTime()) / 1000)
+                  : stepElapsed;
+                stepNodes.push({
+                  label: `⏸ ${stepName} (${frozenElapsed}s)`,
+                  children: [{ label: `${YELLOW}Step failed attempt #${lastSeenAttempt}${RESET}` }],
+                });
+              } else if (!isPaused && lastSeenAttempt > 0 && pausedStepName === stepName) {
+                stepNodes.push({
+                  label: `${frame} ${stepName} — retrying (${stepElapsed}s...)`,
+                });
+              } else {
+                stepNodes.push({ label: `${frame} ${stepName} (${stepElapsed}s...)` });
+              }
             } else {
               stepNodes.push({ label: `[ ] ${stepName}` });
             }
@@ -536,7 +586,14 @@ export async function executeLocalJob(job: Job): Promise<JobResult> {
           },
         ];
 
-        logUpdate(renderTree(tree));
+        let output = renderTree(tree);
+        // Append yellow retry/abort hints below the tree when paused
+        if (isPaused) {
+          output += `\n\n  ${YELLOW}↻ To retry:  machinen retry --runner ${containerName}${RESET}`;
+          output += `\n  ${YELLOW}■ To abort:  machinen abort --runner ${containerName}${RESET}`;
+        }
+
+        logUpdate(output);
       } catch {
         // Best-effort
       }
@@ -624,6 +681,11 @@ export async function executeLocalJob(job: Job): Promise<JobResult> {
     // workspaceDir is now inside containerWorkDir — no separate cleanup needed
     if (fs.existsSync(dirs.shimsDir)) {
       fs.rmSync(dirs.shimsDir, { recursive: true, force: true });
+    }
+    // Keep the signals dir alive when pauseOnFailure is set so the external
+    // retry/abort command can find it. Otherwise clean it up.
+    if (!pauseOnFailure && fs.existsSync(dirs.signalsDir)) {
+      fs.rmSync(dirs.signalsDir, { recursive: true, force: true });
     }
     if (fs.existsSync(dirs.diagDir)) {
       fs.rmSync(dirs.diagDir, { recursive: true, force: true });

--- a/cli/src/runner/step-wrapper.test.ts
+++ b/cli/src/runner/step-wrapper.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { wrapStepScript, wrapJobSteps } from "./step-wrapper.js";
+
+// ── wrapStepScript ────────────────────────────────────────────────────────────
+
+describe("wrapStepScript", () => {
+  it("wraps the original script in a retry loop", () => {
+    const wrapped = wrapStepScript("npm test", "Run tests");
+    expect(wrapped).toContain("npm test");
+    expect(wrapped).toContain('__SIGNALS="/tmp/machinen-signals"');
+    expect(wrapped).toContain("while true; do");
+    expect(wrapped).toContain("Retrying step...");
+  });
+
+  it("includes the step name in the paused signal", () => {
+    const wrapped = wrapStepScript("echo hi", "My Step");
+    expect(wrapped).toContain("printf '%s\\n%s' 'My Step' \"$__ATTEMPT\" > \"$__SIGNALS/paused\"");
+  });
+
+  it("escapes single quotes in step names", () => {
+    const wrapped = wrapStepScript("echo hi", "it's a test");
+    // Should not contain an unescaped single quote that breaks the shell
+    expect(wrapped).toContain("it'\\''s a test");
+  });
+});
+
+// ── wrapJobSteps ──────────────────────────────────────────────────────────────
+
+describe("wrapJobSteps", () => {
+  const scriptStep = {
+    Name: "Run tests",
+    Reference: { Type: "Script" },
+    Inputs: { script: "npm test" },
+  };
+
+  const usesStep = {
+    Name: "Checkout",
+    Reference: { Type: "Repository", Name: "actions/checkout" },
+    Inputs: {},
+  };
+
+  it("returns steps unchanged when pauseOnFailure is false", () => {
+    const result = wrapJobSteps([scriptStep, usesStep], false);
+    expect(result).toEqual([scriptStep, usesStep]);
+  });
+
+  it("wraps run: steps when pauseOnFailure is true", () => {
+    const result = wrapJobSteps([scriptStep, usesStep], true);
+    expect(result[0].Inputs.script).toContain("__SIGNALS");
+    expect(result[0].Inputs.script).toContain("npm test");
+  });
+
+  it("leaves uses: steps untouched", () => {
+    const result = wrapJobSteps([scriptStep, usesStep], true);
+    expect(result[1]).toEqual(usesStep);
+  });
+
+  it("handles undefined/empty steps gracefully", () => {
+    expect(wrapJobSteps([], true)).toEqual([]);
+    expect(wrapJobSteps(undefined as any, false)).toBeUndefined();
+  });
+});

--- a/cli/src/runner/step-wrapper.ts
+++ b/cli/src/runner/step-wrapper.ts
@@ -1,0 +1,65 @@
+// ─── Pause-on-failure step wrapping ───────────────────────────────────────────
+//
+// Wraps `run:` step scripts in a retry loop so the runner pauses on failure
+// and waits for an external signal (retry / abort) before continuing.
+
+/**
+ * Wrap a bash script in the pause-on-failure retry loop.
+ *
+ * The wrapper:
+ *  1. Runs the original script
+ *  2. On success → exits 0
+ *  3. On failure → writes a `paused` signal file, emits a `::error::` annotation,
+ *     and polls until a `retry` or `abort` signal file appears.
+ */
+export function wrapStepScript(script: string, stepName: string): string {
+  // Escape single-quotes in the step name so it's safe inside the echo
+  const safeName = stepName.replace(/'/g, "'\\''");
+  // The original script runs in a subshell `( ... )` so that:
+  //  1. `exit N` inside the script terminates the subshell, not the retry loop
+  //  2. The runner's `set -e` (bash -e {0}) doesn't bypass the wrapper
+  return `__SIGNALS="/tmp/machinen-signals"
+__ATTEMPT=0
+while true; do
+  __ATTEMPT=$((__ATTEMPT + 1))
+  set +e
+  (
+    ${script}
+  )
+  __EC=$?
+  set -e
+  if [ $__EC -eq 0 ]; then exit 0; fi
+  printf '%s\\n%s' '${safeName}' "$__ATTEMPT" > "$__SIGNALS/paused"
+  echo "::error::Step failed (exit $__EC). Paused — waiting for retry signal."
+  while [ ! -f "$__SIGNALS/retry" ] && [ ! -f "$__SIGNALS/abort" ]; do sleep 1; done
+  if [ -f "$__SIGNALS/abort" ]; then rm -f "$__SIGNALS/abort" "$__SIGNALS/paused"; exit $__EC; fi
+  rm -f "$__SIGNALS/retry" "$__SIGNALS/paused"
+  echo "Retrying step..."
+done`;
+}
+
+/**
+ * Clone a steps array, wrapping `run:` steps when `pauseOnFailure` is enabled.
+ *
+ * Only steps with `Reference.Type === "Script"` (i.e. `run:` steps) are wrapped.
+ * `uses:` steps are left untouched because the runner's action dispatcher handles
+ * them internally and can't be wrapped at the shell level.
+ */
+export function wrapJobSteps(steps: any[], pauseOnFailure: boolean): any[] {
+  if (!pauseOnFailure || !steps) {
+    return steps;
+  }
+
+  return steps.map((step) => {
+    if (step?.Reference?.Type !== "Script" || !step?.Inputs?.script) {
+      return step;
+    }
+    return {
+      ...step,
+      Inputs: {
+        ...step.Inputs,
+        script: wrapStepScript(step.Inputs.script, step.Name || step.DisplayName || "step"),
+      },
+    };
+  });
+}

--- a/test/fixtures/pause-test.yml
+++ b/test/fixtures/pause-test.yml
@@ -1,0 +1,15 @@
+name: pause-test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Passing step
+        run: echo "This step passes"
+      - name: Failing step
+        run: |
+          echo "About to fail..."
+          exit 1
+      - name: Should not run
+        run: echo "Unreachable"


### PR DESCRIPTION
## Summary

When `--pause-on-failure` / `-p` is enabled, `run:` steps are wrapped in a bash retry loop that pauses execution on failure and waits for an external signal before continuing.

### What it looks like

```
pause-test.yml (21.8s)
├── Starting runner (14.2s)
└── test
    ├── [✓] Set up job (1s)
    ├── [✓] Run actions/checkout@v4 (0s)
    ├── [✓] Passing step (0s)
    ├── ⏸ Failing step (0s)
    │   └── Step failed attempt #1
    ├── [ ] Should not run
    └── [✓] Post Setup

  ↻ To retry:  machinen retry --runner machinen-81
  ■ To abort:  machinen abort --runner machinen-81
```

### Changes

- **`step-wrapper.ts`** — wraps `run:` steps in a bash retry loop with attempt counter
- **`directory-setup.ts`** — adds `signalsDir` for container ↔ CLI IPC
- **`container-config.ts`** — bind-mounts signals dir to `/tmp/machinen-signals`
- **`local-job.ts`** — threads `pauseOnFailure`, wraps steps, polls for `paused` signal, renders ⏸ with frozen timer and yellow child leaf
- **`cli.ts`** — `--pause-on-failure` flag, `retry`/`abort` commands with Docker container validation
- **`reporter.ts`** — optional `attempt` field on `JobResult`

### Limitations

- `uses:` steps cannot be wrapped (action dispatcher handles them internally)
- Timer shows elapsed time at moment of failure (frozen while paused)

Closes #27