### PR TITLE
feat: agent mode + DTU tarball route

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -31,6 +31,7 @@ import { printSummary, type JobResult } from "./output/reporter.js";
 import { syncWorkspaceForRetry } from "./runner/sync.js";
 import { RunStateStore } from "./output/run-state.js";
 import { renderRunState } from "./output/state-renderer.js";
+import { isAgentMode, setQuietMode } from "./output/agent-mode.js";
 import logUpdate from "log-update";
 
 // ─── Signal helpers for retry / abort commands ────────────────────────────────
@@ -70,6 +71,8 @@ async function run() {
         pauseOnFailure = false;
       } else if (args[i] === "--all" || args[i] === "-a") {
         runAll = true;
+      } else if (args[i] === "--quiet" || args[i] === "-q") {
+        setQuietMode(true);
       } else if (!args[i].startsWith("-")) {
         sha = args[i];
       }
@@ -252,12 +255,75 @@ async function runWorkflows(options: {
   const store = new RunStateStore(runId, storeFilePath);
 
   // Start the render loop — reads from store, never touches execution logic
-  const renderInterval = setInterval(() => {
-    const state = store.getState();
-    if (state.workflows.length > 0) {
-      logUpdate(renderRunState(state));
-    }
-  }, 80);
+  // In agent mode (AI_AGENT=1 or --quiet), skip animated rendering to avoid token waste
+  // but register a synchronous callback for important state changes.
+  let renderInterval: ReturnType<typeof setInterval> | null = null;
+  if (isAgentMode()) {
+    const reportedPauses = new Set<string>();
+    const reportedRunners = new Set<string>();
+    const reportedSteps = new Map<string, Set<string>>();
+    const emit = (msg: string) => process.stderr.write(msg + "\n");
+    store.onUpdate((state) => {
+      for (const wf of state.workflows) {
+        for (const job of wf.jobs) {
+          if (job.status !== "queued" && !reportedRunners.has(job.runnerId)) {
+            reportedRunners.add(job.runnerId);
+            emit(`[Machinen] Starting runner ${job.runnerId} (${wf.id} > ${job.id})`);
+            if (job.logDir) {
+              emit(`  Logs: ${job.logDir}`);
+            }
+          }
+          if (!reportedSteps.has(job.runnerId)) {
+            reportedSteps.set(job.runnerId, new Set());
+          }
+          const seen = reportedSteps.get(job.runnerId)!;
+          for (const step of job.steps) {
+            const key = `${step.index}:${step.status}`;
+            if (seen.has(key)) {
+              continue;
+            }
+            if (step.status === "completed") {
+              seen.add(key);
+              const dur =
+                step.durationMs != null ? ` (${(step.durationMs / 1000).toFixed(1)}s)` : "";
+              emit(`  ✓ ${step.name}${dur}`);
+            } else if (step.status === "failed") {
+              seen.add(key);
+              emit(`  ✗ ${step.name}`);
+            } else if (step.status === "running") {
+              seen.add(key);
+              emit(`  ▸ ${step.name}`);
+            }
+          }
+          if (job.status === "paused" && !reportedPauses.has(job.runnerId)) {
+            reportedPauses.add(job.runnerId);
+            const lines: string[] = [];
+            lines.push(`\n[Machinen] Step failed: "${job.pausedAtStep}" (${wf.id} > ${job.id})`);
+            if (job.attempt && job.attempt > 1) {
+              lines.push(`  Attempt: ${job.attempt}`);
+            }
+            if (job.lastOutputLines && job.lastOutputLines.length > 0) {
+              lines.push("  Last output:");
+              for (const l of job.lastOutputLines) {
+                lines.push(`    ${l}`);
+              }
+            }
+            lines.push(`  To retry:  machinen retry --runner ${job.runnerId}`);
+            emit(lines.join("\n"));
+          } else if (job.status !== "paused" && reportedPauses.has(job.runnerId)) {
+            reportedPauses.delete(job.runnerId);
+          }
+        }
+      }
+    });
+  } else {
+    renderInterval = setInterval(() => {
+      const state = store.getState();
+      if (state.workflows.length > 0) {
+        logUpdate(renderRunState(state));
+      }
+    }, 80);
+  }
 
   try {
     const allResults: JobResult[] = [];
@@ -327,13 +393,17 @@ async function runWorkflows(options: {
     store.complete(allResults.some((r) => !r.succeeded) ? "failed" : "completed");
     return allResults;
   } finally {
-    clearInterval(renderInterval);
-    // Final render — show the completed state
-    const finalState = store.getState();
-    if (finalState.workflows.length > 0) {
-      logUpdate(renderRunState(finalState));
+    if (renderInterval) {
+      clearInterval(renderInterval);
     }
-    logUpdate.done();
+    if (!isAgentMode()) {
+      // Final render — show the completed state
+      const finalState = store.getState();
+      if (finalState.workflows.length > 0) {
+        logUpdate(renderRunState(finalState));
+      }
+      logUpdate.done();
+    }
   }
 }
 
@@ -609,6 +679,9 @@ function printUsage() {
   console.log("  -w, --workflow <path>         Path to the workflow file");
   console.log("  -a, --all                     Discover and run all relevant workflows");
   console.log("  -x, --exit-on-failure         Exit immediately on step failure (default: pause)");
+  console.log(
+    "  -q, --quiet                   Suppress animated rendering (also enabled by AI_AGENT=1)",
+  );
 }
 
 function resolveRepoRoot() {

--- a/cli/src/output/agent-mode.test.ts
+++ b/cli/src/output/agent-mode.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { isAgentMode, setQuietMode } from "./agent-mode.js";
+
+describe("isAgentMode", () => {
+  const originalEnv = process.env.AI_AGENT;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.AI_AGENT;
+    } else {
+      process.env.AI_AGENT = originalEnv;
+    }
+    setQuietMode(false);
+  });
+
+  it("returns true when AI_AGENT=1", () => {
+    process.env.AI_AGENT = "1";
+    expect(isAgentMode()).toBe(true);
+  });
+
+  it("returns false when AI_AGENT is unset", () => {
+    delete process.env.AI_AGENT;
+    expect(isAgentMode()).toBe(false);
+  });
+
+  it("returns false when AI_AGENT is something other than 1", () => {
+    process.env.AI_AGENT = "true";
+    expect(isAgentMode()).toBe(false);
+  });
+
+  it("returns true when --quiet flag is set", () => {
+    delete process.env.AI_AGENT;
+    setQuietMode(true);
+    expect(isAgentMode()).toBe(true);
+  });
+
+  it("returns true when both --quiet and AI_AGENT=1 are set", () => {
+    process.env.AI_AGENT = "1";
+    setQuietMode(true);
+    expect(isAgentMode()).toBe(true);
+  });
+});

--- a/cli/src/output/agent-mode.ts
+++ b/cli/src/output/agent-mode.ts
@@ -1,0 +1,9 @@
+let quietFlag = false;
+
+export function setQuietMode(value: boolean): void {
+  quietFlag = value;
+}
+
+export function isAgentMode(): boolean {
+  return quietFlag || process.env.AI_AGENT === "1";
+}

--- a/cli/src/output/run-state.ts
+++ b/cli/src/output/run-state.ts
@@ -79,9 +79,12 @@ export interface RunState {
  * - Renderer (state-renderer.ts) reads `getState()` to produce terminal output.
  * - State is persisted atomically to disk (write-tmp + rename) for inspection / resumability.
  */
+export type StoreListener = (state: RunState) => void;
+
 export class RunStateStore {
   private state: RunState;
   private filePath: string;
+  private listeners: StoreListener[] = [];
 
   constructor(runId: string, filePath: string) {
     this.state = {
@@ -92,6 +95,11 @@ export class RunStateStore {
     };
     this.filePath = filePath;
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  }
+
+  /** Register a callback that fires synchronously on every state change. */
+  onUpdate(listener: StoreListener): void {
+    this.listeners.push(listener);
   }
 
   getState(): RunState {
@@ -133,6 +141,7 @@ export class RunStateStore {
         ...options,
       });
     }
+    this.notify();
   }
 
   /**
@@ -149,6 +158,7 @@ export class RunStateStore {
       }
     }
     this.save();
+    this.notify();
   }
 
   /** Mark the overall run complete and persist. */
@@ -178,6 +188,16 @@ export class RunStateStore {
       return JSON.parse(fs.readFileSync(filePath, "utf-8")) as RunState;
     } catch {
       return JSON.parse(fs.readFileSync(filePath + ".tmp", "utf-8")) as RunState;
+    }
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(this.state);
+      } catch {
+        // Best-effort — don't let listener errors break state updates
+      }
     }
   }
 

--- a/cli/src/output/state-renderer.ts
+++ b/cli/src/output/state-renderer.ts
@@ -91,7 +91,13 @@ function buildJobNodes(job: JobState, singleJobMode: boolean): TreeNode[] {
     const elapsed = job.startedAt
       ? Math.round((Date.now() - new Date(job.startedAt).getTime()) / 1000)
       : 0;
-    return [{ label: `${getSpinnerFrame()} Starting runner ${job.runnerId} (${elapsed}s)` }];
+    const bootNode: TreeNode = {
+      label: `${getSpinnerFrame()} Starting runner ${job.runnerId} (${elapsed}s)`,
+    };
+    if (job.logDir) {
+      bootNode.children = [{ label: `${DIM}Logs: ${job.logDir}${RESET}` }];
+    }
+    return [bootNode];
   }
 
   // ── Completed / failed in multi-job mode → collapse to one line ────────────
@@ -118,7 +124,11 @@ function buildJobNodes(job: JobState, singleJobMode: boolean): TreeNode[] {
       job.bootDurationMs !== undefined
         ? `Starting runner ${job.runnerId} (${fmtMs(job.bootDurationMs)})`
         : `Starting runner ${job.runnerId}`;
-    return [{ label: bootLabel }, { label: job.id, children: stepNodes }];
+    const bootNode: TreeNode = { label: bootLabel };
+    if (job.logDir) {
+      bootNode.children = [{ label: `${DIM}Logs: ${job.logDir}${RESET}` }];
+    }
+    return [bootNode, { label: job.id, children: stepNodes }];
   }
 
   // ── Multi-job mode: show job name with steps as children ──────────────────

--- a/dtu-github-actions/src/server/routes/github.ts
+++ b/dtu-github-actions/src/server/routes/github.ts
@@ -1,6 +1,9 @@
+import { execSync } from "node:child_process";
 import { Polka } from "polka";
 import { state } from "../store.js";
 import { getBaseUrl } from "./dtu.js";
+
+const EMPTY_TARBALL = execSync("tar czf - -T /dev/null");
 
 export function registerGithubRoutes(app: Polka) {
   // 2. GitHub REST API Mirror - Job Detail
@@ -114,4 +117,17 @@ export function registerGithubRoutes(app: Polka) {
 
   app.post("/actions/runner-registration", globalRunnerRegistrationHandler);
   app.post("/api/v3/actions/runner-registration", globalRunnerRegistrationHandler);
+
+  // 7. Tarball route — actions/checkout downloads repos via this endpoint.
+  // Return an empty tar.gz since the workspace is already bind-mounted.
+  const tarballHandler = (req: any, res: any) => {
+    console.log(`[DTU] Serving empty tarball for ${req.url}`);
+    res.writeHead(200, {
+      "Content-Type": "application/gzip",
+      "Content-Length": String(EMPTY_TARBALL.length),
+    });
+    res.end(EMPTY_TARBALL);
+  };
+  app.get("/repos/:owner/:repo/tarball/:ref", tarballHandler);
+  app.get("/_apis/repos/:owner/:repo/tarball/:ref", tarballHandler);
 }


### PR DESCRIPTION
## Summary

- **Agent mode** (`AI_AGENT=1` env or `--quiet`/`-q` flag): replaces the 80ms animated render loop with plain-text stderr output — runner start (with log path), step progress, and pause/failure details with retry command
- **DTU tarball route**: serves empty tar.gz for `/repos/:owner/:repo/tarball/:ref` so `actions/checkout` no longer 404s (workspace is bind-mounted)
- **Log path display**: shown in both tree view ("Starting runner" node) and quiet mode as a sublead line

Closes #44

## Test plan

- [x] `vitest run` — agent-mode and state-renderer tests pass
- [ ] `pnpm machinen-dev run -w tests.yml -q` — verify step progress prints to stderr
- [ ] `pnpm machinen-dev run -w tests.yml` — verify normal tree rendering unchanged, log path shown
- [ ] `AI_AGENT=1 pnpm machinen-dev run -w tests.yml` — same as `--quiet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)