### PR TITLE
fix: handle rejected promises in job execution

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -39,8 +39,7 @@ import { RunStateStore } from "./output/run-state.js";
 import { renderRunState } from "./output/state-renderer.js";
 import { isAgentMode, setQuietMode } from "./output/agent-mode.js";
 import logUpdate from "log-update";
-
-// ─── Signal helpers for retry / abort commands ────────────────────────────────
+import { createFailedJobResult, wrapJobError, isJobError } from "./runner/job-result.js";
 
 function findSignalsDir(runnerName: string): string | null {
   const workDir = getWorkingDirectory();
@@ -735,53 +734,45 @@ async function handleWorkflow(options: {
         allResults.push(firstResult);
 
         const results = await Promise.allSettled(
-          waveJobs.slice(1).map((ej) => limiter.run(() => runOrSkipJob(ej))),
+          waveJobs.slice(1).map((ej) =>
+            limiter.run(() =>
+              runOrSkipJob(ej).catch((error) => {
+                throw wrapJobError(ej.taskName, error);
+              }),
+            ),
+          ),
         );
-        for (let i = 0; i < results.length; i++) {
-          const r = results[i];
+        for (const r of results) {
           if (r.status === "fulfilled") {
             allResults.push(r.value);
           } else {
-            const ej = waveJobs[i + 1];
-            const errorMessage = String(r.reason?.message || r.reason);
-            console.error(`\n[Agent CI] Job failed with error: ${ej.taskName}`);
+            const taskName = isJobError(r.reason) ? r.reason.taskName : "unknown";
+            const errorMessage = isJobError(r.reason) ? r.reason.message : String(r.reason);
+            console.error(`\n[Agent CI] Job failed with error: ${taskName}`);
             console.error(`  Error: ${errorMessage}`);
-            allResults.push({
-              name: `agent-ci-error-${ej.taskName}`,
-              workflow: path.basename(workflowPath),
-              taskId: ej.taskName,
-              succeeded: false,
-              durationMs: 0,
-              debugLogPath: "",
-              failedStep: "[Job startup failed]",
-              lastOutputLines: [errorMessage],
-            });
+            allResults.push(createFailedJobResult(taskName, workflowPath, r.reason));
           }
         }
         warm = true;
       } else {
         const results = await Promise.allSettled(
-          waveJobs.map((ej) => limiter.run(() => runOrSkipJob(ej))),
+          waveJobs.map((ej) =>
+            limiter.run(() =>
+              runOrSkipJob(ej).catch((error) => {
+                throw wrapJobError(ej.taskName, error);
+              }),
+            ),
+          ),
         );
-        for (let i = 0; i < results.length; i++) {
-          const r = results[i];
+        for (const r of results) {
           if (r.status === "fulfilled") {
             allResults.push(r.value);
           } else {
-            const ej = waveJobs[i];
-            const errorMessage = String(r.reason?.message || r.reason);
-            console.error(`\n[Agent CI] Job failed with error: ${ej.taskName}`);
+            const taskName = isJobError(r.reason) ? r.reason.taskName : "unknown";
+            const errorMessage = isJobError(r.reason) ? r.reason.message : String(r.reason);
+            console.error(`\n[Agent CI] Job failed with error: ${taskName}`);
             console.error(`  Error: ${errorMessage}`);
-            allResults.push({
-              name: `agent-ci-error-${ej.taskName}`,
-              workflow: path.basename(workflowPath),
-              taskId: ej.taskName,
-              succeeded: false,
-              durationMs: 0,
-              debugLogPath: "",
-              failedStep: "[Job startup failed]",
-              lastOutputLines: [errorMessage],
-            });
+            allResults.push(createFailedJobResult(taskName, workflowPath, r.reason));
           }
         }
       }

--- a/packages/cli/src/runner/job-result.test.ts
+++ b/packages/cli/src/runner/job-result.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  createFailedJobResult,
+  wrapJobError,
+  isJobError,
+  getErrorMessage,
+  type JobError,
+} from "./job-result.js";
+
+describe("getErrorMessage", () => {
+  it("extracts message from Error object", () => {
+    const result = getErrorMessage(new Error("test message"));
+    expect(result).toBe("test message");
+  });
+
+  it("returns string as-is", () => {
+    const result = getErrorMessage("string error");
+    expect(result).toBe("string error");
+  });
+
+  it("converts other types to string", () => {
+    expect(getErrorMessage(123)).toBe("123");
+    expect(getErrorMessage(null)).toBe("null");
+    expect(getErrorMessage(undefined)).toBe("undefined");
+    expect(getErrorMessage({ code: "ENOENT" })).toBe("[object Object]");
+  });
+});
+
+describe("isJobError", () => {
+  it("returns true for valid JobError", () => {
+    const error: JobError = {
+      taskName: "test-job",
+      message: "something failed",
+      originalError: new Error("original"),
+    };
+    expect(isJobError(error)).toBe(true);
+  });
+
+  it("returns false for null", () => {
+    expect(isJobError(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isJobError(undefined)).toBe(false);
+  });
+
+  it("returns false for plain Error", () => {
+    expect(isJobError(new Error("test"))).toBe(false);
+  });
+
+  it("returns false for object without taskName", () => {
+    expect(isJobError({ message: "test" })).toBe(false);
+  });
+});
+
+describe("wrapJobError", () => {
+  it("wraps Error with taskName", () => {
+    const original = new Error("original error");
+    const wrapped = wrapJobError("my-job", original);
+
+    expect(wrapped.taskName).toBe("my-job");
+    expect(wrapped.message).toBe("original error");
+    expect(wrapped.originalError).toBe(original);
+  });
+
+  it("wraps string error with taskName", () => {
+    const wrapped = wrapJobError("my-job", "string error");
+
+    expect(wrapped.taskName).toBe("my-job");
+    expect(wrapped.message).toBe("string error");
+  });
+});
+
+describe("createFailedJobResult", () => {
+  it("creates a failed result with error message from Error object", () => {
+    const result = createFailedJobResult(
+      "setup_job",
+      "/path/to/workflow.yml",
+      new Error("Missing required secret: API_KEY"),
+    );
+
+    expect(result.succeeded).toBe(false);
+    expect(result.taskId).toBe("setup_job");
+    expect(result.workflow).toBe("workflow.yml");
+    expect(result.name).toBe("agent-ci-error-setup_job");
+    expect(result.failedStep).toBe("[Job startup failed]");
+    expect(result.durationMs).toBe(0);
+    expect(result.debugLogPath).toBe("");
+    expect(result.lastOutputLines).toEqual(["Missing required secret: API_KEY"]);
+  });
+
+  it("extracts message from JobError", () => {
+    const jobError: JobError = {
+      taskName: "wrapped-job",
+      message: "wrapped message",
+      originalError: new Error("original"),
+    };
+    const result = createFailedJobResult("test", "workflow.yml", jobError);
+
+    expect(result.lastOutputLines).toEqual(["wrapped message"]);
+  });
+
+  it("handles string errors", () => {
+    const result = createFailedJobResult(
+      "build_job",
+      "/home/user/project/.github/workflows/ci.yaml",
+      "Container failed to start",
+    );
+
+    expect(result.succeeded).toBe(false);
+    expect(result.taskId).toBe("build_job");
+    expect(result.workflow).toBe("ci.yaml");
+    expect(result.lastOutputLines).toEqual(["Container failed to start"]);
+  });
+
+  it("handles errors without message property", () => {
+    const result = createFailedJobResult("test_job", "workflow.yml", {
+      code: "ENOENT",
+      path: "/missing/file",
+    });
+
+    expect(result.succeeded).toBe(false);
+    expect(result.lastOutputLines).toEqual(["[object Object]"]);
+  });
+
+  it("handles null/undefined errors", () => {
+    const result = createFailedJobResult("job1", "workflow.yml", null);
+
+    expect(result.succeeded).toBe(false);
+    expect(result.lastOutputLines).toEqual(["null"]);
+  });
+
+  it("extracts basename from full workflow path", () => {
+    const result = createFailedJobResult(
+      "deploy",
+      "/very/long/path/to/.github/workflows/production.yml",
+      new Error("Deploy failed"),
+    );
+
+    expect(result.workflow).toBe("production.yml");
+  });
+});

--- a/packages/cli/src/runner/job-result.ts
+++ b/packages/cli/src/runner/job-result.ts
@@ -1,0 +1,52 @@
+import path from "path";
+import type { JobResult } from "../output/reporter.js";
+
+export interface JobError {
+  taskName: string;
+  message: string;
+  originalError: unknown;
+}
+
+export function isJobError(error: unknown): error is JobError {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const err = error as Record<string, unknown>;
+  return typeof err.taskName === "string";
+}
+
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return String(error);
+}
+
+export function createFailedJobResult(
+  taskName: string,
+  workflowPath: string,
+  error: unknown,
+): JobResult {
+  const errorMessage = isJobError(error) ? error.message : getErrorMessage(error);
+  return {
+    name: `agent-ci-error-${taskName}`,
+    workflow: path.basename(workflowPath),
+    taskId: taskName,
+    succeeded: false,
+    durationMs: 0,
+    debugLogPath: "",
+    failedStep: "[Job startup failed]",
+    lastOutputLines: [errorMessage],
+  };
+}
+
+export function wrapJobError(taskName: string, error: unknown): JobError {
+  return {
+    taskName,
+    message: getErrorMessage(error),
+    originalError: error,
+  };
+}


### PR DESCRIPTION
Fix silent promise rejection bug where job startup errors were silently dropped from results.