### PR TITLE
fix: support large monorepos and sub-path actions

### DIFF
--- a/packages/cli/src/output/cleanup.ts
+++ b/packages/cli/src/output/cleanup.ts
@@ -19,6 +19,7 @@ export function copyWorkspace(repoRoot: string, dest: string): void {
   const files = execSync("git ls-files --cached --others --exclude-standard -z", {
     stdio: "pipe",
     cwd: repoRoot,
+    maxBuffer: 100 * 1024 * 1024, // 100MB — default 1MB overflows in large monorepos
   })
     .toString()
     .split("\0")

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -798,7 +798,12 @@ export async function executeLocalJob(
     }
 
     if (jobSucceeded && fs.existsSync(dirs.containerWorkDir)) {
-      fs.rmSync(dirs.containerWorkDir, { recursive: true, force: true });
+      try {
+        fs.rmSync(dirs.containerWorkDir, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup — ENOTEMPTY can occur when container
+        // processes haven't fully released file handles yet.
+      }
     }
 
     await ephemeralDtu?.close().catch(() => {});

--- a/packages/dtu-github-actions/src/server/routes/actions/index.ts
+++ b/packages/dtu-github-actions/src/server/routes/actions/index.ts
@@ -532,7 +532,10 @@ export function registerActionRoutes(app: Polka) {
 
     for (const action of actions) {
       const key = `${action.nameWithOwner}@${action.ref}`;
-      const downloadUrl = `https://api.github.com/repos/${action.nameWithOwner}/tarball/${action.ref}`;
+      // Strip sub-path from nameWithOwner (e.g. "actions/cache/save" → "actions/cache")
+      // Sub-path actions share the same repo tarball as the parent action.
+      const repoPath = action.nameWithOwner.split("/").slice(0, 2).join("/");
+      const downloadUrl = `https://api.github.com/repos/${repoPath}/tarball/${action.ref}`;
 
       result.actions[key] = {
         nameWithOwner: action.nameWithOwner,


### PR DESCRIPTION
## Summary

Three fixes discovered while running agent-ci against a ~40K file pnpm/turbo monorepo (Trip):

- **Sub-path actions produce invalid tarball URLs** — `actions/cache/save@v5` generates `api.github.com/repos/actions/cache/save/tarball/v5` (404). Fix: strip to `owner/repo` before constructing the download URL. Closes #95.
- **ENOBUFS on large repos** — `copyWorkspace` uses `execSync("git ls-files ...")` with the default 1MB `maxBuffer`. Repos with 30K+ tracked files overflow this, producing an empty workspace in the container. Fix: increase `maxBuffer` to 100MB.
- **ENOTEMPTY on post-success cleanup** — `fs.rmSync(containerWorkDir)` throws when container processes haven't fully released file handles. Fix: wrap in try/catch.

## Test plan

- [x] Verified sub-path action URL fix: `actions/cache/save@v5` now downloads correctly
- [x] Verified workspace copy: 39K+ files copied without ENOBUFS
- [x] Verified full `ci.yml` build job passes (format check, i18n, build packages)
- [x] Cleanup no longer throws ENOTEMPTY