### PR TITLE
fix: re-throw errors in handleWorkflow instead of swallowing them

### DIFF
--- a/.changeset/fix-swallowed-errors.md
+++ b/.changeset/fix-swallowed-errors.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Fix handleWorkflow catch block swallowing errors by re-throwing instead of returning empty array

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -829,8 +829,10 @@ async function handleWorkflow(options: {
 
     return allResults;
   } catch (error) {
-    console.error(`[Agent CI] Failed to trigger run: ${(error as Error).message}`);
-    return [];
+    console.error(
+      `[Agent CI] Failed to run workflow ${path.basename(workflowPath)}: ${(error as Error).message}`,
+    );
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Summary

- Fix `handleWorkflow` catch block that was returning `[]` instead of re-throwing, causing the CLI to exit 0 on workflow setup failures
- Errors now propagate so the CLI exits non-zero and surfaces the failure to the user

Closes #101

## Test plan

- [ ] Verify CLI exits non-zero when a workflow setup error occurs (e.g., DTU seed failure, Docker API error)
- [ ] Verify the error message includes the workflow filename via `path.basename(workflowPath)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)