### PR TITLE
fix: pin runnerName before DTU seed to prevent cross-workflow job stealing

### DIFF
--- a/.changeset/fix-all-job-stealing.md
+++ b/.changeset/fix-all-job-stealing.md
@@ -1,0 +1,8 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Fix --all hanging on single-job workflows due to cross-workflow job stealing.
+
+Pin `job.runnerName = containerName` before the DTU seed call so every job goes to the runner-specific pool. Move container and ephemeral DTU cleanup into a `finally` block to ensure cleanup even on mid-run errors. Set `process.setMaxListeners(0)` to suppress EventEmitter warnings when running many parallel jobs.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -279,6 +279,10 @@ async function runWorkflows(options: {
 }): Promise<JobResult[]> {
   const { workflowPaths, sha, pauseOnFailure, noMatrix = false } = options;
 
+  // Suppress EventEmitter MaxListenersExceeded warnings when running many
+  // parallel jobs (each job adds SIGINT/SIGTERM listeners).
+  process.setMaxListeners(0);
+
   // Create the run state store — single source of truth for all progress
   const runId = `run-${Date.now()}`;
   const storeFilePath = path.join(getWorkingDirectory(), "runs", runId, "run-state.json");

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -217,6 +217,11 @@ export async function executeLocalJob(
   process.once("SIGINT", signalCleanup);
   process.once("SIGTERM", signalCleanup);
 
+  // Hoisted for cleanup in `finally` — assigned inside the try block.
+  let container: Docker.Container | null = null;
+  let serviceCtx: ServiceContext | undefined;
+  const hostRunnerDir = path.resolve(runDir, "runner");
+
   try {
     // 1. Seed the job to Local DTU
     const [githubOwner, githubRepoName] = (job.githubRepo || "").split("/");
@@ -231,6 +236,11 @@ export async function executeLocalJob(
 
     const wrappedSteps = pauseOnFailure ? wrapJobSteps(job.steps ?? [], true) : job.steps;
     const seededSteps = appendOutputCaptureStep(wrappedSteps ?? []);
+
+    // Pin runnerName so the job goes to the runner-specific pool, not the
+    // shared generic pool where a runner from another concurrent workflow
+    // could steal it (see issue #103).
+    job.runnerName = containerName;
 
     t0 = Date.now();
     const seedResponse = await fetch(`${dtuUrl}/_dtu/seed`, {
@@ -304,7 +314,6 @@ export async function executeLocalJob(
     }
 
     // ── Service containers ────────────────────────────────────────────────────
-    let serviceCtx: ServiceContext | undefined;
     if (job.services && job.services.length > 0) {
       const svcStart = Date.now();
       debugRunner(`Starting ${job.services.length} service container(s)...`);
@@ -321,7 +330,6 @@ export async function executeLocalJob(
     // ── Direct container injection ─────────────────────────────────────────────
     const hostWorkDir = dirs.containerWorkDir;
     const hostRunnerSeedDir = path.resolve(getWorkingDirectory(), "runner");
-    const hostRunnerDir = path.resolve(runDir, "runner");
     const useDirectContainer = !!job.container;
     const containerImage = useDirectContainer ? job.container!.image : IMAGE;
 
@@ -498,7 +506,7 @@ export async function executeLocalJob(
     const extraHosts = resolveDockerExtraHosts(dtuHost);
 
     t0 = Date.now();
-    const container = await docker.createContainer({
+    container = await docker.createContainer({
       Image: containerImage,
       name: containerName,
       Env: containerEnv,
@@ -826,27 +834,6 @@ export async function executeLocalJob(
 
     await new Promise<void>((resolve) => debugStream.end(resolve));
 
-    // Cleanup
-    try {
-      await container.remove({ force: true });
-    } catch {
-      /* already removed */
-    }
-    if (serviceCtx) {
-      await cleanupServiceContainers(docker, serviceCtx, (line) => debugRunner(line));
-    }
-    if (fs.existsSync(dirs.shimsDir)) {
-      fs.rmSync(dirs.shimsDir, { recursive: true, force: true });
-    }
-    if (!pauseOnFailure && fs.existsSync(dirs.signalsDir)) {
-      fs.rmSync(dirs.signalsDir, { recursive: true, force: true });
-    }
-    if (fs.existsSync(dirs.diagDir)) {
-      fs.rmSync(dirs.diagDir, { recursive: true, force: true });
-    }
-    if (fs.existsSync(hostRunnerDir)) {
-      fs.rmSync(hostRunnerDir, { recursive: true, force: true });
-    }
     // Read step outputs captured by the DTU server via the runner's outputs API
     let stepOutputs: Record<string, string> = {};
     if (jobSucceeded) {
@@ -869,8 +856,6 @@ export async function executeLocalJob(
       }
     }
 
-    await ephemeralDtu?.close().catch(() => {});
-
     return buildJobResult({
       containerName,
       job,
@@ -884,6 +869,28 @@ export async function executeLocalJob(
       stepOutputs,
     });
   } finally {
+    // Cleanup: always runs even when errors occur mid-run.
+    try {
+      await container?.remove({ force: true });
+    } catch {
+      /* already removed */
+    }
+    if (serviceCtx) {
+      await cleanupServiceContainers(docker, serviceCtx, (line) => debugRunner(line));
+    }
+    if (fs.existsSync(dirs.shimsDir)) {
+      fs.rmSync(dirs.shimsDir, { recursive: true, force: true });
+    }
+    if (!pauseOnFailure && fs.existsSync(dirs.signalsDir)) {
+      fs.rmSync(dirs.signalsDir, { recursive: true, force: true });
+    }
+    if (fs.existsSync(dirs.diagDir)) {
+      fs.rmSync(dirs.diagDir, { recursive: true, force: true });
+    }
+    if (fs.existsSync(hostRunnerDir)) {
+      fs.rmSync(hostRunnerDir, { recursive: true, force: true });
+    }
+    await ephemeralDtu?.close().catch(() => {});
     process.removeListener("SIGINT", signalCleanup);
     process.removeListener("SIGTERM", signalCleanup);
   }

--- a/packages/dtu-github-actions/src/server.test.ts
+++ b/packages/dtu-github-actions/src/server.test.ts
@@ -543,6 +543,62 @@ describe("Artifact v4 upload/download", () => {
     expect(new Date(res.body.lockedUntil).getTime()).toBeGreaterThan(Date.now());
   });
 
+  it("should let runner B steal runner A's job when seeded WITHOUT runnerName (generic pool bug)", async () => {
+    // REPRODUCTION for issue #103:
+    // When local-job.ts seeds a job without setting runnerName, the job lands
+    // in the generic state.jobs pool. If another runner (from a different
+    // concurrent workflow) polls before runner A, it steals the job — causing
+    // runner A to hang forever waiting for a job that will never arrive.
+
+    const runnerA = "agent-ci-repro-A";
+    const runnerB = "agent-ci-repro-B";
+
+    // Register both runners
+    await request("POST", "/_dtu/start-runner", {
+      runnerName: runnerA,
+      logDir: "/tmp/agent-ci-repro-A-logs",
+      timelineDir: "/tmp/agent-ci-repro-A-logs",
+    });
+    await request("POST", "/_dtu/start-runner", {
+      runnerName: runnerB,
+      logDir: "/tmp/agent-ci-repro-B-logs",
+      timelineDir: "/tmp/agent-ci-repro-B-logs",
+    });
+
+    // Seed a job intended for runner A, but WITHOUT runnerName (the bug).
+    // This goes into the generic state.jobs pool.
+    await request("POST", "/_dtu/seed", {
+      id: 4001,
+      name: "job-intended-for-A",
+      // BUG: no runnerName — job lands in generic pool
+    });
+
+    // Runner B creates a session and polls — it shouldn't get A's job,
+    // but because the job is in the generic pool, B steals it.
+    const sessionB = await request("POST", "/_apis/distributedtask/pools/1/sessions", {
+      agent: { name: runnerB },
+    });
+    const pollB = await request(
+      "GET",
+      `/_apis/distributedtask/pools/1/messages?sessionId=${sessionB.body.sessionId}`,
+    );
+
+    // BUG CONFIRMED: runner B stole the job from the generic pool
+    expect(pollB.status).toBe(200);
+    const bodyB = JSON.parse(pollB.body.Body);
+    expect(bodyB.JobDisplayName).toBe("job-intended-for-A");
+
+    // Now runner A creates a session and polls — the job is gone
+    await request("POST", "/_apis/distributedtask/pools/1/sessions", {
+      agent: { name: runnerA },
+    });
+
+    // Runner A's poll will hang (long-poll timeout) because its job was stolen.
+    // We verify by checking state: no jobs remain for A.
+    const aHasJob = state.runnerJobs.has(runnerA) || state.jobs.size > 0;
+    expect(aHasJob).toBe(false); // A's job is gone — it will hang forever
+  }, 10_000);
+
   it("should handle job request finish (PATCH with result + finishTime)", async () => {
     const finishTime = new Date().toISOString();
     const res = await request("PATCH", "/_apis/distributedtask/jobrequests", {


### PR DESCRIPTION
## Summary

Fixes #103. When running `--all`, jobs seeded without `runnerName` landed in the shared generic DTU pool where runners from other concurrent workflows could steal them, causing single-job workflows to hang indefinitely.

- Pin `job.runnerName = containerName` before the `/_dtu/seed` call so every job goes to the runner-specific pool
- Move container and `ephemeralDtu` cleanup into a `finally` block to ensure cleanup even on mid-run errors
- Add `process.setMaxListeners(0)` to suppress EventEmitter warnings when running many parallel jobs
- Add reproduction test demonstrating generic pool job stealing

## Test plan

- [x] Reproduction test confirms runner B can steal from the generic pool when `runnerName` is missing
- [x] All existing DTU tests pass (46 tests)
- [x] All CLI tests pass (348 tests)
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)