### PR TITLE
feat: ts-runner expression evaluator and command parser

### DIFF
--- a/packages/ts-runner/src/commands.ts
+++ b/packages/ts-runner/src/commands.ts
@@ -1,0 +1,250 @@
+/**
+ * GitHub Actions workflow command parser.
+ *
+ * Parses `::` commands from step stdout and file-based commands
+ * from $GITHUB_OUTPUT, $GITHUB_ENV, $GITHUB_PATH.
+ *
+ * Reference: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions
+ */
+
+import fs from "fs";
+
+// ---------------------------------------------------------------------------
+// Workflow commands (stdout `::` protocol)
+// ---------------------------------------------------------------------------
+
+export interface Annotation {
+  level: "error" | "warning" | "notice";
+  message: string;
+  file?: string;
+  line?: number;
+  endLine?: number;
+  col?: number;
+  endColumn?: number;
+  title?: string;
+}
+
+export interface WorkflowCommands {
+  outputs: Record<string, string>;
+  env: Record<string, string>;
+  path: string[];
+  annotations: Annotation[];
+  masks: string[];
+  debugMessages: string[];
+  /** If ::stop-commands:: is active, this contains the token. */
+  stopToken: string | null;
+}
+
+/**
+ * Parse workflow commands from a single line of stdout.
+ *
+ * Mutates the provided `state` object with the parsed results.
+ * Returns the line with commands stripped (for display), or null if
+ * the line should be hidden (debug messages when debug is off).
+ */
+export function parseCommand(line: string, state: WorkflowCommands): string | null {
+  // If stop-commands is active, only look for the resume token
+  if (state.stopToken) {
+    if (line === `::${state.stopToken}::`) {
+      state.stopToken = null;
+      return null;
+    }
+    return line; // Pass through — commands are disabled
+  }
+
+  // ::set-output name=<name>::<value> (deprecated but still used)
+  const setOutputMatch = line.match(/^::set-output name=([^:]+)::(.*)$/);
+  if (setOutputMatch) {
+    state.outputs[setOutputMatch[1]] = setOutputMatch[2];
+    return null;
+  }
+
+  // ::error <props>::<message>
+  const errorMatch = line.match(/^::error\s*(.*?)::(.*)$/);
+  if (errorMatch) {
+    state.annotations.push({
+      level: "error",
+      ...parseAnnotationProps(errorMatch[1]),
+      message: errorMatch[2],
+    });
+    return line;
+  }
+
+  // ::warning <props>::<message>
+  const warningMatch = line.match(/^::warning\s*(.*?)::(.*)$/);
+  if (warningMatch) {
+    state.annotations.push({
+      level: "warning",
+      ...parseAnnotationProps(warningMatch[1]),
+      message: warningMatch[2],
+    });
+    return line;
+  }
+
+  // ::notice <props>::<message>
+  const noticeMatch = line.match(/^::notice\s*(.*?)::(.*)$/);
+  if (noticeMatch) {
+    state.annotations.push({
+      level: "notice",
+      ...parseAnnotationProps(noticeMatch[1]),
+      message: noticeMatch[2],
+    });
+    return line;
+  }
+
+  // ::debug::<message>
+  const debugMatch = line.match(/^::debug::(.*)$/);
+  if (debugMatch) {
+    state.debugMessages.push(debugMatch[1]);
+    return null;
+  }
+
+  // ::group::<name>
+  if (line.startsWith("::group::")) {
+    return line; // Pass through for display
+  }
+
+  // ::endgroup::
+  if (line === "::endgroup::") {
+    return line;
+  }
+
+  // ::add-mask::<value>
+  const maskMatch = line.match(/^::add-mask::(.*)$/);
+  if (maskMatch) {
+    state.masks.push(maskMatch[1]);
+    return null;
+  }
+
+  // ::stop-commands::<token>
+  const stopMatch = line.match(/^::stop-commands::(.+)$/);
+  if (stopMatch) {
+    state.stopToken = stopMatch[1];
+    return null;
+  }
+
+  return line;
+}
+
+function parseAnnotationProps(propsStr: string): Partial<Annotation> {
+  const props: Partial<Annotation> = {};
+  if (!propsStr.trim()) {
+    return props;
+  }
+
+  for (const pair of propsStr.split(",")) {
+    const [key, ...rest] = pair.split("=");
+    const value = rest.join("=");
+    switch (key.trim()) {
+      case "file":
+        props.file = value;
+        break;
+      case "line":
+        props.line = parseInt(value, 10) || undefined;
+        break;
+      case "endLine":
+        props.endLine = parseInt(value, 10) || undefined;
+        break;
+      case "col":
+        props.col = parseInt(value, 10) || undefined;
+        break;
+      case "endColumn":
+        props.endColumn = parseInt(value, 10) || undefined;
+        break;
+      case "title":
+        props.title = value;
+        break;
+    }
+  }
+  return props;
+}
+
+export function createEmptyCommands(): WorkflowCommands {
+  return {
+    outputs: {},
+    env: {},
+    path: [],
+    annotations: [],
+    masks: [],
+    debugMessages: [],
+    stopToken: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// File-based commands ($GITHUB_OUTPUT, $GITHUB_ENV, $GITHUB_PATH)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a GITHUB_OUTPUT or GITHUB_ENV file.
+ *
+ * Format:
+ *   name=value        (single-line)
+ *   name<<EOF         (multi-line)
+ *   value line 1
+ *   value line 2
+ *   EOF
+ */
+export function parseKeyValueFile(filePath: string): Record<string, string> {
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, "utf8");
+  } catch {
+    return {};
+  }
+
+  const result: Record<string, string> = {};
+  const lines = content.split("\n");
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Multi-line: name<<DELIMITER
+    const multiMatch = line.match(/^([^=]+)<<(.+)$/);
+    if (multiMatch) {
+      const name = multiMatch[1];
+      const delimiter = multiMatch[2];
+      const valueLines: string[] = [];
+      i++;
+      while (i < lines.length && lines[i] !== delimiter) {
+        valueLines.push(lines[i]);
+        i++;
+      }
+      result[name] = valueLines.join("\n");
+      i++; // skip delimiter line
+      continue;
+    }
+
+    // Single-line: name=value
+    const eqIndex = line.indexOf("=");
+    if (eqIndex > 0) {
+      const name = line.slice(0, eqIndex);
+      const value = line.slice(eqIndex + 1);
+      result[name] = value;
+    }
+
+    i++;
+  }
+
+  return result;
+}
+
+/**
+ * Parse a GITHUB_PATH file.
+ *
+ * One path per line, prepended to PATH for subsequent steps.
+ */
+export function parsePathFile(filePath: string): string[] {
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, "utf8");
+  } catch {
+    return [];
+  }
+
+  return content
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+}

--- a/packages/ts-runner/src/expressions.test.ts
+++ b/packages/ts-runner/src/expressions.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect } from "vitest";
+
+import { evaluate, interpolate, evaluateCondition, type ExpressionContext } from "./expressions.js";
+
+function makeCtx(overrides: Partial<ExpressionContext> = {}): ExpressionContext {
+  return {
+    github: {
+      actor: "octocat",
+      ref: "refs/heads/main",
+      ref_name: "main",
+      sha: "abc123",
+      run_id: "42",
+    },
+    env: { NODE_ENV: "test", CI: "true" },
+    secrets: { DEPLOY_KEY: "secret123" },
+    matrix: { os: "ubuntu-latest", node: "20" },
+    steps: {
+      build: { outputs: { artifact: "dist.tar.gz" }, outcome: "success", conclusion: "success" },
+      test: { outputs: {}, outcome: "failure", conclusion: "failure" },
+    },
+    needs: {
+      setup: { outputs: { cache_key: "v1-abc" }, result: "success" },
+    },
+    runner: {
+      os: "Linux",
+      arch: "X64",
+      name: "ts-runner",
+      temp: "/tmp",
+      tool_cache: "/tmp/tool-cache",
+    },
+    job: { status: "success" },
+    inputs: { environment: "staging" },
+    ...overrides,
+  };
+}
+
+describe("evaluate", () => {
+  describe("literals", () => {
+    it("evaluates string literals", () => {
+      expect(evaluate("'hello'", makeCtx())).toBe("hello");
+    });
+
+    it("evaluates number literals", () => {
+      expect(evaluate("42", makeCtx())).toBe(42);
+    });
+
+    it("evaluates boolean literals", () => {
+      expect(evaluate("true", makeCtx())).toBe(true);
+      expect(evaluate("false", makeCtx())).toBe(false);
+    });
+
+    it("evaluates null", () => {
+      expect(evaluate("null", makeCtx())).toBe(null);
+    });
+  });
+
+  describe("context access", () => {
+    it("reads github context", () => {
+      expect(evaluate("github.actor", makeCtx())).toBe("octocat");
+    });
+
+    it("reads env context", () => {
+      expect(evaluate("env.NODE_ENV", makeCtx())).toBe("test");
+    });
+
+    it("reads secrets", () => {
+      expect(evaluate("secrets.DEPLOY_KEY", makeCtx())).toBe("secret123");
+    });
+
+    it("reads matrix values", () => {
+      expect(evaluate("matrix.os", makeCtx())).toBe("ubuntu-latest");
+    });
+
+    it("reads step outputs", () => {
+      expect(evaluate("steps.build.outputs.artifact", makeCtx())).toBe("dist.tar.gz");
+    });
+
+    it("reads step outcome", () => {
+      expect(evaluate("steps.build.outcome", makeCtx())).toBe("success");
+    });
+
+    it("reads needs outputs", () => {
+      expect(evaluate("needs.setup.outputs.cache_key", makeCtx())).toBe("v1-abc");
+    });
+
+    it("reads needs result", () => {
+      expect(evaluate("needs.setup.result", makeCtx())).toBe("success");
+    });
+
+    it("returns empty string for missing context", () => {
+      expect(evaluate("github.nonexistent", makeCtx())).toBe("");
+    });
+
+    it("reads runner context", () => {
+      expect(evaluate("runner.os", makeCtx())).toBe("Linux");
+    });
+
+    it("reads inputs", () => {
+      expect(evaluate("inputs.environment", makeCtx())).toBe("staging");
+    });
+  });
+
+  describe("comparisons", () => {
+    it("evaluates ==", () => {
+      expect(evaluate("github.actor == 'octocat'", makeCtx())).toBe(true);
+      expect(evaluate("github.actor == 'other'", makeCtx())).toBe(false);
+    });
+
+    it("evaluates != ", () => {
+      expect(evaluate("github.actor != 'other'", makeCtx())).toBe(true);
+    });
+
+    it("string comparison is case-insensitive", () => {
+      expect(evaluate("'ABC' == 'abc'", makeCtx())).toBe(true);
+    });
+
+    it("number comparison", () => {
+      expect(evaluate("1 == 1", makeCtx())).toBe(true);
+      expect(evaluate("1 < 2", makeCtx())).toBe(true);
+      expect(evaluate("2 > 1", makeCtx())).toBe(true);
+      expect(evaluate("1 <= 1", makeCtx())).toBe(true);
+      expect(evaluate("1 >= 1", makeCtx())).toBe(true);
+    });
+  });
+
+  describe("logical operators", () => {
+    it("evaluates &&", () => {
+      expect(evaluate("true && true", makeCtx())).toBe(true);
+      expect(evaluate("true && false", makeCtx())).toBe(false);
+    });
+
+    it("evaluates ||", () => {
+      expect(evaluate("false || true", makeCtx())).toBe(true);
+      expect(evaluate("false || false", makeCtx())).toBe(false);
+    });
+
+    it("evaluates !", () => {
+      expect(evaluate("!true", makeCtx())).toBe(false);
+      expect(evaluate("!false", makeCtx())).toBe(true);
+    });
+
+    it("short-circuits &&", () => {
+      // false && anything => false (returns left operand)
+      expect(evaluate("false && true", makeCtx())).toBe(false);
+    });
+
+    it("short-circuits ||", () => {
+      // true || anything => true (returns left operand)
+      expect(evaluate("true || false", makeCtx())).toBe(true);
+    });
+  });
+
+  describe("functions", () => {
+    it("success() returns true when all steps succeeded", () => {
+      const ctx = makeCtx({
+        steps: {
+          a: { outputs: {}, outcome: "success", conclusion: "success" },
+        },
+      });
+      expect(evaluate("success()", ctx)).toBe(true);
+    });
+
+    it("failure() returns true when a step failed", () => {
+      const ctx = makeCtx(); // has a "test" step with failure
+      expect(evaluate("failure()", ctx)).toBe(true);
+    });
+
+    it("always() returns true", () => {
+      expect(evaluate("always()", makeCtx())).toBe(true);
+    });
+
+    it("contains() with string", () => {
+      expect(evaluate("contains('hello world', 'world')", makeCtx())).toBe(true);
+      expect(evaluate("contains('hello world', 'xyz')", makeCtx())).toBe(false);
+    });
+
+    it("contains() is case-insensitive", () => {
+      expect(evaluate("contains('Hello', 'hello')", makeCtx())).toBe(true);
+    });
+
+    it("startsWith()", () => {
+      expect(evaluate("startsWith('hello world', 'hello')", makeCtx())).toBe(true);
+      expect(evaluate("startsWith('hello world', 'world')", makeCtx())).toBe(false);
+    });
+
+    it("endsWith()", () => {
+      expect(evaluate("endsWith('hello world', 'world')", makeCtx())).toBe(true);
+    });
+
+    it("format()", () => {
+      expect(evaluate("format('Hello {0}, {1}!', 'world', 'test')", makeCtx())).toBe(
+        "Hello world, test!",
+      );
+    });
+
+    it("join()", () => {
+      // join with a context value that is an array would be tested with arrays
+      // For now, test with a string (returns the string as-is)
+      expect(evaluate("join('hello', '-')", makeCtx())).toBe("hello");
+    });
+
+    it("toJSON()", () => {
+      expect(evaluate("toJSON('hello')", makeCtx())).toBe('"hello"');
+    });
+
+    it("fromJSON()", () => {
+      expect(evaluate("fromJSON('42')", makeCtx())).toBe(42);
+      expect(evaluate("fromJSON('true')", makeCtx())).toBe(true);
+    });
+  });
+
+  describe("complex expressions", () => {
+    it("nested function calls in comparisons", () => {
+      expect(
+        evaluate("contains(github.ref_name, 'main') && github.actor == 'octocat'", makeCtx()),
+      ).toBe(true);
+    });
+
+    it("parenthesized expressions", () => {
+      expect(evaluate("(true || false) && true", makeCtx())).toBe(true);
+    });
+
+    it("negated comparison", () => {
+      expect(evaluate("!(github.actor == 'other')", makeCtx())).toBe(true);
+    });
+  });
+});
+
+describe("interpolate", () => {
+  it("interpolates expressions in strings", () => {
+    expect(interpolate("Hello ${{ github.actor }}!", makeCtx())).toBe("Hello octocat!");
+  });
+
+  it("handles multiple expressions", () => {
+    expect(interpolate("${{ matrix.os }}-${{ matrix.node }}", makeCtx())).toBe("ubuntu-latest-20");
+  });
+
+  it("preserves non-expression text", () => {
+    expect(interpolate("no expressions here", makeCtx())).toBe("no expressions here");
+  });
+
+  it("returns empty string for unknown contexts", () => {
+    expect(interpolate("${{ unknown.thing }}", makeCtx())).toBe("");
+  });
+});
+
+describe("evaluateCondition", () => {
+  it("defaults to success() when empty", () => {
+    const ctx = makeCtx({
+      steps: { a: { outputs: {}, outcome: "success", conclusion: "success" } },
+    });
+    expect(evaluateCondition("", ctx)).toBe(true);
+  });
+
+  it("strips ${{ }} wrapper", () => {
+    expect(evaluateCondition("${{ true }}", makeCtx())).toBe(true);
+  });
+
+  it("evaluates failure()", () => {
+    expect(evaluateCondition("failure()", makeCtx())).toBe(true);
+  });
+
+  it("evaluates always()", () => {
+    expect(evaluateCondition("always()", makeCtx())).toBe(true);
+  });
+
+  it("evaluates context comparison", () => {
+    expect(evaluateCondition("github.actor == 'octocat'", makeCtx())).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression tests for bug fixes (#133)
+// ---------------------------------------------------------------------------
+
+describe("bug fixes", () => {
+  it("parses escaped single quotes in string literals", () => {
+    const ctx = makeCtx();
+    // 'it''s' should parse as the string "it's"
+    expect(evaluate("'it''s'", ctx)).toBe("it's");
+    expect(evaluate("'don''t stop'", ctx)).toBe("don't stop");
+    // Empty escaped quote: '''' = single quote
+    expect(evaluate("''''", ctx)).toBe("'");
+  });
+
+  it("treats string '0' and 'false' as truthy", () => {
+    const ctx = makeCtx({ env: { ...makeCtx().env, ZERO: "0", FALSE: "false" } });
+    // In GitHub Actions, non-empty strings are truthy
+    expect(evaluate("env.ZERO && 'yes'", ctx)).toBe("yes");
+    expect(evaluate("env.FALSE && 'yes'", ctx)).toBe("yes");
+    // Empty string is still falsy
+    expect(evaluate("'' && 'yes'", ctx)).toBe("");
+  });
+
+  it("simpleMatch escapes regex metacharacters in glob patterns", () => {
+    // hashFiles uses simpleMatch internally — test via evaluate
+    // The key thing is that patterns with regex metacharacters don't crash
+    const ctx = makeCtx({ workspace: "/nonexistent" });
+    // This should not throw (previously would crash on unbalanced brackets)
+    expect(() => evaluate("hashFiles('src/file[1].txt')", ctx)).not.toThrow();
+    expect(() => evaluate("hashFiles('src/c++/main.cpp')", ctx)).not.toThrow();
+  });
+});

--- a/packages/ts-runner/src/expressions.ts
+++ b/packages/ts-runner/src/expressions.ts
@@ -1,0 +1,873 @@
+/**
+ * GitHub Actions expression evaluator.
+ *
+ * Evaluates `${{ }}` expressions used in workflow files. Supports:
+ * - Property access: `github.actor`, `steps.build.outputs.result`
+ * - Functions: `success()`, `failure()`, `always()`, `cancelled()`,
+ *   `contains()`, `startsWith()`, `endsWith()`, `format()`, `join()`,
+ *   `toJSON()`, `fromJSON()`, `hashFiles()`
+ * - Operators: `==`, `!=`, `&&`, `||`, `!`, `<`, `<=`, `>`, `>=`
+ * - Literals: strings ('...'), numbers, booleans (true/false), null
+ *
+ * Reference: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions
+ */
+
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ExpressionValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ExpressionValue[]
+  | { [key: string]: ExpressionValue };
+
+export interface ExpressionContext {
+  github: Record<string, ExpressionValue>;
+  env: Record<string, string>;
+  secrets: Record<string, string>;
+  matrix: Record<string, string>;
+  steps: Record<string, { outputs: Record<string, string>; outcome: string; conclusion: string }>;
+  needs: Record<string, { outputs: Record<string, string>; result: string }>;
+  runner: Record<string, string>;
+  job: Record<string, ExpressionValue>;
+  inputs: Record<string, string>;
+  /** Workspace root for hashFiles() resolution */
+  workspace?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Tokenizer
+// ---------------------------------------------------------------------------
+
+enum TokenType {
+  String,
+  Number,
+  Boolean,
+  Null,
+  Ident,
+  Dot,
+  LParen,
+  RParen,
+  LBracket,
+  RBracket,
+  Comma,
+  Star,
+  Eq,
+  Neq,
+  Lt,
+  Le,
+  Gt,
+  Ge,
+  And,
+  Or,
+  Not,
+  EOF,
+}
+
+interface Token {
+  type: TokenType;
+  value: string;
+  pos: number;
+}
+
+function tokenize(input: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+
+  while (i < input.length) {
+    // Skip whitespace
+    if (/\s/.test(input[i])) {
+      i++;
+      continue;
+    }
+
+    const pos = i;
+
+    // Two-char operators
+    if (i + 1 < input.length) {
+      const two = input.slice(i, i + 2);
+      if (two === "==") {
+        tokens.push({ type: TokenType.Eq, value: two, pos });
+        i += 2;
+        continue;
+      }
+      if (two === "!=") {
+        tokens.push({ type: TokenType.Neq, value: two, pos });
+        i += 2;
+        continue;
+      }
+      if (two === "<=") {
+        tokens.push({ type: TokenType.Le, value: two, pos });
+        i += 2;
+        continue;
+      }
+      if (two === ">=") {
+        tokens.push({ type: TokenType.Ge, value: two, pos });
+        i += 2;
+        continue;
+      }
+      if (two === "&&") {
+        tokens.push({ type: TokenType.And, value: two, pos });
+        i += 2;
+        continue;
+      }
+      if (two === "||") {
+        tokens.push({ type: TokenType.Or, value: two, pos });
+        i += 2;
+        continue;
+      }
+    }
+
+    // Single-char tokens
+    const ch = input[i];
+    if (ch === "(") {
+      tokens.push({ type: TokenType.LParen, value: ch, pos });
+      i++;
+      continue;
+    }
+    if (ch === ")") {
+      tokens.push({ type: TokenType.RParen, value: ch, pos });
+      i++;
+      continue;
+    }
+    if (ch === "[") {
+      tokens.push({ type: TokenType.LBracket, value: ch, pos });
+      i++;
+      continue;
+    }
+    if (ch === "]") {
+      tokens.push({ type: TokenType.RBracket, value: ch, pos });
+      i++;
+      continue;
+    }
+    if (ch === ",") {
+      tokens.push({ type: TokenType.Comma, value: ch, pos });
+      i++;
+      continue;
+    }
+    if (ch === ".") {
+      tokens.push({ type: TokenType.Dot, value: ch, pos });
+      i++;
+      continue;
+    }
+    if (ch === "<") {
+      tokens.push({ type: TokenType.Lt, value: ch, pos });
+      i++;
+      continue;
+    }
+    if (ch === ">") {
+      tokens.push({ type: TokenType.Gt, value: ch, pos });
+      i++;
+      continue;
+    }
+    if (ch === "!") {
+      tokens.push({ type: TokenType.Not, value: ch, pos });
+      i++;
+      continue;
+    }
+    if (ch === "*") {
+      tokens.push({ type: TokenType.Star, value: ch, pos });
+      i++;
+      continue;
+    }
+
+    // String literal (single-quoted)
+    if (ch === "'") {
+      let str = "";
+      i++; // skip opening quote
+      while (i < input.length) {
+        if (input[i] === "'" && i + 1 < input.length && input[i + 1] === "'") {
+          str += "'"; // escaped quote ''
+          i += 2;
+        } else if (input[i] === "'") {
+          break; // closing quote
+        } else {
+          str += input[i];
+          i++;
+        }
+      }
+      i++; // skip closing quote
+      tokens.push({ type: TokenType.String, value: str, pos });
+      continue;
+    }
+
+    // Number
+    if (/[\d]/.test(ch) || (ch === "-" && i + 1 < input.length && /[\d]/.test(input[i + 1]))) {
+      let num = ch;
+      i++;
+      while (i < input.length && /[\d.]/.test(input[i])) {
+        num += input[i];
+        i++;
+      }
+      // Check for hex
+      if (num === "0" && i < input.length && input[i] === "x") {
+        num += input[i];
+        i++;
+        while (i < input.length && /[\da-fA-F]/.test(input[i])) {
+          num += input[i];
+          i++;
+        }
+      }
+      tokens.push({ type: TokenType.Number, value: num, pos });
+      continue;
+    }
+
+    // Identifier or keyword
+    if (/[a-zA-Z_]/.test(ch)) {
+      let ident = ch;
+      i++;
+      while (i < input.length && /[a-zA-Z0-9_-]/.test(input[i])) {
+        ident += input[i];
+        i++;
+      }
+      if (ident === "true" || ident === "false") {
+        tokens.push({ type: TokenType.Boolean, value: ident, pos });
+      } else if (ident === "null") {
+        tokens.push({ type: TokenType.Null, value: ident, pos });
+      } else {
+        tokens.push({ type: TokenType.Ident, value: ident, pos });
+      }
+      continue;
+    }
+
+    // Unknown character — skip
+    i++;
+  }
+
+  tokens.push({ type: TokenType.EOF, value: "", pos: i });
+  return tokens;
+}
+
+// ---------------------------------------------------------------------------
+// Parser — recursive descent producing an AST
+// ---------------------------------------------------------------------------
+
+type Expr =
+  | { kind: "literal"; value: ExpressionValue }
+  | { kind: "context"; path: string[] }
+  | { kind: "index"; object: Expr; index: Expr }
+  | { kind: "call"; name: string; args: Expr[] }
+  | { kind: "not"; operand: Expr }
+  | {
+      kind: "binary";
+      op: "==" | "!=" | "<" | "<=" | ">" | ">=" | "&&" | "||";
+      left: Expr;
+      right: Expr;
+    };
+
+class Parser {
+  private pos = 0;
+  constructor(private tokens: Token[]) {}
+
+  private peek(): Token {
+    return this.tokens[this.pos] || { type: TokenType.EOF, value: "", pos: -1 };
+  }
+
+  private advance(): Token {
+    return this.tokens[this.pos++];
+  }
+
+  private expect(type: TokenType): Token {
+    const t = this.advance();
+    if (t.type !== type) {
+      throw new Error(
+        `Expected ${TokenType[type]} but got ${TokenType[t.type]} ("${t.value}") at position ${t.pos}`,
+      );
+    }
+    return t;
+  }
+
+  parse(): Expr {
+    const expr = this.parseOr();
+    return expr;
+  }
+
+  // Precedence (lowest to highest): ||, &&, ==|!=|<|<=|>|>=, !, primary
+  private parseOr(): Expr {
+    let left = this.parseAnd();
+    while (this.peek().type === TokenType.Or) {
+      this.advance();
+      const right = this.parseAnd();
+      left = { kind: "binary", op: "||", left, right };
+    }
+    return left;
+  }
+
+  private parseAnd(): Expr {
+    let left = this.parseComparison();
+    while (this.peek().type === TokenType.And) {
+      this.advance();
+      const right = this.parseComparison();
+      left = { kind: "binary", op: "&&", left, right };
+    }
+    return left;
+  }
+
+  private parseComparison(): Expr {
+    let left = this.parseUnary();
+    const t = this.peek();
+    if (
+      t.type === TokenType.Eq ||
+      t.type === TokenType.Neq ||
+      t.type === TokenType.Lt ||
+      t.type === TokenType.Le ||
+      t.type === TokenType.Gt ||
+      t.type === TokenType.Ge
+    ) {
+      const op = this.advance().value as "==" | "!=" | "<" | "<=" | ">" | ">=";
+      const right = this.parseUnary();
+      left = { kind: "binary", op, left, right };
+    }
+    return left;
+  }
+
+  private parseUnary(): Expr {
+    if (this.peek().type === TokenType.Not) {
+      this.advance();
+      const operand = this.parseUnary();
+      return { kind: "not", operand };
+    }
+    return this.parsePrimary();
+  }
+
+  private parsePrimary(): Expr {
+    const t = this.peek();
+
+    // Parenthesized expression
+    if (t.type === TokenType.LParen) {
+      this.advance();
+      const expr = this.parseOr();
+      this.expect(TokenType.RParen);
+      return expr;
+    }
+
+    // String literal
+    if (t.type === TokenType.String) {
+      this.advance();
+      return { kind: "literal", value: t.value };
+    }
+
+    // Number literal
+    if (t.type === TokenType.Number) {
+      this.advance();
+      return { kind: "literal", value: Number(t.value) };
+    }
+
+    // Boolean literal
+    if (t.type === TokenType.Boolean) {
+      this.advance();
+      return { kind: "literal", value: t.value === "true" };
+    }
+
+    // Null literal
+    if (t.type === TokenType.Null) {
+      this.advance();
+      return { kind: "literal", value: null };
+    }
+
+    // Identifier — could be context access or function call
+    if (t.type === TokenType.Ident) {
+      this.advance();
+      const name = t.value;
+
+      // Function call: ident(args...)
+      if (this.peek().type === TokenType.LParen) {
+        // But first check if next-next is RParen or an arg — this IS a function call
+        this.advance(); // consume (
+        const args: Expr[] = [];
+        if (this.peek().type !== TokenType.RParen) {
+          args.push(this.parseOr());
+          while (this.peek().type === TokenType.Comma) {
+            this.advance();
+            args.push(this.parseOr());
+          }
+        }
+        this.expect(TokenType.RParen);
+        return { kind: "call", name, args };
+      }
+
+      // Context access: ident.prop.prop or ident['key']
+      const pathParts: string[] = [name];
+      let base: Expr = { kind: "context", path: pathParts };
+
+      while (true) {
+        if (this.peek().type === TokenType.Dot) {
+          this.advance();
+          // Accept both identifiers and * (wildcard filter)
+          const next = this.peek();
+          if (next.type === TokenType.Ident) {
+            pathParts.push(this.advance().value);
+          } else if (next.type === TokenType.Star) {
+            pathParts.push(this.advance().value);
+          } else {
+            throw new Error(
+              `Expected identifier or * after '.' but got ${TokenType[next.type]} ("${next.value}") at position ${next.pos}`,
+            );
+          }
+        } else if (this.peek().type === TokenType.LBracket) {
+          this.advance();
+          const index = this.parseOr();
+          this.expect(TokenType.RBracket);
+          // If we've been building a context path, convert to index expression
+          base = { kind: "index", object: base, index };
+          // Can't keep appending to pathParts after a dynamic index
+          return base;
+        } else {
+          break;
+        }
+      }
+
+      return base;
+    }
+
+    throw new Error(`Unexpected token: ${TokenType[t.type]} ("${t.value}") at position ${t.pos}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Evaluator
+// ---------------------------------------------------------------------------
+
+function resolveContext(pathParts: string[], ctx: ExpressionContext): ExpressionValue {
+  const root = pathParts[0];
+  let value: ExpressionValue;
+
+  switch (root) {
+    case "github":
+      value = ctx.github;
+      break;
+    case "env":
+      value = ctx.env;
+      break;
+    case "secrets":
+      value = ctx.secrets;
+      break;
+    case "matrix":
+      value = ctx.matrix;
+      break;
+    case "runner":
+      value = ctx.runner;
+      break;
+    case "job":
+      value = ctx.job;
+      break;
+    case "inputs":
+      value = ctx.inputs;
+      break;
+    case "steps": {
+      // steps.id.outputs.name or steps.id.outcome/conclusion
+      const stepId = pathParts[1];
+      if (!stepId) {
+        return ctx.steps;
+      }
+      const step = ctx.steps[stepId];
+      if (!step) {
+        return "";
+      }
+      if (pathParts[2] === "outputs") {
+        return pathParts[3] ? (step.outputs[pathParts[3]] ?? "") : step.outputs;
+      }
+      if (pathParts[2] === "outcome") {
+        return step.outcome;
+      }
+      if (pathParts[2] === "conclusion") {
+        return step.conclusion;
+      }
+      return "";
+    }
+    case "needs": {
+      const jobId = pathParts[1];
+      if (!jobId) {
+        return ctx.needs;
+      }
+      const job = ctx.needs[jobId];
+      if (!job) {
+        return "";
+      }
+      if (pathParts[2] === "outputs") {
+        return pathParts[3] ? (job.outputs[pathParts[3]] ?? "") : job.outputs;
+      }
+      if (pathParts[2] === "result") {
+        return job.result;
+      }
+      return "";
+    }
+    default:
+      return "";
+  }
+
+  // Walk remaining path
+  for (let i = 1; i < pathParts.length; i++) {
+    if (value == null || typeof value !== "object" || Array.isArray(value)) {
+      return "";
+    }
+    value = (value as Record<string, ExpressionValue>)[pathParts[i]] ?? "";
+  }
+
+  return value ?? "";
+}
+
+/** Coerce a value to string (GitHub Actions coercion rules). */
+function coerceToString(v: ExpressionValue): string {
+  if (v === null) {
+    return "";
+  }
+  if (typeof v === "boolean") {
+    return v ? "true" : "false";
+  }
+  if (typeof v === "number") {
+    return String(v);
+  }
+  if (typeof v === "string") {
+    return v;
+  }
+  return JSON.stringify(v);
+}
+
+/** Coerce a value to boolean (GitHub Actions truthiness). */
+function coerceToBool(v: ExpressionValue): boolean {
+  if (v === null) {
+    return false;
+  }
+  if (typeof v === "boolean") {
+    return v;
+  }
+  if (typeof v === "number") {
+    return v !== 0;
+  }
+  if (typeof v === "string") {
+    return v !== "";
+  }
+  return true;
+}
+
+/** Compare two values with type coercion (GitHub Actions rules). */
+function compareValues(left: ExpressionValue, right: ExpressionValue): number {
+  // Null comparisons
+  if (left === null && right === null) {
+    return 0;
+  }
+  if (left === null) {
+    return typeof right === "number" ? -right : -1;
+  }
+  if (right === null) {
+    return typeof left === "number" ? (left as number) : 1;
+  }
+
+  // If both are numbers, compare numerically
+  if (typeof left === "number" && typeof right === "number") {
+    return left - right;
+  }
+
+  // If one is a number, try to coerce the other
+  if (typeof left === "number" && typeof right === "string") {
+    const n = Number(right);
+    if (!isNaN(n)) {
+      return left - n;
+    }
+  }
+  if (typeof right === "number" && typeof left === "string") {
+    const n = Number(left);
+    if (!isNaN(n)) {
+      return n - right;
+    }
+  }
+
+  // String comparison (case-insensitive for == and !=)
+  const ls = coerceToString(left).toLowerCase();
+  const rs = coerceToString(right).toLowerCase();
+  if (ls < rs) {
+    return -1;
+  }
+  if (ls > rs) {
+    return 1;
+  }
+  return 0;
+}
+
+function hashFilesImpl(patterns: string[], workspace: string): string {
+  const hash = crypto.createHash("sha256");
+  let hasAny = false;
+
+  for (const pattern of patterns) {
+    const files = findFiles(workspace, pattern);
+    for (const f of files.sort()) {
+      try {
+        hash.update(fs.readFileSync(f));
+        hasAny = true;
+      } catch {
+        // skip unreadable files
+      }
+    }
+  }
+
+  return hasAny ? hash.digest("hex") : "";
+}
+
+function findFiles(rootDir: string, pattern: string): string[] {
+  // Simple recursive glob — import minimatch if available, otherwise basic matching
+  const results: string[] = [];
+  const normPattern = pattern.replace(/^\.\//, "");
+
+  function walk(dir: string, relative: string) {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith(".") || entry.name === "node_modules") {
+        continue;
+      }
+      const relChild = relative ? `${relative}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        walk(path.join(dir, entry.name), relChild);
+      } else if (simpleMatch(relChild, normPattern)) {
+        results.push(path.join(dir, entry.name));
+      }
+    }
+  }
+
+  walk(rootDir, "");
+  return results;
+}
+
+/** Minimal glob matching — supports * and **. For production, use minimatch. */
+function simpleMatch(filepath: string, pattern: string): boolean {
+  const regex = pattern
+    .replace(/\*\*/g, "{{GLOBSTAR}}")
+    .replace(/\*/g, "{{STAR}}")
+    .replace(/\?/g, "{{QMARK}}")
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\{\{GLOBSTAR\}\}/g, ".*")
+    .replace(/\{\{STAR\}\}/g, "[^/]*")
+    .replace(/\{\{QMARK\}\}/g, "[^/]");
+  return new RegExp(`^${regex}$`).test(filepath);
+}
+
+function evaluateExpr(expr: Expr, ctx: ExpressionContext): ExpressionValue {
+  switch (expr.kind) {
+    case "literal":
+      return expr.value;
+
+    case "context":
+      return resolveContext(expr.path, ctx);
+
+    case "index": {
+      const obj = evaluateExpr(expr.object, ctx);
+      const idx = evaluateExpr(expr.index, ctx);
+      if (obj == null || typeof obj !== "object") {
+        return "";
+      }
+      const key = coerceToString(idx);
+      if (Array.isArray(obj)) {
+        const i = parseInt(key, 10);
+        return isNaN(i) ? "" : (obj[i] ?? "");
+      }
+      return (obj as Record<string, ExpressionValue>)[key] ?? "";
+    }
+
+    case "not":
+      return !coerceToBool(evaluateExpr(expr.operand, ctx));
+
+    case "binary": {
+      // Short-circuit for && and ||
+      if (expr.op === "&&") {
+        const left = evaluateExpr(expr.left, ctx);
+        if (!coerceToBool(left)) {
+          return left;
+        }
+        return evaluateExpr(expr.right, ctx);
+      }
+      if (expr.op === "||") {
+        const left = evaluateExpr(expr.left, ctx);
+        if (coerceToBool(left)) {
+          return left;
+        }
+        return evaluateExpr(expr.right, ctx);
+      }
+
+      const left = evaluateExpr(expr.left, ctx);
+      const right = evaluateExpr(expr.right, ctx);
+      const cmp = compareValues(left, right);
+
+      switch (expr.op) {
+        case "==":
+          return cmp === 0;
+        case "!=":
+          return cmp !== 0;
+        case "<":
+          return cmp < 0;
+        case "<=":
+          return cmp <= 0;
+        case ">":
+          return cmp > 0;
+        case ">=":
+          return cmp >= 0;
+      }
+      return false;
+    }
+
+    case "call":
+      return evaluateFunction(expr.name, expr.args, ctx);
+  }
+}
+
+function evaluateFunction(name: string, argExprs: Expr[], ctx: ExpressionContext): ExpressionValue {
+  switch (name) {
+    case "success": {
+      // All upstream jobs/steps succeeded (or no upstream)
+      const stepValues = Object.values(ctx.steps);
+      if (stepValues.length === 0) {
+        return true;
+      }
+      return stepValues.every((s) => s.conclusion === "success" || s.conclusion === "skipped");
+    }
+
+    case "failure": {
+      return Object.values(ctx.steps).some((s) => s.conclusion === "failure");
+    }
+
+    case "always":
+      return true;
+
+    case "cancelled":
+      return false; // Local runs don't get cancelled
+
+    case "contains": {
+      const search = evaluateExpr(argExprs[0], ctx);
+      const item = evaluateExpr(argExprs[1], ctx);
+      if (Array.isArray(search)) {
+        const itemStr = coerceToString(item).toLowerCase();
+        return search.some((v) => coerceToString(v).toLowerCase() === itemStr);
+      }
+      return coerceToString(search).toLowerCase().includes(coerceToString(item).toLowerCase());
+    }
+
+    case "startsWith": {
+      const str = coerceToString(evaluateExpr(argExprs[0], ctx)).toLowerCase();
+      const prefix = coerceToString(evaluateExpr(argExprs[1], ctx)).toLowerCase();
+      return str.startsWith(prefix);
+    }
+
+    case "endsWith": {
+      const str = coerceToString(evaluateExpr(argExprs[0], ctx)).toLowerCase();
+      const suffix = coerceToString(evaluateExpr(argExprs[1], ctx)).toLowerCase();
+      return str.endsWith(suffix);
+    }
+
+    case "format": {
+      const template = coerceToString(evaluateExpr(argExprs[0], ctx));
+      const args = argExprs.slice(1).map((a) => coerceToString(evaluateExpr(a, ctx)));
+      return template.replace(/\{(\d+)\}/g, (_m, idx) => {
+        const i = parseInt(idx, 10);
+        return i < args.length ? args[i] : "";
+      });
+    }
+
+    case "join": {
+      const arr = evaluateExpr(argExprs[0], ctx);
+      const sep = argExprs.length > 1 ? coerceToString(evaluateExpr(argExprs[1], ctx)) : ",";
+      if (Array.isArray(arr)) {
+        return arr.map((v) => coerceToString(v)).join(sep);
+      }
+      return coerceToString(arr);
+    }
+
+    case "toJSON": {
+      const val = evaluateExpr(argExprs[0], ctx);
+      return JSON.stringify(val);
+    }
+
+    case "fromJSON": {
+      const str = coerceToString(evaluateExpr(argExprs[0], ctx));
+      try {
+        return JSON.parse(str) as ExpressionValue;
+      } catch {
+        return str;
+      }
+    }
+
+    case "hashFiles": {
+      const patterns = argExprs.map((a) => coerceToString(evaluateExpr(a, ctx)));
+      if (!ctx.workspace) {
+        return "";
+      }
+      return hashFilesImpl(patterns, ctx.workspace);
+    }
+
+    default:
+      throw new Error(`Unknown function: ${name}()`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate a single expression string (without `${{ }}` delimiters).
+ *
+ * Returns the raw value — callers can coerce with `coerceToString()`.
+ */
+export function evaluate(expression: string, ctx: ExpressionContext): ExpressionValue {
+  const tokens = tokenize(expression);
+  const parser = new Parser(tokens);
+  const ast = parser.parse();
+  return evaluateExpr(ast, ctx);
+}
+
+/**
+ * Interpolate a string containing `${{ }}` expressions.
+ *
+ * Non-expression text is preserved as-is. Expression results are coerced to strings.
+ */
+export function interpolate(template: string, ctx: ExpressionContext): string {
+  return template.replace(/\$\{\{([\s\S]*?)\}\}/g, (_match, expr: string) => {
+    try {
+      const result = evaluate(expr.trim(), ctx);
+      return coerceToString(result);
+    } catch {
+      return "";
+    }
+  });
+}
+
+/**
+ * Evaluate a condition expression (used for `if:` on steps and jobs).
+ *
+ * Returns a boolean. If the expression is empty, defaults to `success()`.
+ * If the expression can't be parsed, warns and returns true (run the step
+ * rather than silently skipping it).
+ */
+export function evaluateCondition(expression: string, ctx: ExpressionContext): boolean {
+  if (!expression.trim()) {
+    return coerceToBool(evaluateFunction("success", [], ctx));
+  }
+
+  // Strip ${{ }} wrapper if present
+  let expr = expression.trim();
+  const wrapped = expr.match(/^\$\{\{\s*([\s\S]*?)\s*\}\}$/);
+  if (wrapped) {
+    expr = wrapped[1];
+  }
+
+  try {
+    return coerceToBool(evaluate(expr, ctx));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[ts-runner] Warning: could not evaluate condition, defaulting to true: ${msg}`);
+    console.error(`[ts-runner]   expression: ${expr}`);
+    return true;
+  }
+}
+
+export { coerceToString, coerceToBool };


### PR DESCRIPTION
## Summary

Adds the two foundational leaf modules for ts-runner — both standalone with no local imports:

- **expressions.ts** (~870 lines): Full `${{ }}` expression evaluator with tokenizer, recursive-descent parser, and AST interpreter. All 9 GitHub Actions contexts, all built-in functions, all operators.
- **commands.ts** (~250 lines): Parses `::` workflow commands from stdout and file-based commands from `$GITHUB_OUTPUT`, `$GITHUB_ENV`, `$GITHUB_PATH`.
- **expressions.test.ts**: 50 unit tests covering literals, context access, comparisons, operators, all functions, interpolation, conditions, and regression tests.

**PR 2 of 4** in the ts-runner series. Tracking issue: #139

## Test plan
- [x] 50 expression evaluator tests pass
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)