### PR TITLE
fix: guard against undefined template.jobs from workflow parser

### DIFF
--- a/.changeset/guard-template-jobs.md
+++ b/.changeset/guard-template-jobs.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Guard against undefined template.jobs from workflow parser to prevent TypeError crash.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -513,7 +513,7 @@ async function handleWorkflow(options: {
     const [owner, name] = githubRepo.split("/");
 
     const template = await getWorkflowTemplate(workflowPath);
-    const jobs = template.jobs.filter((j) => j.type === "job");
+    const jobs = (template.jobs ?? []).filter((j) => j.type === "job");
 
     if (jobs.length === 0) {
       debugCli(`[Agent CI] No jobs found in workflow: ${path.basename(workflowPath)}`);

--- a/packages/cli/src/workflow/workflow-parser.ts
+++ b/packages/cli/src/workflow/workflow-parser.ts
@@ -359,7 +359,7 @@ export async function parseWorkflowSteps(
   // Derive repoPath from filePath (.../repoPath/.github/workflows/foo.yml → repoPath)
   const repoPath = path.dirname(path.dirname(path.dirname(filePath)));
   // Find the job by ID or Name
-  const job = template.jobs.find((j) => {
+  const job = (template.jobs ?? []).find((j) => {
     if (j.type !== "job") {
       return false;
     }


### PR DESCRIPTION
## Summary

- Adds nullish coalescing (`?? []`) to both `template.jobs` access sites in `cli.ts` and `workflow-parser.ts`
- When `@actions/workflow-parser` can't model certain expressions (e.g. `runner.temp` in env), it may return a template without a `jobs` array, causing a `TypeError` crash
- With this fix, those cases fall through to the existing "no jobs found" / "task not found" error paths instead of crashing

Closes #96 (issue 1 of 3).

## Test plan

- [x] All 360 existing tests pass
- [ ] Manually test with a workflow containing `runner.temp` in env values to confirm graceful handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)