### PR TITLE
fix: mount warm-modules at /tmp/node_modules for pnpm TS compat

### DIFF
--- a/.changeset/fix-pnpm-types-warmmod.md
+++ b/.changeset/fix-pnpm-types-warmmod.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Fix TypeScript @types resolution for pnpm projects using warm-modules cache.

--- a/packages/cli/src/docker/container-config.test.ts
+++ b/packages/cli/src/docker/container-config.test.ts
@@ -69,7 +69,7 @@ describe("buildContainerBinds", () => {
     expect(binds).toContain("/tmp/work:/home/runner/_work");
     expect(binds).toContain("/var/run/docker.sock:/var/run/docker.sock"); // default when dockerSocketPath is not set
     expect(binds).toContain("/tmp/shims:/tmp/agent-ci-shims");
-    expect(binds).toContain("/tmp/warm:/tmp/warm-modules");
+    expect(binds).toContain("/tmp/warm:/tmp/node_modules");
     expect(binds).toContain("/tmp/pnpm:/home/runner/_work/.pnpm-store");
     expect(binds).toContain("/tmp/npm:/home/runner/.npm");
     expect(binds).toContain("/tmp/bun:/home/runner/.bun/install/cache");

--- a/packages/cli/src/docker/container-config.ts
+++ b/packages/cli/src/docker/container-config.ts
@@ -116,8 +116,10 @@ export function buildContainerBinds(opts: ContainerBindsOpts): string[] {
     `${h(playwrightCacheDir)}:/home/runner/.cache/ms-playwright`,
     // Warm node_modules: mounted outside the workspace so actions/checkout can
     // delete the symlink without EBUSY. A symlink in the entrypoint points
-    // workspace/node_modules → /tmp/warm-modules.
-    `${h(warmModulesDir)}:/tmp/warm-modules`,
+    // workspace/node_modules → /tmp/node_modules.
+    // Mounted at /tmp/node_modules (not /tmp/warm-modules) so that TypeScript's
+    // upward @types walk from .pnpm realpath finds /tmp/node_modules/@types.
+    `${h(warmModulesDir)}:/tmp/node_modules`,
   ];
 }
 
@@ -158,7 +160,7 @@ export function buildContainerCmd(opts: ContainerCmdOpts): string[] {
     `REPO_NAME=$(basename $GITHUB_REPOSITORY)`,
     `WORKSPACE_PATH=/home/runner/_work/$REPO_NAME/$REPO_NAME`,
     `mkdir -p $WORKSPACE_PATH`,
-    `ln -sfn /tmp/warm-modules $WORKSPACE_PATH/node_modules`,
+    `ln -sfn /tmp/node_modules $WORKSPACE_PATH/node_modules`,
     T("workspace-setup"),
     `echo "[agent-ci:boot] total: $(($(date +%s%3N)-BOOT_T0))ms"`,
     `echo "[agent-ci:boot] starting run.sh --once"`,


### PR DESCRIPTION
## Summary
- Mounts the warm-modules cache at `/tmp/node_modules` instead of `/tmp/warm-modules` inside the container
- This fixes TypeScript `@types/*` resolution for pnpm projects, where `fs.realpathSync()` resolves through `.pnpm/` into the mount and then walks upward looking for `node_modules/@types/`
- With `/tmp/node_modules`, the walk from `/tmp/node_modules/.pnpm/...` naturally finds `/tmp/node_modules/@types/`

Closes #176

## Test plan
- [x] Unit tests pass (449/449)
- [ ] Manual test with a pnpm + TypeScript project (e.g. Khan/wonder-blocks) to verify `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)