### PR TITLE
fix: remove test script from ts-runner to unblock releases

### DIFF
--- a/.changeset/fix-ts-runner-tests.md
+++ b/.changeset/fix-ts-runner-tests.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Remove test script from ts-runner package to unblock release workflow.

--- a/packages/ts-runner/package.json
+++ b/packages/ts-runner/package.json
@@ -33,16 +33,14 @@
   "scripts": {
     "build": "tsgo",
     "typecheck": "tsgo",
-    "ts-runner": "tsx src/cli.ts",
-    "test": "vitest run"
+    "ts-runner": "tsx src/cli.ts"
   },
   "dependencies": {
     "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
-    "tsx": "^4.21.0",
-    "vitest": "^4.0.18"
+    "tsx": "^4.21.0"
   },
   "engines": {
     "node": ">=22"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,9 +189,6 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
-      vitest:
-        specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 


### PR DESCRIPTION
## Summary

- The `ts-runner` package scaffold shipped with `"test": "vitest run"` but has no test files yet. Vitest exits with code 1 when it finds nothing to run, which has been failing the Release workflow since the package was added (every run since April 7).
- Removes the `test` script and `vitest` devDependency from `packages/ts-runner/package.json`, unblocking `changesets/action` so the 15 pending changesets can be released.

## Test plan

- [x] `pnpm --include-workspace-root=false -r test` passes (the exact command from `release.yml` line 37)
- [ ] Verify the Release workflow succeeds on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)