### PR TITLE
fix: disable ts-runner npm publishing

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,6 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "ignore": ["@redwoodjs/ts-runner"]
 }

--- a/packages/ts-runner/package.json
+++ b/packages/ts-runner/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@redwoodjs/ts-runner",
   "version": "0.7.0",
+  "private": true,
   "description": "TypeScript GitHub Actions step runner — no Docker, no .NET binary.",
   "keywords": [
     "ci",
@@ -26,9 +27,6 @@
   "main": "./dist/index.js",
   "exports": {
     ".": "./dist/index.js"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "scripts": {
     "build": "tsgo",


### PR DESCRIPTION
## Summary
- Marks `@redwoodjs/ts-runner` as `"private": true` to prevent npm publishing
- Adds `@redwoodjs/ts-runner` to changeset `ignore` list so it's excluded from versioning
- Removes `publishConfig` since the package is no longer published

`@redwoodjs/ts-runner@0.7.0` is returning npm 404 errors, breaking installs. This disables future publishing until the package is ready.

No changeset needed — this is a config-only change that prevents publishing, not a feature of the published packages.

## Test plan
- [x] Verified unit tests pass (5 pre-existing failures on main, unrelated)
- [ ] Confirm next release workflow skips ts-runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)