### PR TITLE
fix: clean up runner directory on SIGINT/SIGTERM

### DIFF
--- a/.changeset/clean-signals-run.md
+++ b/.changeset/clean-signals-run.md
@@ -3,4 +3,4 @@
 "dtu-github-actions": patch
 ---
 
-Fix signal handler to clean up runner directory on Ctrl+C.
+Fix signal handler to clean up runner directory on Ctrl+C. Add parent-PID liveness tracking to detect and kill orphaned Docker containers on startup. Wire up pruneStaleWorkspaces to clean up old run directories.

--- a/.changeset/clean-signals-run.md
+++ b/.changeset/clean-signals-run.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Fix signal handler to clean up runner directory on Ctrl+C.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -33,7 +33,11 @@ import { Job } from "./types.js";
 import { createConcurrencyLimiter, getDefaultMaxConcurrentJobs } from "./output/concurrency.js";
 import { isWarmNodeModules, computeLockfileHash } from "./output/cleanup.js";
 import { getWorkingDirectory } from "./output/working-directory.js";
-import { pruneOrphanedDockerResources } from "./docker/shutdown.js";
+import {
+  pruneOrphanedDockerResources,
+  killOrphanedContainers,
+  pruneStaleWorkspaces,
+} from "./docker/shutdown.js";
 import { topoSort } from "./workflow/job-scheduler.js";
 import { expandReusableJobs } from "./workflow/reusable-workflow.js";
 import { prefetchRemoteWorkflows } from "./workflow/remote-workflow-fetch.js";
@@ -817,6 +821,8 @@ async function handleWorkflow(options: {
   };
 
   pruneOrphanedDockerResources();
+  killOrphanedContainers();
+  pruneStaleWorkspaces(getWorkingDirectory(), 24 * 60 * 60 * 1000);
 
   const limiter = createConcurrencyLimiter(maxJobs);
   const allResults: JobResult[] = [];

--- a/packages/cli/src/docker/shutdown.test.ts
+++ b/packages/cli/src/docker/shutdown.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
@@ -114,6 +114,99 @@ describe("Stale workspace pruning", () => {
 
     expect(pruned).toEqual([]);
     expect(fs.existsSync(otherDir)).toBe(true);
+  });
+});
+
+// ── Orphaned container cleanup ────────────────────────────────────────────────
+
+describe("killOrphanedContainers", () => {
+  const execSyncMock = vi.fn();
+  const killSpy = vi.spyOn(process, "kill");
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execSync: execSyncMock,
+    }));
+    execSyncMock.mockReset();
+    killSpy.mockReset();
+  });
+
+  afterEach(() => {
+    killSpy.mockRestore();
+  });
+
+  it("kills containers whose parent PID is dead", async () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("docker ps")) {
+        return "abc123 agent-ci-runner-1 99999\n";
+      }
+      return "";
+    });
+    killSpy.mockImplementation(((pid: number, signal?: string | number) => {
+      if (signal === 0 && pid === 99999) {
+        throw new Error("ESRCH");
+      }
+      return true;
+    }) as typeof process.kill);
+
+    const { killOrphanedContainers } = await import("./shutdown.js");
+    killOrphanedContainers();
+
+    const rmCalls = execSyncMock.mock.calls.filter(([cmd]: string[]) =>
+      cmd.includes("docker rm -f agent-ci-runner-1"),
+    );
+    expect(rmCalls.length).toBeGreaterThan(0);
+  });
+
+  it("leaves containers whose parent PID is alive", async () => {
+    const myPid = process.pid;
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("docker ps")) {
+        return `abc123 agent-ci-runner-2 ${myPid}\n`;
+      }
+      return "";
+    });
+    killSpy.mockImplementation(((pid: number, signal?: string | number) => {
+      if (signal === 0 && pid === myPid) {
+        return true;
+      }
+      throw new Error("ESRCH");
+    }) as typeof process.kill);
+
+    const { killOrphanedContainers } = await import("./shutdown.js");
+    killOrphanedContainers();
+
+    const rmCalls = execSyncMock.mock.calls.filter(([cmd]: string[]) =>
+      cmd.includes("docker rm -f"),
+    );
+    expect(rmCalls).toEqual([]);
+  });
+
+  it("skips containers without a PID label", async () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("docker ps")) {
+        return "abc123 agent-ci-runner-3 \n";
+      }
+      return "";
+    });
+
+    const { killOrphanedContainers } = await import("./shutdown.js");
+    killOrphanedContainers();
+
+    const rmCalls = execSyncMock.mock.calls.filter(([cmd]: string[]) =>
+      cmd.includes("docker rm -f"),
+    );
+    expect(rmCalls).toEqual([]);
+  });
+
+  it("handles Docker not reachable gracefully", async () => {
+    execSyncMock.mockImplementation(() => {
+      throw new Error("Cannot connect to Docker daemon");
+    });
+
+    const { killOrphanedContainers } = await import("./shutdown.js");
+    expect(() => killOrphanedContainers()).not.toThrow();
   });
 });
 

--- a/packages/cli/src/docker/shutdown.ts
+++ b/packages/cli/src/docker/shutdown.ts
@@ -105,6 +105,55 @@ export function pruneOrphanedDockerResources(): void {
   }
 }
 
+// ─── Orphaned container cleanup ───────────────────────────────────────────────
+
+/**
+ * Find and kill running `agent-ci-*` containers whose parent process is dead.
+ *
+ * Every container created by `executeLocalJob` is labelled with
+ * `agent-ci.pid=<PID>`. If the process that spawned the container is no
+ * longer alive, the container is an orphan and should be killed — along with
+ * its svc-* sidecars and bridge network (via `killRunnerContainers`).
+ *
+ * Containers without the label (created before this feature) are skipped.
+ */
+export function killOrphanedContainers(): void {
+  let lines: string[];
+  try {
+    // Format: "containerId containerName pid-label"
+    const raw = execSync(
+      `docker ps --filter "name=agent-ci-" --filter "status=running" --format "{{.ID}} {{.Names}} {{.Label \\"agent-ci.pid\\"}}"`,
+      { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+    ).trim();
+    if (!raw) {
+      return;
+    }
+    lines = raw.split("\n");
+  } catch {
+    // Docker not reachable — skip
+    return;
+  }
+
+  for (const line of lines) {
+    const [, containerName, pidStr] = line.split(" ");
+    if (!containerName || !pidStr) {
+      continue;
+    }
+
+    const pid = Number(pidStr);
+    if (!Number.isFinite(pid) || pid <= 0) {
+      continue;
+    }
+
+    try {
+      process.kill(pid, 0); // signal 0 = liveness check, throws if dead
+    } catch {
+      // Parent is dead — this container is an orphan.
+      killRunnerContainers(containerName);
+    }
+  }
+}
+
 // ─── Workspace pruning ────────────────────────────────────────────────────────
 
 /**

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -232,13 +232,24 @@ export async function executeLocalJob(
   // Open debug stream to capture raw container output
   const debugStream = fs.createWriteStream(debugLogPath);
 
+  // Hoisted for cleanup in `finally` — assigned inside the try block.
+  let container: Docker.Container | null = null;
+  let serviceCtx: ServiceContext | undefined;
+  const hostRunnerDir = path.resolve(runDir, "runner");
+
   // Signal handler: ensure cleanup runs even when killed.
   // Do NOT call process.exit() here — multiple jobs register handlers concurrently,
   // and an early exit would prevent other jobs' handlers from cleaning up their containers.
   // killRunnerContainers already handles the runner, its svc-* sidecars, and the network.
   const signalCleanup = () => {
     killRunnerContainers(containerName);
-    for (const d of [dirs.containerWorkDir, dirs.shimsDir, dirs.signalsDir, dirs.diagDir]) {
+    for (const d of [
+      dirs.containerWorkDir,
+      dirs.shimsDir,
+      dirs.signalsDir,
+      dirs.diagDir,
+      hostRunnerDir,
+    ]) {
       try {
         fs.rmSync(d, { recursive: true, force: true });
       } catch {}
@@ -246,11 +257,6 @@ export async function executeLocalJob(
   };
   process.on("SIGINT", signalCleanup);
   process.on("SIGTERM", signalCleanup);
-
-  // Hoisted for cleanup in `finally` — assigned inside the try block.
-  let container: Docker.Container | null = null;
-  let serviceCtx: ServiceContext | undefined;
-  const hostRunnerDir = path.resolve(runDir, "runner");
 
   try {
     // 1. Seed the job to Local DTU

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -550,6 +550,9 @@ export async function executeLocalJob(
     container = await getDocker().createContainer({
       Image: containerImage,
       name: containerName,
+      Labels: {
+        "agent-ci.pid": String(process.pid),
+      },
       Env: containerEnv,
       ...(useDirectContainer ? { Entrypoint: ["bash"] } : {}),
       Cmd: containerCmd,


### PR DESCRIPTION
## Problem

When the agent-ci CLI process dies unexpectedly (SIGKILL, terminal closed, crash), Docker containers keep running forever. The SIGINT/SIGTERM signal handlers never fire, so cleanup never happens. `pruneOrphanedDockerResources()` only removes **stopped** containers — running orphans slip through.

Additionally, the signal handler was missing `hostRunnerDir` from its cleanup list, leaking runner directories on Ctrl+C. And `pruneStaleWorkspaces()` existed with tests but was never called.

## Solution

- **PID-based orphan detection**: Label every container with `agent-ci.pid=<PID>`. On startup, scan running `agent-ci-*` containers and check if their parent PID is still alive (`process.kill(pid, 0)`). Dead PID means orphan — kill it along with its sidecars and network.
- **Signal handler fix**: Move `hostRunnerDir` declaration above the signal handler and add it to the cleanup loop so Ctrl+C doesn't leak runner directories.
- **Wire up `pruneStaleWorkspaces()`**: Call it on startup to remove run directories older than 24 hours.

Closes #186

## Test plan

- [x] `pnpm --filter agent-ci test` passes (458 tests)
- [x] `pnpm --filter dtu-github-actions test` passes (52 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)