### PR TITLE
fix: support actions/checkout@v6

### DIFF
--- a/.changeset/fix-checkout-v6.md
+++ b/.changeset/fix-checkout-v6.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Fix actions/checkout@v6 compatibility by using the real HEAD SHA instead of a fake placeholder.

--- a/packages/cli/src/runner/git-shim.test.ts
+++ b/packages/cli/src/runner/git-shim.test.ts
@@ -3,25 +3,6 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
-// ── computeFakeSha ────────────────────────────────────────────────────────────
-
-describe("computeFakeSha", () => {
-  it("returns the headSha when it is a real SHA", async () => {
-    const { computeFakeSha } = await import("./git-shim.js");
-    expect(computeFakeSha("abc123def456")).toBe("abc123def456");
-  });
-
-  it("returns the deterministic fake when headSha is HEAD", async () => {
-    const { computeFakeSha } = await import("./git-shim.js");
-    expect(computeFakeSha("HEAD")).toBe("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-  });
-
-  it("returns the deterministic fake when headSha is undefined", async () => {
-    const { computeFakeSha } = await import("./git-shim.js");
-    expect(computeFakeSha(undefined)).toBe("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-  });
-});
-
 // ── writeGitShim ──────────────────────────────────────────────────────────────
 
 describe("writeGitShim", () => {

--- a/packages/cli/src/runner/git-shim.ts
+++ b/packages/cli/src/runner/git-shim.ts
@@ -1,16 +1,6 @@
 import path from "path";
 import fs from "fs";
 
-// ─── Fake SHA computation ─────────────────────────────────────────────────────
-
-/**
- * Resolve which SHA the git shim should return for ls-remote / rev-parse.
- * Uses the real SHA if provided, otherwise falls back to a deterministic fake.
- */
-export function computeFakeSha(headSha?: string): string {
-  return headSha && headSha !== "HEAD" ? headSha : "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-}
-
 // ─── Git shim script ──────────────────────────────────────────────────────────
 
 /**

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -20,7 +20,7 @@ import { type JobResult, tailLogFile } from "../output/reporter.js";
 import { RunStateStore, type StepState } from "../output/run-state.js";
 
 import { writeJobMetadata } from "./metadata.js";
-import { computeFakeSha, writeGitShim } from "./git-shim.js";
+import { writeGitShim } from "./git-shim.js";
 import { prepareWorkspace } from "./workspace.js";
 import { createRunDirectories } from "./directory-setup.js";
 import {
@@ -297,8 +297,7 @@ export async function executeLocalJob(
     // 4. Write git shim BEFORE container start so the entrypoint can install it
     // immediately. On Linux, prepareWorkspace (rsync) is slow enough that the
     // container entrypoint would race ahead and find an empty shims dir.
-    const fakeSha = computeFakeSha(job.headSha);
-    writeGitShim(dirs.shimsDir, fakeSha);
+    writeGitShim(dirs.shimsDir, job.realHeadSha);
 
     // Prepare workspace files in parallel with container setup
     const workspacePrepStart = Date.now();

--- a/packages/dtu-github-actions/src/server/routes/actions/generators.ts
+++ b/packages/dtu-github-actions/src/server/routes/actions/generators.ts
@@ -182,13 +182,7 @@ export function createJobResponse(
   const repoName = payload.repository?.name || repoFullName.split("/")[1] || "";
   const workspacePath = `/home/runner/_work/${repoName}/${repoName}`;
 
-  const headSha =
-    payload.headSha && payload.headSha !== "HEAD"
-      ? payload.headSha
-      : "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-  // realHeadSha is the actual HEAD commit SHA, even when headSha is unset
-  // (dirty workspace mode). Used for push event context (before/after).
-  const realHeadSha = payload.realHeadSha || headSha;
+  const realHeadSha = payload.realHeadSha;
 
   const Variables: { [key: string]: JobVariable } = {
     // Standard GitHub Actions environment variables — always set by real runners.


### PR DESCRIPTION
## Problem

`actions/checkout@v6` added post-fetch SHA validation that verifies the checked-out ref matches `github.sha`. In dirty workspace mode (no `--sha` flag), the git shim returned a fake placeholder SHA (`aaaa...`) while `github.sha` used the real HEAD commit, causing every checkout step to fail with: "The ref does not point to the expected commit."

## Solution

Use `realHeadSha` (always computed from `git rev-parse HEAD`) consistently in both the git shim and event payload. Remove the now-dead `computeFakeSha` helper and its fake SHA fallback.

## Test plan

- [x] Reproduced failure with `actions/checkout@v6` test workflow
- [x] Verified fix passes with both `actions/checkout@v4` and `@v6`
- [x] Unit tests pass (`git-shim`, `local-job`, `generators`)
- [x] E2E workflow (`tests.yml`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)