### PR TITLE
fix: mount warm node_modules directly at workspace path

### DIFF
--- a/.changeset/warm-modules-bind-mount.md
+++ b/.changeset/warm-modules-bind-mount.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Mount warm node_modules directly at workspace path instead of symlinking via /tmp

--- a/.github/fixtures/pnpm-esbuild-resolve/apps/web/package.json
+++ b/.github/fixtures/pnpm-esbuild-resolve/apps/web/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "web",
+  "private": true,
+  "dependencies": {
+    "ms": "^2.1.3"
+  }
+}

--- a/.github/fixtures/pnpm-esbuild-resolve/apps/web/src/index.mjs
+++ b/.github/fixtures/pnpm-esbuild-resolve/apps/web/src/index.mjs
@@ -1,0 +1,7 @@
+import ms from "ms";
+
+// Exercises esbuild resolution through pnpm workspace symlinks.
+// In a pnpm monorepo, apps/web/node_modules/ms is a symlink to
+// ../../node_modules/.pnpm/ms@2.x/node_modules/ms — esbuild must
+// follow this chain correctly to bundle the file.
+console.log(ms("1d"));

--- a/.github/fixtures/pnpm-esbuild-resolve/package.json
+++ b/.github/fixtures/pnpm-esbuild-resolve/package.json
@@ -1,0 +1,3 @@
+{
+  "private": true
+}

--- a/.github/fixtures/pnpm-esbuild-resolve/pnpm-lock.yaml
+++ b/.github/fixtures/pnpm-esbuild-resolve/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  apps/web:
+    dependencies:
+      ms:
+        specifier: ^2.1.3
+        version: 2.1.3
+
+packages:
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+snapshots:
+
+  ms@2.1.3: {}

--- a/.github/fixtures/pnpm-esbuild-resolve/pnpm-workspace.yaml
+++ b/.github/fixtures/pnpm-esbuild-resolve/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "apps/*"

--- a/.github/workflows/smoke-pnpm-esbuild-resolve.yml
+++ b/.github/workflows/smoke-pnpm-esbuild-resolve.yml
@@ -1,0 +1,39 @@
+name: "Smoke: pnpm monorepo esbuild resolution"
+
+# Reproduces a bug where esbuild fails to resolve imports through
+# pnpm workspace symlinks when warm node_modules is mounted via
+# a symlink to /tmp/node_modules instead of a direct bind mount.
+#
+# The bug manifests as esbuild "Cannot read file" errors because
+# the symlink chain (workspace/node_modules → /tmp/node_modules)
+# causes path resolution to produce incorrect intermediate paths.
+#
+# Fixture: .github/fixtures/pnpm-esbuild-resolve/
+#   A minimal pnpm monorepo with apps/web importing a root-hoisted
+#   dependency (ms). esbuild must follow the pnpm symlink chain
+#   from apps/web/node_modules/ms → ../../node_modules/.pnpm/ms@2.x/...
+
+on:
+  pull_request_target:
+    types: [opened, labeled, synchronize]
+
+jobs:
+  esbuild-resolve:
+    if: '!github.event.pull_request.draft && (contains(fromJSON(''["MEMBER", "OWNER", "COLLABORATOR"]''), github.event.pull_request.author_association) || contains(github.event.pull_request.labels.*.name, ''safe-to-run''))'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm and dependencies
+        working-directory: .github/fixtures/pnpm-esbuild-resolve
+        run: |
+          npm install -g pnpm
+          pnpm install
+
+      # ── Verify esbuild resolves through pnpm workspace symlinks ──
+      - name: esbuild bundle through workspace symlinks
+        working-directory: .github/fixtures/pnpm-esbuild-resolve
+        run: |
+          npx esbuild apps/web/src/index.mjs --bundle --platform=node --outfile=/tmp/out.js
+          node /tmp/out.js
+          echo "✅ esbuild bundle + execution succeeded"

--- a/packages/cli/src/docker/container-config.test.ts
+++ b/packages/cli/src/docker/container-config.test.ts
@@ -64,12 +64,13 @@ describe("buildContainerBinds", () => {
       warmModulesDir: "/tmp/warm",
       hostRunnerDir: "/tmp/runner",
       useDirectContainer: false,
+      githubRepo: "org/repo",
     });
 
     expect(binds).toContain("/tmp/work:/home/runner/_work");
     expect(binds).toContain("/var/run/docker.sock:/var/run/docker.sock"); // default when dockerSocketPath is not set
     expect(binds).toContain("/tmp/shims:/tmp/agent-ci-shims");
-    expect(binds).toContain("/tmp/warm:/tmp/node_modules");
+    expect(binds).toContain("/tmp/warm:/home/runner/_work/repo/repo/node_modules");
     expect(binds).toContain("/tmp/pnpm:/home/runner/_work/.pnpm-store");
     expect(binds).toContain("/tmp/npm:/home/runner/.npm");
     expect(binds).toContain("/tmp/bun:/home/runner/.bun/install/cache");
@@ -88,6 +89,7 @@ describe("buildContainerBinds", () => {
       warmModulesDir: "/tmp/warm",
       hostRunnerDir: "/tmp/runner",
       useDirectContainer: false,
+      githubRepo: "org/repo",
     });
 
     expect(binds).toContain("/tmp/work:/home/runner/_work");
@@ -108,6 +110,7 @@ describe("buildContainerBinds", () => {
       warmModulesDir: "/tmp/warm",
       hostRunnerDir: "/tmp/runner",
       useDirectContainer: false,
+      githubRepo: "org/repo",
     });
 
     expect(binds).toContain("/tmp/npm:/home/runner/.npm");
@@ -126,6 +129,7 @@ describe("buildContainerBinds", () => {
       warmModulesDir: "/tmp/warm",
       hostRunnerDir: "/tmp/runner",
       useDirectContainer: false,
+      githubRepo: "org/repo",
       dockerSocketPath: "/Users/test/.orbstack/run/docker.sock",
     });
 
@@ -147,6 +151,7 @@ describe("buildContainerBinds", () => {
       warmModulesDir: "/tmp/warm",
       hostRunnerDir: "/tmp/runner",
       useDirectContainer: true,
+      githubRepo: "org/repo",
     });
 
     expect(binds).toContain("/tmp/runner:/home/runner");
@@ -383,6 +388,7 @@ describe("buildContainerBinds with dockerSocketPath", () => {
     warmModulesDir: "/tmp/warm",
     hostRunnerDir: "/tmp/runner",
     useDirectContainer: false,
+    githubRepo: "org/repo",
   };
 
   it("uses default /var/run/docker.sock when no dockerSocketPath is provided", async () => {
@@ -417,6 +423,7 @@ describe("buildContainerBinds with signalsDir", () => {
     warmModulesDir: "/tmp/warm",
     hostRunnerDir: "/tmp/runner",
     useDirectContainer: false,
+    githubRepo: "org/repo",
   };
 
   it("includes signals bind-mount when signalsDir is provided", async () => {

--- a/packages/cli/src/docker/container-config.ts
+++ b/packages/cli/src/docker/container-config.ts
@@ -22,6 +22,8 @@ export interface ContainerBindsOpts {
   warmModulesDir: string;
   hostRunnerDir: string;
   useDirectContainer: boolean;
+  /** GitHub repository slug (e.g. "org/repo"), used to compute workspace node_modules mount. */
+  githubRepo: string;
   /** Host-side Docker socket path (resolved by resolveDockerSocket). */
   dockerSocketPath?: string;
 }
@@ -95,9 +97,11 @@ export function buildContainerBinds(opts: ContainerBindsOpts): string[] {
     warmModulesDir,
     hostRunnerDir,
     useDirectContainer,
+    githubRepo,
     dockerSocketPath = "/var/run/docker.sock",
   } = opts;
 
+  const repoName = githubRepo.split("/").pop() || "repo";
   const h = toHostPath;
   return [
     // When using a custom container, bind-mount the extracted runner
@@ -114,12 +118,11 @@ export function buildContainerBinds(opts: ContainerBindsOpts): string[] {
     ...(npmCacheDir ? [`${h(npmCacheDir)}:/home/runner/.npm`] : []),
     ...(bunCacheDir ? [`${h(bunCacheDir)}:/home/runner/.bun/install/cache`] : []),
     `${h(playwrightCacheDir)}:/home/runner/.cache/ms-playwright`,
-    // Warm node_modules: mounted outside the workspace so actions/checkout can
-    // delete the symlink without EBUSY. A symlink in the entrypoint points
-    // workspace/node_modules → /tmp/node_modules.
-    // Mounted at /tmp/node_modules (not /tmp/warm-modules) so that TypeScript's
-    // upward @types walk from .pnpm realpath finds /tmp/node_modules/@types.
-    `${h(warmModulesDir)}:/tmp/node_modules`,
+    // Warm node_modules: mounted directly at the workspace node_modules path
+    // so pnpm/esbuild path resolution sees a real directory (not a symlink).
+    // The git shim blocks `git clean` and checkout is patched with clean:false,
+    // so EBUSY on this bind mount is not a concern.
+    `${h(warmModulesDir)}:/home/runner/_work/${repoName}/${repoName}/node_modules`,
   ];
 }
 
@@ -160,7 +163,6 @@ export function buildContainerCmd(opts: ContainerCmdOpts): string[] {
     `REPO_NAME=$(basename $GITHUB_REPOSITORY)`,
     `WORKSPACE_PATH=/home/runner/_work/$REPO_NAME/$REPO_NAME`,
     `mkdir -p $WORKSPACE_PATH`,
-    `ln -sfn /tmp/node_modules $WORKSPACE_PATH/node_modules`,
     T("workspace-setup"),
     `echo "[agent-ci:boot] total: $(($(date +%s%3N)-BOOT_T0))ms"`,
     `echo "[agent-ci:boot] starting run.sh --once"`,

--- a/packages/cli/src/runner/directory-setup.test.ts
+++ b/packages/cli/src/runner/directory-setup.test.ts
@@ -191,6 +191,7 @@ describe("buildContainerBinds — PM-scoped mounts", () => {
       warmModulesDir: "/tmp/warm",
       hostRunnerDir: "/tmp/runner",
       useDirectContainer: false,
+      githubRepo: "org/repo",
     });
 
     expect(binds).toContain("/tmp/npm-cache:/home/runner/.npm");
@@ -212,6 +213,7 @@ describe("buildContainerBinds — PM-scoped mounts", () => {
       warmModulesDir: "/tmp/warm",
       hostRunnerDir: "/tmp/runner",
       useDirectContainer: false,
+      githubRepo: "org/repo",
     });
 
     expect(binds).toContain("/tmp/pnpm-store:/home/runner/_work/.pnpm-store");
@@ -233,6 +235,7 @@ describe("buildContainerBinds — PM-scoped mounts", () => {
       warmModulesDir: "/tmp/warm",
       hostRunnerDir: "/tmp/runner",
       useDirectContainer: false,
+      githubRepo: "org/repo",
     });
 
     expect(binds).toContain("/tmp/bun-cache:/home/runner/.bun/install/cache");
@@ -253,6 +256,7 @@ describe("buildContainerBinds — PM-scoped mounts", () => {
       warmModulesDir: "/tmp/warm",
       hostRunnerDir: "/tmp/runner",
       useDirectContainer: false,
+      githubRepo: "org/repo",
     });
 
     expect(binds.some((b) => b.includes(".pnpm-store"))).toBe(false);

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -527,6 +527,7 @@ export async function executeLocalJob(
       warmModulesDir: dirs.warmModulesDir,
       hostRunnerDir,
       useDirectContainer,
+      githubRepo,
       dockerSocketPath: getDockerSocket().socketPath || undefined,
     });
 


### PR DESCRIPTION
## Problem

pnpm monorepos (e.g. przm) fail to build in agent-ci but succeed in production GitHub Actions. esbuild's directive scanner produces 1952 "Cannot read file" errors, resolving paths like `apps/web/tmp/node_modules/.pnpm/jose@6.2.1/...` instead of `/tmp/node_modules/.pnpm/jose@6.2.1/...`. The warm modules symlink (`workspace/node_modules → /tmp/node_modules`) causes esbuild to treat `tmp/node_modules` as a relative path within the project.

## Solution

Mount the warm cache as a Docker bind mount directly at `$WORKSPACE_PATH/node_modules` instead of at `/tmp/node_modules` with a symlink. This makes the filesystem layout identical to production GitHub Actions. The original EBUSY concern that motivated the symlink approach is already mitigated by the git shim (blocks `git clean`) and checkout patching (`clean: false`).

Adds a smoke test exercising esbuild resolution through pnpm workspace symlinks.

## Test plan

- [x] Unit tests pass (`pnpm exec vitest run`)
- [x] Khan/pnpm-symlinks smoke test passes (TypeScript @types resolution)
- [x] New pnpm-esbuild-resolve smoke test passes (esbuild through workspace symlinks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)