### PR TITLE
fix: skip inaccessible docker sockets during resolution

### DIFF
--- a/.changeset/fix-ubuntu-docker-sock.md
+++ b/.changeset/fix-ubuntu-docker-sock.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Fix Docker socket detection on Linux when /var/run/docker.sock exists but is not accessible (EACCES).

--- a/packages/cli/src/docker/docker-socket.test.ts
+++ b/packages/cli/src/docker/docker-socket.test.ts
@@ -26,6 +26,7 @@ describe("resolveDockerSocket", () => {
   it("uses DOCKER_HOST when set to a unix socket that exists", async () => {
     process.env.DOCKER_HOST = "unix:///tmp/test-docker.sock";
     vi.spyOn(fs, "realpathSync").mockReturnValue("/tmp/test-docker.sock");
+    vi.spyOn(fs, "accessSync").mockReturnValue(undefined);
 
     const { resolveDockerSocket } = await importFresh();
     const result = resolveDockerSocket();
@@ -54,12 +55,43 @@ describe("resolveDockerSocket", () => {
       }
       throw new Error("ENOENT");
     });
+    vi.spyOn(fs, "accessSync").mockReturnValue(undefined);
 
     const { resolveDockerSocket } = await importFresh();
     const result = resolveDockerSocket();
 
     expect(result.socketPath).toBe("/Users/test/.orbstack/run/docker.sock");
     expect(result.uri).toBe("unix:///Users/test/.orbstack/run/docker.sock");
+  });
+
+  // ── EACCES fallthrough ─────────────────────────────────────────────────
+
+  it("falls through to docker context when default socket is not accessible", async () => {
+    delete process.env.DOCKER_HOST;
+    // Socket exists but is not accessible (e.g. root:docker 660 on Linux)
+    vi.spyOn(fs, "realpathSync").mockReturnValue("/var/run/docker.sock");
+    vi.spyOn(fs, "accessSync").mockImplementation(() => {
+      throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+    });
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+      return String(p) === "/home/user/.docker/desktop/docker.sock";
+    });
+    mockedExecSync.mockReturnValue(
+      JSON.stringify([
+        {
+          Endpoints: {
+            docker: {
+              Host: "unix:///home/user/.docker/desktop/docker.sock",
+            },
+          },
+        },
+      ]),
+    );
+
+    const { resolveDockerSocket } = await importFresh();
+    const result = resolveDockerSocket();
+
+    expect(result.socketPath).toBe("/home/user/.docker/desktop/docker.sock");
   });
 
   // ── Docker context fallback ─────────────────────────────────────────────

--- a/packages/cli/src/docker/docker-socket.ts
+++ b/packages/cli/src/docker/docker-socket.ts
@@ -119,13 +119,17 @@ export function resolveDockerSocket(): DockerSocket {
 }
 
 /**
- * If `socketPath` exists (following symlinks), return the real path.
- * Returns undefined otherwise.
+ * If `socketPath` exists (following symlinks) and is accessible, return the
+ * real path.  Returns undefined otherwise so the caller can keep searching.
  */
 function resolveIfExists(socketPath: string): string | undefined {
   try {
     // fs.realpathSync follows symlinks and throws if the target doesn't exist
-    return fs.realpathSync(socketPath);
+    const resolved = fs.realpathSync(socketPath);
+    // Verify we can actually connect — the socket may exist but be owned by
+    // root:docker with 660 perms (common on Linux with Docker Desktop).
+    fs.accessSync(resolved, fs.constants.R_OK | fs.constants.W_OK);
+    return resolved;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Problem

On Ubuntu with Docker Desktop, `/var/run/docker.sock` exists but is owned by `root:docker` with `660` permissions. If the user isn't in the `docker` group, they get `EACCES`. Our socket resolution finds the file, sees it exists, and stops — never reaching `docker context inspect` which knows Docker Desktop's actual accessible socket.

## Solution

Check that the socket is accessible (`fs.accessSync` with `R_OK | W_OK`), not just that it exists. If we can't read/write it, keep searching — `docker context inspect` already knows the right path.

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)