### PR TITLE
feat: resolve workflow secrets from environment variables

### DIFF
--- a/.changeset/env-var-secrets.md
+++ b/.changeset/env-var-secrets.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": minor
+"dtu-github-actions": minor
+---
+
+Resolve workflow secrets from shell environment variables (fallback to .env.agent-ci file). Also auto-populate `secrets.GITHUB_TOKEN` from `--github-token`.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,28 @@ For default behavior, env overrides, and remote-daemon caveats, see the CLI pack
 
 ---
 
+## Secrets
+
+Workflow secrets (`${{ secrets.FOO }}`) are resolved in order:
+
+1. **`.env.agent-ci`** file in the repo root (`KEY=VALUE` syntax, `#` comments supported)
+2. **Shell environment variables** — any env var matching a required secret name acts as a fallback
+3. **`--github-token`** — automatically provides `secrets.GITHUB_TOKEN`
+
+```bash
+# All three approaches work:
+# 1. .env.agent-ci file
+echo "CLOUDFLARE_API_TOKEN=xxx" >> .env.agent-ci
+
+# 2. Inline env vars
+CLOUDFLARE_API_TOKEN=xxx agent-ci run -w .github/workflows/deploy.yml
+
+# 3. --github-token for GITHUB_TOKEN specifically
+agent-ci run -w .github/workflows/ci.yml --github-token
+```
+
+---
+
 ## Environment variables
 
 All configuration is available via environment variables. For persistent machine-local overrides, create a `.env.agent-ci` file in your project root — Agent CI loads it automatically (`KEY=VALUE` syntax, `#` comments supported).

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -17,6 +17,7 @@ import {
   parseWorkflowServices,
   parseWorkflowContainer,
   validateSecrets,
+  extractSecretRefs,
   parseMatrixDef,
   expandMatrixCombinations,
   collapseMatrixToSingle,
@@ -628,7 +629,11 @@ async function handleWorkflow(options: {
   if (expandedJobs.length === 1) {
     const ej = expandedJobs[0];
     const actualTaskName = ej.sourceTaskName ?? ej.taskName;
-    const secrets = loadMachineSecrets(repoRoot);
+    const requiredRefs = extractSecretRefs(ej.workflowPath, actualTaskName);
+    const secrets = loadMachineSecrets(repoRoot, requiredRefs);
+    if (githubToken && !secrets["GITHUB_TOKEN"]) {
+      secrets["GITHUB_TOKEN"] = githubToken;
+    }
     const secretsFilePath = path.join(repoRoot, ".env.agent-ci");
     validateSecrets(ej.workflowPath, actualTaskName, secrets, secretsFilePath);
 
@@ -710,7 +715,11 @@ async function handleWorkflow(options: {
 
   const buildJob = (ej: ExpandedJob): Job => {
     const actualTaskName = ej.sourceTaskName ?? ej.taskName;
-    const secrets = loadMachineSecrets(repoRoot);
+    const requiredRefs = extractSecretRefs(ej.workflowPath, actualTaskName);
+    const secrets = loadMachineSecrets(repoRoot, requiredRefs);
+    if (githubToken && !secrets["GITHUB_TOKEN"]) {
+      secrets["GITHUB_TOKEN"] = githubToken;
+    }
     const secretsFilePath = path.join(repoRoot, ".env.agent-ci");
     validateSecrets(ej.workflowPath, actualTaskName, secrets, secretsFilePath);
 
@@ -785,7 +794,11 @@ async function handleWorkflow(options: {
     debugCli(
       `Running: ${path.basename(ej.workflowPath)} | Task: ${taskName}${matrixContext ? ` | Matrix: ${JSON.stringify(Object.fromEntries(Object.entries(matrixContext).filter(([k]) => !k.startsWith("__"))))}` : ""}`,
     );
-    const secrets = loadMachineSecrets(repoRoot);
+    const requiredRefs = extractSecretRefs(ej.workflowPath, actualTaskName);
+    const secrets = loadMachineSecrets(repoRoot, requiredRefs);
+    if (githubToken && !secrets["GITHUB_TOKEN"]) {
+      secrets["GITHUB_TOKEN"] = githubToken;
+    }
     const secretsFilePath = path.join(repoRoot, ".env.agent-ci");
     validateSecrets(ej.workflowPath, actualTaskName, secrets, secretsFilePath);
     const inputsContext = resolveInputsForJob(ej, secrets, needsContext);
@@ -1101,6 +1114,12 @@ function printUsage() {
   console.log(
     "      --commit-status           Post a GitHub commit status after the run (requires --github-token)",
   );
+  console.log("");
+  console.log("Secrets:");
+  console.log("  Workflow secrets (${{ secrets.FOO }}) are resolved from:");
+  console.log("    1. .env.agent-ci file in the repo root");
+  console.log("    2. Environment variables (shell env acts as fallback)");
+  console.log("    3. --github-token automatically provides secrets.GITHUB_TOKEN");
 }
 
 function resolveRepoRoot() {

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -3,7 +3,13 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { config, getFirstRemoteUrl, parseRepoSlug, resolveRepoSlug } from "./config.js";
+import {
+  config,
+  getFirstRemoteUrl,
+  loadMachineSecrets,
+  parseRepoSlug,
+  resolveRepoSlug,
+} from "./config.js";
 
 describe("parseRepoSlug", () => {
   it.each([
@@ -179,5 +185,98 @@ describe("GITHUB_REPO env var override priority", () => {
     expect(() => {
       return config.GITHUB_REPO ?? resolveRepoSlug(tmpDir);
     }).toThrow(/Could not detect GitHub repository/);
+  });
+});
+
+// ─── loadMachineSecrets ──────────────────────────────────────────────────────
+
+describe("loadMachineSecrets", () => {
+  let tmpDir: string;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  function saveEnv(...keys: string[]) {
+    for (const k of keys) {
+      savedEnv[k] = process.env[k];
+    }
+  }
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = v;
+      }
+    }
+  });
+
+  function writeEnvFile(content: string): string {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "secrets-test-"));
+    fs.writeFileSync(path.join(tmpDir, ".env.agent-ci"), content);
+    return tmpDir;
+  }
+
+  function makeTmpDir(): string {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "secrets-test-"));
+    return tmpDir;
+  }
+
+  it("returns empty object when .env.agent-ci does not exist", () => {
+    const dir = makeTmpDir();
+    expect(loadMachineSecrets(dir)).toEqual({});
+  });
+
+  it("parses KEY=VALUE pairs from file", () => {
+    const dir = writeEnvFile("FOO=bar\nBAZ=qux\n");
+    expect(loadMachineSecrets(dir)).toEqual({ FOO: "bar", BAZ: "qux" });
+  });
+
+  it("fills missing secrets from process.env when envFallbackKeys provided", () => {
+    const dir = makeTmpDir();
+    saveEnv("TEST_SECRET_ABC");
+    process.env.TEST_SECRET_ABC = "from-env";
+
+    const secrets = loadMachineSecrets(dir, ["TEST_SECRET_ABC"]);
+    expect(secrets.TEST_SECRET_ABC).toBe("from-env");
+  });
+
+  it("file values take precedence over process.env", () => {
+    const dir = writeEnvFile("MY_TOKEN=from-file\n");
+    saveEnv("MY_TOKEN");
+    process.env.MY_TOKEN = "from-env";
+
+    const secrets = loadMachineSecrets(dir, ["MY_TOKEN"]);
+    expect(secrets.MY_TOKEN).toBe("from-file");
+  });
+
+  it("does not pull from process.env for keys not in envFallbackKeys", () => {
+    const dir = makeTmpDir();
+    saveEnv("UNRELATED_VAR");
+    process.env.UNRELATED_VAR = "should-not-appear";
+
+    const secrets = loadMachineSecrets(dir, ["OTHER_KEY"]);
+    expect(secrets.UNRELATED_VAR).toBeUndefined();
+    expect(secrets.OTHER_KEY).toBeUndefined();
+  });
+
+  it("does not pull from process.env when envFallbackKeys is omitted", () => {
+    const dir = makeTmpDir();
+    saveEnv("SOME_SECRET");
+    process.env.SOME_SECRET = "env-value";
+
+    const secrets = loadMachineSecrets(dir);
+    expect(secrets.SOME_SECRET).toBeUndefined();
+  });
+
+  it("merges file secrets and env fallbacks", () => {
+    const dir = writeEnvFile("FROM_FILE=file-val\n");
+    saveEnv("FROM_ENV");
+    process.env.FROM_ENV = "env-val";
+
+    const secrets = loadMachineSecrets(dir, ["FROM_FILE", "FROM_ENV"]);
+    expect(secrets).toEqual({ FROM_FILE: "file-val", FROM_ENV: "env-val" });
   });
 });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -64,37 +64,52 @@ export const config: {
 };
 
 /**
- * Load machine-local secrets from `.env.machine` at the agent-ci project root.
+ * Load machine-local secrets from `.env.agent-ci` at the given base directory.
  * The file uses KEY=VALUE syntax (lines starting with # are ignored).
- * Returns an empty object if the file doesn't exist.
+ *
+ * When `envFallbackKeys` is provided, any key in that list that is NOT already
+ * present in the file will be filled from `process.env` (shell environment
+ * variables act as a fallback for the .env file).
+ *
+ * Returns an empty object if the file doesn't exist and no env fallbacks match.
  */
-export function loadMachineSecrets(baseDir?: string): Record<string, string> {
+export function loadMachineSecrets(
+  baseDir?: string,
+  envFallbackKeys?: string[],
+): Record<string, string> {
   const envMachinePath = path.join(baseDir ?? PROJECT_ROOT, ".env.agent-ci");
-  if (!fs.existsSync(envMachinePath)) {
-    return {};
-  }
   const secrets: Record<string, string> = {};
-  const lines = fs.readFileSync(envMachinePath, "utf-8").split("\n");
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) {
-      continue;
+  if (fs.existsSync(envMachinePath)) {
+    const lines = fs.readFileSync(envMachinePath, "utf-8").split("\n");
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) {
+        continue;
+      }
+      const eqIdx = trimmed.indexOf("=");
+      if (eqIdx < 1) {
+        continue;
+      }
+      const key = trimmed.slice(0, eqIdx).trim();
+      let value = trimmed.slice(eqIdx + 1).trim();
+      // Strip optional surrounding quotes
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (key) {
+        secrets[key] = value;
+      }
     }
-    const eqIdx = trimmed.indexOf("=");
-    if (eqIdx < 1) {
-      continue;
-    }
-    const key = trimmed.slice(0, eqIdx).trim();
-    let value = trimmed.slice(eqIdx + 1).trim();
-    // Strip optional surrounding quotes
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
-    if (key) {
-      secrets[key] = value;
+  }
+  // Fill missing secrets from process.env (shell env vars act as fallback)
+  if (envFallbackKeys) {
+    for (const key of envFallbackKeys) {
+      if (!secrets[key] && process.env[key]) {
+        secrets[key] = process.env[key]!;
+      }
     }
   }
   return secrets;

--- a/packages/cli/src/workflow/workflow-parser.ts
+++ b/packages/cli/src/workflow/workflow-parser.ts
@@ -828,7 +828,7 @@ export function validateSecrets(
   }
   throw new Error(
     `[Agent CI] Missing secrets required by workflow job "${taskName}".\n` +
-      `Add the following to ${secretsFilePath}:\n\n` +
+      `Add the following to ${secretsFilePath} or set them as environment variables:\n\n` +
       missing.map((n) => `${n}=`).join("\n") +
       "\n",
   );


### PR DESCRIPTION
## Summary

- Workflow secrets (`${{ secrets.FOO }}`) now resolve from shell environment variables as a fallback when not found in `.env.agent-ci`. This lets you pass secrets inline: `CLOUDFLARE_API_TOKEN=xxx agent-ci run ...`
- `--github-token` automatically populates `secrets.GITHUB_TOKEN` so workflows referencing it no longer require a separate entry in the env file.
- Updated error message and help text to document the new resolution order.

## Test plan
- [x] All 508 existing tests pass (456 cli + 52 dtu)
- [ ] Manual: run a workflow with secrets passed as env vars instead of `.env.agent-ci`
- [ ] Manual: verify `--github-token` satisfies `${{ secrets.GITHUB_TOKEN }}` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)