### PR TITLE
fix: deduplicate identical failure errors in output summary

### DIFF
--- a/.changeset/quiet-errors-group.md
+++ b/.changeset/quiet-errors-group.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Deduplicate identical failure errors in output summary and streaming messages.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -982,6 +982,8 @@ async function handleWorkflow(options: {
     return result;
   };
 
+  const seenErrorMessages = new Set<string>();
+
   for (let wi = 0; wi < filteredWaves.length; wi++) {
     const waveJobIds = new Set(filteredWaves[wi]);
     const waveJobs = expandedJobs.filter((j) => waveJobIds.has(j.taskName));
@@ -1011,8 +1013,11 @@ async function handleWorkflow(options: {
         } else {
           const taskName = isJobError(r.reason) ? r.reason.taskName : "unknown";
           const errorMessage = isJobError(r.reason) ? r.reason.message : String(r.reason);
-          console.error(`\n[Agent CI] Job failed with error: ${taskName}`);
-          console.error(`  Error: ${errorMessage}`);
+          if (!seenErrorMessages.has(errorMessage)) {
+            seenErrorMessages.add(errorMessage);
+            console.error(`\n[Agent CI] Job failed with error: ${taskName}`);
+            console.error(`  Error: ${errorMessage}`);
+          }
           allResults.push(createFailedJobResult(taskName, workflowPath, r.reason));
         }
       }
@@ -1033,8 +1038,11 @@ async function handleWorkflow(options: {
         } else {
           const taskName = isJobError(r.reason) ? r.reason.taskName : "unknown";
           const errorMessage = isJobError(r.reason) ? r.reason.message : String(r.reason);
-          console.error(`\n[Agent CI] Job failed with error: ${taskName}`);
-          console.error(`  Error: ${errorMessage}`);
+          if (!seenErrorMessages.has(errorMessage)) {
+            seenErrorMessages.add(errorMessage);
+            console.error(`\n[Agent CI] Job failed with error: ${taskName}`);
+            console.error(`  Error: ${errorMessage}`);
+          }
           allResults.push(createFailedJobResult(taskName, workflowPath, r.reason));
         }
       }

--- a/packages/cli/src/output/reporter.test.ts
+++ b/packages/cli/src/output/reporter.test.ts
@@ -78,6 +78,56 @@ describe("printSummary", () => {
     expect(output).toContain('✗ retry-proof.yml > test > "Run assertion test"');
   });
 
+  it("deduplicates failures with identical error content", () => {
+    printSummary([
+      makeResult({
+        taskId: "test (1)",
+        failedStep: "[Job startup failed]",
+        lastOutputLines: ["Missing secrets"],
+      }),
+      makeResult({
+        taskId: "test (2)",
+        failedStep: "[Job startup failed]",
+        lastOutputLines: ["Missing secrets"],
+      }),
+      makeResult({
+        taskId: "test (3)",
+        failedStep: "[Job startup failed]",
+        lastOutputLines: ["Missing secrets"],
+      }),
+    ]);
+
+    // Error content should appear only once
+    const matches = output.match(/Missing secrets/g);
+    expect(matches).toHaveLength(1);
+
+    // All job headers should still appear
+    expect(output).toContain('test (1) > "[Job startup failed]"');
+    expect(output).toContain('test (2) > "[Job startup failed]"');
+    expect(output).toContain('test (3) > "[Job startup failed]"');
+
+    // Summary should show correct count
+    expect(output).toContain("3 failed");
+  });
+
+  it("keeps distinct errors separate", () => {
+    printSummary([
+      makeResult({
+        taskId: "build",
+        failedStep: "Compile",
+        lastOutputLines: ["syntax error"],
+      }),
+      makeResult({
+        taskId: "lint",
+        failedStep: "ESLint",
+        lastOutputLines: ["unused variable"],
+      }),
+    ]);
+
+    expect(output).toContain("syntax error");
+    expect(output).toContain("unused variable");
+  });
+
   it("shows pass count in summary for a successful run", () => {
     printSummary([makeResult({ succeeded: true })]);
 

--- a/packages/cli/src/output/reporter.ts
+++ b/packages/cli/src/output/reporter.ts
@@ -40,6 +40,23 @@ function formatDuration(ms: number): string {
 
 // ─── Failures-first summary (emitted after all jobs complete) ─────────────────
 
+function getErrorContent(f: JobResult): string {
+  if (f.failedStepLogPath && fs.existsSync(f.failedStepLogPath)) {
+    return fs.readFileSync(f.failedStepLogPath, "utf-8");
+  }
+  if (f.lastOutputLines && f.lastOutputLines.length > 0) {
+    return f.lastOutputLines.join("\n") + "\n";
+  }
+  return "";
+}
+
+function formatFailureHeader(f: JobResult): string {
+  if (f.failedStep) {
+    return `  ✗ ${f.workflow} > ${f.taskId} > "${f.failedStep}"`;
+  }
+  return `  ✗ ${f.workflow} > ${f.taskId}`;
+}
+
 export function printSummary(results: JobResult[], runDir?: string): void {
   const failures = results.filter((r) => !r.succeeded);
   const passes = results.filter((r) => r.succeeded);
@@ -47,17 +64,29 @@ export function printSummary(results: JobResult[], runDir?: string): void {
 
   if (failures.length > 0) {
     process.stdout.write("\n━━━ FAILURES ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n");
+
+    // Group failures by error content to avoid repeating identical errors
+    const groups: { failures: JobResult[]; errorContent: string }[] = [];
+    const seen = new Map<string, (typeof groups)[number]>();
+
     for (const f of failures) {
-      if (f.failedStep) {
-        process.stdout.write(`  ✗ ${f.workflow} > ${f.taskId} > "${f.failedStep}"\n`);
+      const content = getErrorContent(f);
+      const existing = seen.get(content);
+      if (existing) {
+        existing.failures.push(f);
       } else {
-        process.stdout.write(`  ✗ ${f.workflow} > ${f.taskId}\n`);
+        const group = { failures: [f], errorContent: content };
+        groups.push(group);
+        seen.set(content, group);
       }
-      if (f.failedStepLogPath && fs.existsSync(f.failedStepLogPath)) {
-        const content = fs.readFileSync(f.failedStepLogPath, "utf-8");
-        process.stdout.write("\n" + content);
-      } else if (f.lastOutputLines && f.lastOutputLines.length > 0) {
-        process.stdout.write("\n" + f.lastOutputLines.join("\n") + "\n");
+    }
+
+    for (const group of groups) {
+      for (const f of group.failures) {
+        process.stdout.write(formatFailureHeader(f) + "\n");
+      }
+      if (group.errorContent) {
+        process.stdout.write("\n" + group.errorContent);
       }
       process.stdout.write("\n");
     }


### PR DESCRIPTION
## Problem

When multiple matrix jobs fail with the same root cause (e.g. missing secrets), the output is overwhelming — the identical error message is repeated once per job both during streaming output and in the FAILURES summary. In the attached example, 8 matrix jobs all missing the same secrets produced the error 8 times during execution, then 8 more times in the summary — 16 repetitions of the same multi-line message.

## Solution

**FAILURES summary** (`reporter.ts`): Group failures by their error content. All affected job headers are listed together, then the error is shown once:

```
  ✗ playwright.yml > test (1) > "[Job startup failed]"
  ✗ playwright.yml > test (2) > "[Job startup failed]"
  ...

[Agent CI] Missing secrets required by workflow job "test".
Add the following to .env.agent-ci:
  CLOUDFLARE_ACCOUNT_ID=
  ...
```

**Streaming output** (`cli.ts`): Track seen error messages with a `Set<string>` so the same error is only printed once during execution.

## Test plan

- [x] Added test: deduplicates failures with identical error content (error shown once, all headers listed)
- [x] Added test: keeps distinct errors separate
- [x] All 458 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)