### PR TITLE
fix: show failure output for paused jobs in multi-job workflows

### DIFF
--- a/.changeset/show-pause-output-multijob.md
+++ b/.changeset/show-pause-output-multijob.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Show failure output and retry/abort hints for paused jobs in multi-job workflows.

--- a/packages/cli/src/output/state-renderer.test.ts
+++ b/packages/cli/src/output/state-renderer.test.ts
@@ -402,11 +402,56 @@ describe("renderRunState", () => {
       });
 
       const output = renderRunState(state);
-      // Retry hint is a child node (not trailing output like single-job mode)
+      // Retry hint is a child node in the tree
       expect(output).toContain("↻ retry: agent-ci retry --runner agent-ci-5-j2");
-      // No trailing "To retry:" / "To abort:" lines in multi-job mode
-      expect(output).not.toContain("↻ To retry:");
-      expect(output).not.toContain("■ To abort:");
+      // Trailing "To retry:" / "To abort:" lines also shown in multi-job mode
+      expect(output).toContain("↻ To retry:");
+      expect(output).toContain("■ To abort:");
+    });
+
+    it("shows last output lines for paused job in multi-job mode", () => {
+      const state = makeState({
+        workflows: [
+          {
+            id: "ci.yml",
+            path: "/repo/.github/workflows/ci.yml",
+            status: "running",
+            jobs: [
+              {
+                id: "build",
+                runnerId: "agent-ci-5-j1",
+                status: "completed",
+                durationMs: 5000,
+                steps: [],
+              },
+              {
+                id: "test",
+                runnerId: "agent-ci-5-j2",
+                status: "paused",
+                pausedAtStep: "Run tests",
+                pausedAtMs: "1970-01-01T00:00:05.000Z",
+                attempt: 1,
+                lastOutputLines: ["FAIL src/app.test.ts", "  Expected: true", "  Received: false"],
+                bootDurationMs: 1000,
+                steps: [
+                  {
+                    name: "Run tests",
+                    index: 1,
+                    status: "paused",
+                    startedAt: "1970-01-01T00:00:03.000Z",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      const output = renderRunState(state);
+      expect(output).toContain("Last output:");
+      expect(output).toContain("FAIL src/app.test.ts");
+      expect(output).toContain("Expected: true");
+      expect(output).toContain("Received: false");
     });
   });
 

--- a/packages/cli/src/output/state-renderer.ts
+++ b/packages/cli/src/output/state-renderer.ts
@@ -174,16 +174,16 @@ export function renderRunState(state: RunState): string {
   const singleJobMode = state.workflows.length === 1 && totalJobs === 1;
 
   const roots: TreeNode[] = [];
-  let pausedSingleJob: JobState | undefined;
+  let pausedJob: JobState | undefined;
 
   for (const wf of state.workflows) {
     const children: TreeNode[] = [];
     for (const job of wf.jobs) {
       children.push(...buildJobNodes(job, singleJobMode));
 
-      // Capture the first paused job for single-job trailing output
-      if (singleJobMode && job.status === "paused" && !pausedSingleJob) {
-        pausedSingleJob = job;
+      // Capture the first paused job for trailing output
+      if (job.status === "paused" && !pausedJob) {
+        pausedJob = job;
       }
     }
     roots.push({ label: path.basename(wf.path), children });
@@ -191,9 +191,9 @@ export function renderRunState(state: RunState): string {
 
   let output = renderTree(roots);
 
-  // ── Single-job pause: append last output + retry/abort hints below tree ────
-  if (pausedSingleJob) {
-    const { lastOutputLines, runnerId } = pausedSingleJob;
+  // ── Paused job: append last output + retry/abort hints below tree ──────────
+  if (pausedJob) {
+    const { lastOutputLines, runnerId } = pausedJob;
     if (lastOutputLines && lastOutputLines.length > 0) {
       output += `\n\n  ${DIM}Last output:${RESET}`;
       for (const line of lastOutputLines) {


### PR DESCRIPTION
## Summary
- When `--pause-on-failure` triggers in a multi-job workflow (e.g. build + test), the "Last output" lines and retry/abort hints were suppressed — only `"Step failed attempt #1"` was shown with no error context
- Removed the `singleJobMode` gate so trailing failure output and retry/abort instructions are always displayed below the tree when a job pauses

## Test plan
- [x] Updated existing multi-job pause test to expect retry/abort hints
- [x] Added new test for `lastOutputLines` rendering in multi-job mode
- [x] All 15 state-renderer tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)