### PR TITLE
feat: compute dirty SHA for uncommitted worktrees

### DIFF
--- a/.changeset/dirty-sha-worktree.md
+++ b/.changeset/dirty-sha-worktree.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": minor
+"dtu-github-actions": minor
+---
+
+Compute dirty SHA for uncommitted worktrees so `github.sha` reflects the code actually being executed.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -44,6 +44,7 @@ import { expandReusableJobs } from "./workflow/reusable-workflow.js";
 import { prefetchRemoteWorkflows } from "./workflow/remote-workflow-fetch.js";
 import { printSummary, type JobResult } from "./output/reporter.js";
 import { syncWorkspaceForRetry } from "./runner/sync.js";
+import { computeDirtySha } from "./runner/dirty-sha.js";
 import { RunStateStore } from "./output/run-state.js";
 import { renderRunState } from "./output/state-renderer.js";
 import { isAgentMode, setQuietMode } from "./output/agent-mode.js";
@@ -556,9 +557,13 @@ async function handleWorkflow(options: {
   const { headSha, shaRef } = sha
     ? resolveHeadSha(repoRoot, sha)
     : { headSha: undefined, shaRef: undefined };
-  // Always resolve the real HEAD SHA for the push event context (before/after).
-  // This is separate from headSha which may be undefined for dirty workspace copies.
-  const realHeadSha = headSha ?? resolveHeadSha(repoRoot, "HEAD").headSha;
+  // Always resolve a SHA that represents the code being executed.
+  // When the working tree is dirty and no explicit --sha was given, compute an
+  // ephemeral commit SHA that captures the dirty state (including untracked files).
+  // This is purely informational — actions/checkout is always stubbed, so no
+  // workflow will ever try to fetch this SHA from a remote.
+  const realHeadSha =
+    headSha ?? computeDirtySha(repoRoot) ?? resolveHeadSha(repoRoot, "HEAD").headSha;
   const baseSha = resolveBaseSha(repoRoot, realHeadSha);
   const githubRepo = config.GITHUB_REPO ?? resolveRepoSlug(repoRoot);
   config.GITHUB_REPO = githubRepo;

--- a/packages/cli/src/runner/dirty-sha.test.ts
+++ b/packages/cli/src/runner/dirty-sha.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execSync } from "child_process";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { computeDirtySha } from "./dirty-sha.js";
+
+describe("computeDirtySha", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "dirty-sha-test-"));
+    execSync("git init", { cwd: repoDir, stdio: "pipe" });
+    execSync('git config user.name "test"', { cwd: repoDir, stdio: "pipe" });
+    execSync('git config user.email "test@test.com"', { cwd: repoDir, stdio: "pipe" });
+    // Create an initial commit so HEAD exists
+    fs.writeFileSync(path.join(repoDir, "initial.txt"), "initial");
+    execSync("git add -A && git commit -m 'initial'", { cwd: repoDir, stdio: "pipe" });
+  });
+
+  afterEach(() => {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("returns undefined for a clean working tree", () => {
+    expect(computeDirtySha(repoDir)).toBeUndefined();
+  });
+
+  it("returns a SHA when tracked files are modified", () => {
+    fs.writeFileSync(path.join(repoDir, "initial.txt"), "modified");
+    const sha = computeDirtySha(repoDir);
+    expect(sha).toBeDefined();
+    expect(sha).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("returns a SHA when untracked files are present", () => {
+    fs.writeFileSync(path.join(repoDir, "untracked.txt"), "new file");
+    const sha = computeDirtySha(repoDir);
+    expect(sha).toBeDefined();
+    expect(sha).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("returns a different SHA for different dirty states", () => {
+    fs.writeFileSync(path.join(repoDir, "a.txt"), "content a");
+    const sha1 = computeDirtySha(repoDir);
+
+    // Stage and commit a.txt, then modify differently
+    execSync("git add -A && git commit -m 'add a'", { cwd: repoDir, stdio: "pipe" });
+    fs.writeFileSync(path.join(repoDir, "a.txt"), "content b");
+    const sha2 = computeDirtySha(repoDir);
+
+    expect(sha1).toBeDefined();
+    expect(sha2).toBeDefined();
+    expect(sha1).not.toBe(sha2);
+  });
+
+  it("does not move HEAD or create refs", () => {
+    const headBefore = execSync("git rev-parse HEAD", { cwd: repoDir, stdio: "pipe" })
+      .toString()
+      .trim();
+    const refsBefore = execSync("git for-each-ref", { cwd: repoDir, stdio: "pipe" })
+      .toString()
+      .trim();
+
+    fs.writeFileSync(path.join(repoDir, "dirty.txt"), "dirty");
+    computeDirtySha(repoDir);
+
+    const headAfter = execSync("git rev-parse HEAD", { cwd: repoDir, stdio: "pipe" })
+      .toString()
+      .trim();
+    const refsAfter = execSync("git for-each-ref", { cwd: repoDir, stdio: "pipe" })
+      .toString()
+      .trim();
+
+    expect(headAfter).toBe(headBefore);
+    expect(refsAfter).toBe(refsBefore);
+  });
+
+  it("does not modify the real index", () => {
+    // Stage nothing, but have an untracked file
+    fs.writeFileSync(path.join(repoDir, "untracked.txt"), "new");
+
+    const statusBefore = execSync("git status --porcelain", { cwd: repoDir, stdio: "pipe" })
+      .toString()
+      .trim();
+
+    computeDirtySha(repoDir);
+
+    const statusAfter = execSync("git status --porcelain", { cwd: repoDir, stdio: "pipe" })
+      .toString()
+      .trim();
+
+    expect(statusAfter).toBe(statusBefore);
+  });
+
+  it("returns a valid commit object parented on HEAD", () => {
+    fs.writeFileSync(path.join(repoDir, "dirty.txt"), "content");
+    const sha = computeDirtySha(repoDir);
+    expect(sha).toBeDefined();
+
+    // Verify it's a valid commit object
+    const type = execSync(`git cat-file -t ${sha}`, { cwd: repoDir, stdio: "pipe" })
+      .toString()
+      .trim();
+    expect(type).toBe("commit");
+
+    // Read the parent SHA directly from the commit object (bypasses any git shims
+    // that intercept `git rev-parse HEAD` in CI environments).
+    const commitBody = execSync(`git cat-file -p ${sha}`, {
+      cwd: repoDir,
+      stdio: "pipe",
+    }).toString();
+    const parentMatch = commitBody.match(/^parent ([0-9a-f]{40})$/m);
+    expect(parentMatch).not.toBeNull();
+
+    // Read HEAD the same way to compare — resolve the ref from .git/HEAD.
+    const headContent = fs.readFileSync(path.join(repoDir, ".git", "HEAD"), "utf-8").trim();
+    const headSha = headContent.startsWith("ref: ")
+      ? fs.readFileSync(path.join(repoDir, ".git", headContent.slice(5)), "utf-8").trim()
+      : headContent;
+
+    expect(parentMatch![1]).toBe(headSha);
+  });
+});

--- a/packages/cli/src/runner/dirty-sha.ts
+++ b/packages/cli/src/runner/dirty-sha.ts
@@ -1,0 +1,69 @@
+import { execSync } from "child_process";
+import path from "path";
+import fs from "fs";
+
+/**
+ * Compute a SHA that represents the current dirty working-tree state, as if
+ * it were committed.  Uses a temporary index + `git write-tree` /
+ * `git commit-tree` so no refs are moved and real history is untouched.
+ *
+ * Returns `undefined` when the tree is clean (no uncommitted changes).
+ */
+export function computeDirtySha(repoRoot: string): string | undefined {
+  try {
+    // Quick check: anything dirty?
+    const status = execSync("git status --porcelain", {
+      cwd: repoRoot,
+      stdio: "pipe",
+    })
+      .toString()
+      .trim();
+    if (!status) {
+      return undefined;
+    }
+
+    const gitDir = execSync("git rev-parse --git-dir", {
+      cwd: repoRoot,
+      stdio: "pipe",
+    })
+      .toString()
+      .trim();
+    const absoluteGitDir = path.isAbsolute(gitDir) ? gitDir : path.join(repoRoot, gitDir);
+    const tmpIndex = path.join(absoluteGitDir, `index-agent-ci-${Date.now()}`);
+
+    try {
+      // Seed the temp index from the real one so we start from the current staging area.
+      fs.copyFileSync(path.join(absoluteGitDir, "index"), tmpIndex);
+
+      const env = { ...process.env, GIT_INDEX_FILE: tmpIndex };
+
+      // Stage everything (tracked + untracked, respecting .gitignore) into the temp index.
+      execSync("git add -A", { cwd: repoRoot, stdio: "pipe", env });
+
+      // Write a tree object from the temp index.
+      const tree = execSync("git write-tree", {
+        cwd: repoRoot,
+        stdio: "pipe",
+        env,
+      })
+        .toString()
+        .trim();
+
+      // Create an ephemeral commit object parented on HEAD — no ref is updated.
+      const sha = execSync(`git commit-tree ${tree} -p HEAD -m "agent-ci: dirty working tree"`, {
+        cwd: repoRoot,
+        stdio: "pipe",
+      })
+        .toString()
+        .trim();
+
+      return sha;
+    } finally {
+      try {
+        fs.unlinkSync(tmpIndex);
+      } catch {}
+    }
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Problem

`github.sha` returns `git rev-parse HEAD`, which reflects the last commit. When the working tree is dirty (uncommitted changes), the runner executes code that doesn't match the reported SHA — making the SHA misleading for debugging and traceability.

## Solution

When no `--sha` flag is given and the working tree has uncommitted changes, compute an ephemeral commit SHA that represents the actual dirty state. Uses `git write-tree` + `git commit-tree` with a temporary index file, so:

- No refs are moved, no history is modified
- Untracked files (respecting `.gitignore`) are included
- The real index is untouched (temp index is cleaned up in a `finally` block)
- Falls back gracefully to `HEAD` on any error or clean tree

This is safe because `actions/checkout` is always stubbed by Agent CI — no workflow will ever try to fetch this SHA from a remote.

Closes #198

## Test plan

- [x] Unit tests (7 tests): clean tree → `undefined`, tracked mods, untracked files, different states → different SHAs, HEAD/refs unchanged, real index unchanged, valid commit object with correct parent
- [x] `pnpm agent-ci-dev run --workflow .github/workflows/tests.yml --quiet` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)