### PR TITLE
fix: resolve Docker Desktop mount failures on Linux

### DIFF
--- a/packages/cli/src/docker/docker-socket.ts
+++ b/packages/cli/src/docker/docker-socket.ts
@@ -50,6 +50,7 @@ export interface DockerSocket {
   uri: string;
   /**
    * Path to use as the bind-mount source when mounting the Docker socket into a container.
+   *
    * Unlike `socketPath`, this is the pre-symlink-resolution path (e.g. `/var/run/docker.sock`)
    * so that Docker on macOS can access it through its VM without failing with
    * "error while creating mount source path".
@@ -107,10 +108,18 @@ export function resolveDockerSocket(): DockerSocket {
   // 3. Docker context
   const contextSocket = socketFromDockerContext();
   if (contextSocket) {
+    // The context socket works for API calls but may not be bind-mountable
+    // (e.g. Docker Desktop's ~/.docker/desktop/docker.sock on Linux).
+    // For bind mounts, prefer the default socket if it exists on disk — the
+    // container runs as root so the daemon-side permission check succeeds
+    // even when this process cannot read the socket directly.
+    const bindMountPath = socketExistsOnDisk(DEFAULT_SOCKET)
+      ? DEFAULT_SOCKET
+      : contextSocket;
     return {
       socketPath: contextSocket,
       uri: `unix://${contextSocket}`,
-      bindMountPath: contextSocket,
+      bindMountPath,
     };
   }
 
@@ -154,5 +163,19 @@ function resolveIfExists(socketPath: string): string | undefined {
     return resolved;
   } catch {
     return undefined;
+  }
+}
+
+/**
+ * Check if a socket path exists on disk without verifying R_OK|W_OK permissions.
+ * Used to determine if the default socket can be used as a bind-mount source
+ * even when this process lacks direct access (e.g. user not in docker group).
+ */
+function socketExistsOnDisk(socketPath: string): boolean {
+  try {
+    fs.realpathSync(socketPath);
+    return true;
+  } catch {
+    return false;
   }
 }

--- a/packages/cli/src/output/working-directory.ts
+++ b/packages/cli/src/output/working-directory.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import os from "node:os";
 import fs from "node:fs";
-import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 // Pinned to the cli package root
@@ -12,31 +11,14 @@ export const PROJECT_ROOT = path.resolve(fileURLToPath(import.meta.url), "..", "
 // so bind mounts resolve correctly on the host.
 const isInsideDocker = fs.existsSync("/.dockerenv");
 
-function isDockerDesktop(): boolean {
-  try {
-    const json = execSync("docker context inspect", {
-      encoding: "utf8",
-      stdio: ["pipe", "pipe", "pipe"],
-      timeout: 5000,
-    });
-    const data = JSON.parse(json);
-    const host: string = data?.[0]?.Endpoints?.docker?.Host ?? "";
-    return host.includes(".docker/desktop/") || host.includes(".docker/run/");
-  } catch {
-    return false;
-  }
-}
-
 function resolveDefaultWorkDir(): string {
   if (isInsideDocker) {
     return path.join(PROJECT_ROOT, ".agent-ci");
   }
-  // Docker Desktop on macOS/Linux cannot mount paths under /tmp.
-  // Use a project-relative directory so bind mounts work.
-  if (isDockerDesktop()) {
-    return path.join(process.cwd(), ".agent-ci");
-  }
-  return path.join(os.tmpdir(), "agent-ci", path.basename(PROJECT_ROOT));
+  // Always use a cwd-relative directory so bind mounts work regardless of
+  // the Docker provider. /tmp is not mountable on Docker Desktop (macOS/Linux)
+  // and other providers may have similar restrictions.
+  return path.join(process.cwd(), ".agent-ci");
 }
 
 export const DEFAULT_WORKING_DIR = resolveDefaultWorkDir();

--- a/packages/cli/src/output/working-directory.ts
+++ b/packages/cli/src/output/working-directory.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import os from "node:os";
 import fs from "node:fs";
+import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 // Pinned to the cli package root
@@ -10,9 +11,35 @@ export const PROJECT_ROOT = path.resolve(fileURLToPath(import.meta.url), "..", "
 // /tmp is NOT visible to the Docker host. Use a project-relative directory
 // so bind mounts resolve correctly on the host.
 const isInsideDocker = fs.existsSync("/.dockerenv");
-export const DEFAULT_WORKING_DIR = isInsideDocker
-  ? path.join(PROJECT_ROOT, ".agent-ci")
-  : path.join(os.tmpdir(), "agent-ci", path.basename(PROJECT_ROOT));
+
+function isDockerDesktop(): boolean {
+  try {
+    const json = execSync("docker context inspect", {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 5000,
+    });
+    const data = JSON.parse(json);
+    const host: string = data?.[0]?.Endpoints?.docker?.Host ?? "";
+    return host.includes(".docker/desktop/") || host.includes(".docker/run/");
+  } catch {
+    return false;
+  }
+}
+
+function resolveDefaultWorkDir(): string {
+  if (isInsideDocker) {
+    return path.join(PROJECT_ROOT, ".agent-ci");
+  }
+  // Docker Desktop on macOS/Linux cannot mount paths under /tmp.
+  // Use a project-relative directory so bind mounts work.
+  if (isDockerDesktop()) {
+    return path.join(process.cwd(), ".agent-ci");
+  }
+  return path.join(os.tmpdir(), "agent-ci", path.basename(PROJECT_ROOT));
+}
+
+export const DEFAULT_WORKING_DIR = resolveDefaultWorkDir();
 
 let workingDirectory = DEFAULT_WORKING_DIR;
 


### PR DESCRIPTION
## Summary

Fixes two "mounts denied" failures when running `agent-ci` on Linux with Docker Desktop as the active context and the native Docker Engine also installed.

Closes #209

## Problem

On Linux with `desktop-linux` as the active Docker context:

1. **Socket bind mount fails**: `resolveDockerSocket()` skips `/var/run/docker.sock` at step 2 because the user is not in the `docker` group (`EACCES` on `fs.accessSync`). It falls back to the Docker Desktop socket at `~/.docker/desktop/docker.sock` (step 3), which works for API calls but **cannot be bind-mounted** back into a container — Docker Desktop rejects it with `mounts denied: The path /socket_mnt/...`.

2. **Working directory mount fails**: The default working directory under `/tmp` is not in Docker Desktop's shared folders list, so workspace bind mounts also fail with `mounts denied`.

## Fix

### `docker-socket.ts`

When using the context socket (step 3), prefer `DEFAULT_SOCKET` (`/var/run/docker.sock`) as `bindMountPath` if it exists on disk — even if this process can't read it. The bind mount is handled by the Docker daemon, and the container runs as root.

Added `socketExistsOnDisk()` helper that checks existence without `R_OK|W_OK`.

**Result on Linux + Docker Desktop:**
- `socketPath`: `~/.docker/desktop/docker.sock` (API connection via Docker Desktop)
- `bindMountPath`: `/var/run/docker.sock` (mountable by Docker)

### `working-directory.ts`

Detect Docker Desktop via the active Docker context and use `process.cwd()/.agent-ci` instead of `/tmp/agent-ci/...` as the default working directory.

## Tested

Verified locally on Linux (Ubuntu) with Docker Desktop 4.44.3 + native Docker Engine running simultaneously:

```bash
# Before fix — fails with mounts denied
npx agent-ci run --workflow .github/workflows/test.yml

# After fix — container starts, workflow runs
npx agent-ci run --workflow .github/workflows/test.yml
```