### PR TITLE
perf: hoist docker cleanup and image prefetch to session bootstrap

### DIFF
--- a/.changeset/perf-bootstrap-docker-ops.md
+++ b/.changeset/perf-bootstrap-docker-ops.md
@@ -1,0 +1,13 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+perf: hoist docker cleanup and image prefetch to session bootstrap
+
+`agent-ci run --all` now runs global Docker cleanup (prune orphans, kill
+stale containers, prune stale workspaces) and runner image prefetch exactly
+once per session instead of once per workflow. Also dedupes concurrent
+`ensureImagePulled` calls so parallel workflows share a single in-flight
+`docker pull`. Eliminates cold-start thundering herd and the N× `docker
+volume prune` storm that was serializing multi-workflow runs. See #211.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -11,7 +11,13 @@ import {
 } from "./output/working-directory.js";
 import { debugCli } from "./output/debug.js";
 
-import { executeLocalJob } from "./runner/local-job.js";
+import { executeLocalJob, getDocker } from "./runner/local-job.js";
+import {
+  discoverRunnerImage,
+  ensureRunnerImage,
+  UPSTREAM_RUNNER_IMAGE,
+} from "./runner/runner-image.js";
+import { ensureImagePulled } from "./docker/image-pull.js";
 import {
   parseWorkflowSteps,
   parseWorkflowServices,
@@ -309,6 +315,47 @@ async function run() {
   }
 }
 
+// ─── prefetchRunnerImages ──────────────────────────────────────────────────
+// Pull (and, if necessary, build) every runner image that the upcoming
+// workflows will need — once, before any job starts. Without this, each
+// parallel workflow independently races to pull/build the same image, which
+// with `--all` means dozens of concurrent `docker pull` calls on a cold
+// cache. The per-job calls in local-job.ts remain as a safety net and take
+// the inspect() fast path since images are already warm.
+async function prefetchRunnerImages(workflowPaths: string[]): Promise<void> {
+  const docker = getDocker();
+
+  // The upstream runner image is always needed: default mode uses it
+  // directly, direct-container mode uses it to seed the runner binary.
+  const pulls: Promise<unknown>[] = [ensureImagePulled(docker, UPSTREAM_RUNNER_IMAGE)];
+
+  // Additionally, each unique repo root may resolve to a custom runner
+  // image (env override or Dockerfile). Build/pull each unique one.
+  const seenRepos = new Set<string>();
+  const seenImages = new Set<string>([UPSTREAM_RUNNER_IMAGE]);
+  for (const wf of workflowPaths) {
+    const repoRoot = resolveRepoRootFromWorkflow(wf);
+    if (seenRepos.has(repoRoot)) {
+      continue;
+    }
+    seenRepos.add(repoRoot);
+    const resolved = discoverRunnerImage(repoRoot);
+    if (seenImages.has(resolved.image)) {
+      continue;
+    }
+    seenImages.add(resolved.image);
+    pulls.push(ensureRunnerImage(docker, resolved));
+  }
+
+  try {
+    await Promise.all(pulls);
+  } catch (err) {
+    // Don't block startup on prefetch failure — per-job calls will retry
+    // and produce a clearer error for the specific job that needs it.
+    debugCli(`[Agent CI] Image prefetch failed: ${(err as Error).message}`);
+  }
+}
+
 // ─── runWorkflows ──────────────────────────────────────────────────────────────
 // Single entry point for both `--workflow` and `--all`.
 // One workflow = --all with a single entry.
@@ -397,6 +444,17 @@ async function runWorkflows(options: {
   };
   process.on("SIGINT", exitOnSignal);
   process.on("SIGTERM", exitOnSignal);
+
+  // ── Session bootstrap ─────────────────────────────────────────────────────
+  // Global Docker/workspace cleanup + image prefetch run once per session
+  // instead of per-workflow. With `--all` launching many workflows in
+  // parallel, running these inside handleWorkflow() hammered the Docker
+  // daemon (N× `docker volume prune`, N× cold-start image pulls) and
+  // serialized work that should have been free. See issue #211.
+  pruneOrphanedDockerResources();
+  killOrphanedContainers();
+  pruneStaleWorkspaces(getWorkingDirectory(), 24 * 60 * 60 * 1000);
+  await prefetchRunnerImages(workflowPaths);
 
   try {
     const allResults: JobResult[] = [];
@@ -823,10 +881,6 @@ async function handleWorkflow(options: {
 
     return result;
   };
-
-  pruneOrphanedDockerResources();
-  killOrphanedContainers();
-  pruneStaleWorkspaces(getWorkingDirectory(), 24 * 60 * 60 * 1000);
 
   const limiter = createConcurrencyLimiter(maxJobs);
   const allResults: JobResult[] = [];

--- a/packages/cli/src/docker/image-pull.test.ts
+++ b/packages/cli/src/docker/image-pull.test.ts
@@ -51,4 +51,42 @@ describe("ensureImagePulled", () => {
     // Act: calling again must not throw
     await expect(ensureImagePulled(docker, TEST_IMAGE)).resolves.toBeUndefined();
   });
+
+  it("dedupes concurrent pulls of the same image", { timeout: 60_000 }, async () => {
+    // Arrange: remove the image so all callers hit the pull path
+    try {
+      await docker.getImage(TEST_IMAGE).remove({ force: true });
+    } catch {
+      // Already absent — fine
+    }
+
+    // Spy on docker.pull so we can count invocations. The dedup cache
+    // should ensure a single pull is shared across all concurrent callers.
+    const originalPull = docker.pull.bind(docker);
+    let pullInvocations = 0;
+    (docker as unknown as { pull: Docker["pull"] }).pull = ((
+      ...args: Parameters<Docker["pull"]>
+    ) => {
+      pullInvocations++;
+      return originalPull(...args);
+    }) as Docker["pull"];
+
+    try {
+      // Act: fire 5 concurrent callers before the first pull completes
+      await Promise.all([
+        ensureImagePulled(docker, TEST_IMAGE),
+        ensureImagePulled(docker, TEST_IMAGE),
+        ensureImagePulled(docker, TEST_IMAGE),
+        ensureImagePulled(docker, TEST_IMAGE),
+        ensureImagePulled(docker, TEST_IMAGE),
+      ]);
+    } finally {
+      (docker as unknown as { pull: Docker["pull"] }).pull = originalPull;
+    }
+
+    // Assert: exactly one underlying pull, and image is now present
+    expect(pullInvocations).toBe(1);
+    const info = await docker.getImage(TEST_IMAGE).inspect();
+    expect(info.RepoTags).toContain(TEST_IMAGE);
+  });
 });

--- a/packages/cli/src/docker/image-pull.ts
+++ b/packages/cli/src/docker/image-pull.ts
@@ -1,5 +1,10 @@
 import type Docker from "dockerode";
 
+// Dedup concurrent pulls of the same image. Without this, `--all` runs racing
+// to pull the same runner image trigger N concurrent `docker pull` requests
+// for the same tag. See issue #211.
+const inflightPulls = new Map<string, Promise<void>>();
+
 /**
  * Ensures a Docker image is present locally, pulling it if not.
  *
@@ -18,7 +23,12 @@ export async function ensureImagePulled(docker: Docker, image: string): Promise<
     // Not found locally — fall through to pull
   }
 
-  await new Promise<void>((resolve, reject) => {
+  const existing = inflightPulls.get(image);
+  if (existing) {
+    return existing;
+  }
+
+  const pull = new Promise<void>((resolve, reject) => {
     docker.pull(image, (err: Error | null, stream: NodeJS.ReadableStream) => {
       if (err) {
         return reject(wrapPullError(image, err));
@@ -31,7 +41,12 @@ export async function ensureImagePulled(docker: Docker, image: string): Promise<
         }
       });
     });
+  }).finally(() => {
+    inflightPulls.delete(image);
   });
+
+  inflightPulls.set(image, pull);
+  return pull;
 }
 
 function wrapPullError(image: string, cause: Error): Error {

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -57,7 +57,7 @@ function getDockerSocket(): DockerSocket {
   return _resolvedSocket;
 }
 
-function getDocker(): Docker {
+export function getDocker(): Docker {
   if (!_docker) {
     const socket = getDockerSocket();
     if (socket.socketPath) {


### PR DESCRIPTION
## Summary

Fixes #211. With \`run --all\`, global Docker cleanup and runner-image prefetch now run **once per session** instead of once per workflow:

- Hoists \`pruneOrphanedDockerResources\`, \`killOrphanedContainers\`, and \`pruneStaleWorkspaces\` out of \`handleWorkflow\` (where they were running N× in parallel and hammering the daemon with \`docker volume prune -f\`, \`docker ps\`, \`docker network ls\`) into one-time bootstrap at the top of \`runWorkflows\`.
- Prefetches \`UPSTREAM_RUNNER_IMAGE\` + per-repo runner image once at bootstrap, before workflows dispatch in parallel.
- Dedupes concurrent \`ensureImagePulled\` calls via an in-flight promise map, so if two callers race, they share a single \`docker pull\`.

Per-job \`ensureImagePulled\` calls stay as a safety net — they'll take the \`inspect()\` fast path since images are already warm.

## Impact

Local \`pnpm agent-ci-dev run --all\` on this repo: **~50s wall time** for 23 workflows, all passing. Cumulative workflow duration reported as ~7m 50s, so parallelism is doing its job.

## Test plan

- [x] \`pnpm -r run typecheck\` passes
- [x] \`pnpm --filter @redwoodjs/agent-ci test\` — 498/498 pass, including a new \`image-pull.test.ts\` case that proves 5 concurrent \`ensureImagePulled\` callers produce exactly 1 underlying \`docker.pull\`
- [x] \`pnpm format:check\` / \`pnpm lint\` clean
- [x] \`pnpm agent-ci-dev run --all -q\` — 23/23 workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)