### PR TITLE
fix: use /var/run/docker.sock as bind mount when user is not in docker group (#209)

### DIFF
--- a/.changeset/fix-209-docker-socket-linux-desktop.md
+++ b/.changeset/fix-209-docker-socket-linux-desktop.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Fix Docker socket bind mount on Linux + Docker Desktop when user is not in the docker group (#209). `resolveDockerSocket()` now treats `socketPath` (API client) and `bindMountPath` (container mount source) as independent decisions: whenever `/var/run/docker.sock` exists on the host, it is used as the bind-mount source regardless of our process's R/W access. This collapses the macOS Docker Desktop symlink case (#197) and the Linux Docker Desktop non-docker-group case (#209) into one rule.

--- a/packages/cli/src/docker/docker-socket.test.ts
+++ b/packages/cli/src/docker/docker-socket.test.ts
@@ -103,15 +103,21 @@ describe("resolveDockerSocket", () => {
 
   // ── EACCES fallthrough ─────────────────────────────────────────────────
 
-  it("falls through to docker context when default socket is not accessible", async () => {
+  it("falls through to docker context when default socket is not accessible, and uses /var/run/docker.sock for bind mount (regression #209)", async () => {
     delete process.env.DOCKER_HOST;
-    // Socket exists but is not accessible (e.g. root:docker 660 on Linux)
+    // Exact #209 cell: Linux + Docker Desktop, user not in docker group.
+    // - /var/run/docker.sock exists (owned by root:docker 660) — exists but EACCES for us
+    // - Active docker context points at the Desktop socket — what our API client must use
+    // - Bind mount must NOT be the Desktop socket (Docker Desktop rejects its own socket
+    //   path as a mount source with "mounts denied") — it must be /var/run/docker.sock,
+    //   which Docker Desktop's mount proxy accepts.
     vi.spyOn(fs, "realpathSync").mockReturnValue("/var/run/docker.sock");
     vi.spyOn(fs, "accessSync").mockImplementation(() => {
       throw Object.assign(new Error("EACCES"), { code: "EACCES" });
     });
     vi.spyOn(fs, "existsSync").mockImplementation((p) => {
-      return String(p) === "/home/user/.docker/desktop/docker.sock";
+      const s = String(p);
+      return s === "/var/run/docker.sock" || s === "/home/user/.docker/desktop/docker.sock";
     });
     mockedExecSync.mockReturnValue(
       JSON.stringify([
@@ -128,8 +134,10 @@ describe("resolveDockerSocket", () => {
     const { resolveDockerSocket } = await importFresh();
     const result = resolveDockerSocket();
 
+    // API client connects via the Desktop socket (we can't R/W /var/run/docker.sock)
     expect(result.socketPath).toBe("/home/user/.docker/desktop/docker.sock");
-    expect(result.bindMountPath).toBe("/home/user/.docker/desktop/docker.sock");
+    // Bind mount uses /var/run/docker.sock — the path Docker Desktop's mount proxy accepts
+    expect(result.bindMountPath).toBe("/var/run/docker.sock");
   });
 
   // ── Docker context fallback ─────────────────────────────────────────────

--- a/packages/cli/src/docker/docker-socket.ts
+++ b/packages/cli/src/docker/docker-socket.ts
@@ -60,16 +60,35 @@ export interface DockerSocket {
 /**
  * Resolve the Docker daemon socket.
  *
- * Resolution order:
+ * Two decisions with different requirements:
+ *   - `socketPath` — what our Node process opens for the Docker API client.
+ *     Needs R/W access from our UID.
+ *   - `bindMountPath` — what we pass as the bind-mount *source* when mounting
+ *     the Docker socket into a runner container. Docker's VM (on macOS + Linux
+ *     Docker Desktop) validates this path against its shared-mount list. Our
+ *     process's permissions are irrelevant here — only path recognition matters.
+ *
+ * Invariant: whenever `/var/run/docker.sock` exists on the host, use it as
+ * `bindMountPath` regardless of R/W access. Every Docker provider we've seen
+ * (Docker Desktop mac + Linux, OrbStack, Colima, native dockerd) either creates
+ * it directly or symlinks to it, and Docker Desktop's mount proxy accepts it.
+ * This collapses the macOS Desktop symlink case (#197) and the Linux Desktop +
+ * non-docker-group case (#209) into one rule.
+ *
+ * Resolution order for `socketPath`:
  *  1. `DOCKER_HOST` env var (returned as-is for non-unix schemes)
- *  2. Default socket `/var/run/docker.sock` (resolves symlinks)
+ *  2. Default socket `/var/run/docker.sock` (resolves symlinks, requires R/W)
  *  3. Active Docker context (`docker context inspect`)
  *  4. Well-known macOS provider sockets
  *
  * Throws with actionable guidance when no socket can be found.
  */
 export function resolveDockerSocket(): DockerSocket {
-  // 1. Explicit DOCKER_HOST
+  // `/var/run/docker.sock` existence check is independent of R/W access —
+  // `existsSync` only needs search permission on `/var/run`, which is always granted.
+  const mountableDefault = fs.existsSync(DEFAULT_SOCKET) ? DEFAULT_SOCKET : undefined;
+
+  // 1. Explicit DOCKER_HOST — user's explicit choice wins for bindMountPath too.
   const envHost = process.env.DOCKER_HOST?.trim();
   if (envHost) {
     if (envHost.startsWith("unix://")) {
@@ -92,11 +111,6 @@ export function resolveDockerSocket(): DockerSocket {
   // 2. Default socket path (often a symlink on macOS)
   const defaultResolved = resolveIfExists(DEFAULT_SOCKET);
   if (defaultResolved) {
-    // Always use DEFAULT_SOCKET as the bind-mount path, even if it resolves to a
-    // different location. On macOS Docker Desktop, /var/run/docker.sock is a symlink
-    // to a path inside the user's home directory; using the resolved path as a bind
-    // mount source causes "error while creating mount source path" because Docker's
-    // VM cannot access that host path.
     return {
       socketPath: defaultResolved,
       uri: `unix://${defaultResolved}`,
@@ -110,7 +124,7 @@ export function resolveDockerSocket(): DockerSocket {
     return {
       socketPath: contextSocket,
       uri: `unix://${contextSocket}`,
-      bindMountPath: contextSocket,
+      bindMountPath: mountableDefault ?? contextSocket,
     };
   }
 
@@ -118,7 +132,11 @@ export function resolveDockerSocket(): DockerSocket {
   if (process.platform === "darwin") {
     for (const candidate of MACOS_PROVIDER_SOCKETS) {
       if (fs.existsSync(candidate)) {
-        return { socketPath: candidate, uri: `unix://${candidate}`, bindMountPath: candidate };
+        return {
+          socketPath: candidate,
+          uri: `unix://${candidate}`,
+          bindMountPath: mountableDefault ?? candidate,
+        };
       }
     }
   }


### PR DESCRIPTION
## Problem

On Linux with Docker Desktop as the active context, `agent-ci` fails at runner container creation with:

> mounts denied: The path /socket_mnt/home/<user>/.docker/desktop/docker.sock is not shared

when the user isn't in the `docker` group.

### Root cause

`resolveDockerSocket()` conflates two independent decisions:

| Field | Opened by | Requires |
|---|---|---|
| `socketPath` | our Node process, for the Docker API client | R/W access from our UID |
| `bindMountPath` | Docker's VM / mount proxy, validating the mount source | a path Docker Desktop recognizes as shared |

When `fs.accessSync(R_OK\|W_OK)` fails on `/var/run/docker.sock` (user not in `docker` group), the resolver falls through to the docker context and wires the Desktop-owned socket (`~/.docker/desktop/docker.sock`) into **both** `socketPath` and `bindMountPath`. The API call works, but Docker Desktop rejects its own socket path as a mount source.

## Solution

Split the decisions, and hoist the `bindMountPath` rule above all resolution branches:

> Whenever `/var/run/docker.sock` exists on the host (existence-only check, no R/W required), use it as `bindMountPath`. `socketPath` resolution is unchanged.

`existsSync` on `/var/run/docker.sock` works without R/W because it only needs search permission on `/var/run`, which is always granted on macOS and Linux. Every Docker provider we've seen (Docker Desktop mac + Linux, OrbStack, Colima, native dockerd) either creates `/var/run/docker.sock` directly or symlinks to it, and Docker Desktop's mount proxy always accepts it as a mount source.

This collapses #197 (macOS Desktop symlink) and #209 (Linux Desktop non-`docker`-group) into one invariant instead of patching one more branch. Every future Docker provider quirk that affects `socketPath` resolution will route through the same `bindMountPath` rule and won't re-introduce this bug class.

## Empirical validation

Reproduced the #209 cell in an Ubuntu 24.04 VM (OrbStack-hosted — no nested virt for real Docker Desktop, but the resolution logic is the bug):

- Native `docker-ce` installed; `/var/run/docker.sock` owned `root:docker 660`
- Test user `peterp` **not** in `docker` group
- `socat` proxy at `/home/peterp/docker.sock` owned by the user, routing to `/var/run/docker.sock`
- Second docker context `linux-desktop` pointing at the proxy, made active — mirrors the Linux + Desktop setup

Old resolver returned:
```json
{ "socketPath": "/home/peterp/docker.sock", "bindMountPath": "/home/peterp/docker.sock" }
```

New resolver returns:
```json
{ "socketPath": "/home/peterp/docker.sock", "bindMountPath": "/var/run/docker.sock" }
```

`socketPath` stays on the socket we can actually open; `bindMountPath` moves to the path Docker Desktop's mount proxy accepts.

## Test plan

- [x] Unit tests: 497/497 pass (`pnpm --filter @redwoodjs/agent-ci test`)
- [x] Updated `docker-socket.test.ts` — the existing *"falls through to docker context when default socket is not accessible"* test was codifying the #209 bug (asserting `bindMountPath` === Desktop socket). Flipped it into a regression test for #209.
- [x] Full workflow suite: 23/23 passed in 8m17s (`pnpm agent-ci-dev run --all -q -p`)
- [x] Manual VM repro: old logic reproduces #209, new logic fixes it
- [x] #197 regression coverage remains green — default-socket branch is unchanged

## Scope

This PR addresses the **socket half** of the original problem in #210. The **working-directory half** — Linux Docker Desktop doesn't share `/tmp` by default, so workspace bind mounts also fail — is a distinct, orthogonal problem with a broader blast radius and is tracked separately in #215.

Closes #209

Credit to @BastiaanBH for identifying the problem in #210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)