### PR TITLE
fix: service containers leak on unclean shutdown

### DIFF
--- a/.changeset/fix-container-leak.md
+++ b/.changeset/fix-container-leak.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Fix service container and runner leak on unclean shutdown.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -444,6 +444,7 @@ async function runWorkflows(options: {
   };
   process.on("SIGINT", exitOnSignal);
   process.on("SIGTERM", exitOnSignal);
+  process.on("SIGHUP", exitOnSignal);
 
   // ── Session bootstrap ─────────────────────────────────────────────────────
   // Global Docker/workspace cleanup + image prefetch run once per session
@@ -558,6 +559,7 @@ async function runWorkflows(options: {
   } finally {
     process.removeListener("SIGINT", exitOnSignal);
     process.removeListener("SIGTERM", exitOnSignal);
+    process.removeListener("SIGHUP", exitOnSignal);
     if (renderInterval) {
       clearInterval(renderInterval);
     }

--- a/packages/cli/src/docker/service-containers.test.ts
+++ b/packages/cli/src/docker/service-containers.test.ts
@@ -191,6 +191,16 @@ describe("startServiceContainers", () => {
     expect(call.Healthcheck.Retries).toBe(10);
   });
 
+  it("labels service containers with agent-ci.pid for orphan cleanup", async () => {
+    const docker = makeMockDocker({ healthStatus: "healthy" });
+    await startServiceContainers(docker, [MYSQL_SERVICE, REDIS_SERVICE], "agent-ci-42");
+
+    for (const call of docker.createContainer.mock.calls) {
+      expect(call[0].Labels).toBeDefined();
+      expect(call[0].Labels["agent-ci.pid"]).toBe(String(process.pid));
+    }
+  });
+
   it("does not set Healthcheck when options are absent", async () => {
     const docker = makeMockDocker();
     await startServiceContainers(docker, [REDIS_SERVICE], "agent-ci-42");

--- a/packages/cli/src/docker/service-containers.ts
+++ b/packages/cli/src/docker/service-containers.ts
@@ -162,6 +162,9 @@ export async function startServiceContainers(
     const container = await docker.createContainer({
       Image: svc.image,
       name: containerName,
+      Labels: {
+        "agent-ci.pid": String(process.pid),
+      },
       Env: envArr,
       ExposedPorts: exposedPorts,
       Healthcheck: healthConfig,

--- a/packages/cli/src/docker/shutdown.test.ts
+++ b/packages/cli/src/docker/shutdown.test.ts
@@ -183,9 +183,10 @@ describe("killOrphanedContainers", () => {
     expect(rmCalls).toEqual([]);
   });
 
-  it("skips containers without a PID label", async () => {
+  it("kills unlabeled containers as orphans", async () => {
     execSyncMock.mockImplementation((cmd: string) => {
       if (cmd.startsWith("docker ps")) {
+        // Empty pid label — unlabeled container
         return "abc123 agent-ci-runner-3 \n";
       }
       return "";
@@ -195,9 +196,58 @@ describe("killOrphanedContainers", () => {
     killOrphanedContainers();
 
     const rmCalls = execSyncMock.mock.calls.filter(([cmd]: string[]) =>
-      cmd.includes("docker rm -f"),
+      cmd.includes("docker rm -f agent-ci-runner-3"),
     );
-    expect(rmCalls).toEqual([]);
+    expect(rmCalls.length).toBeGreaterThan(0);
+  });
+
+  it("derives runner name from svc container and cleans both", async () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("docker ps")) {
+        // An unlabeled svc container whose runner is already gone
+        return "def456 agent-ci-2307-j2-svc-cache-db \n";
+      }
+      return "";
+    });
+
+    const { killOrphanedContainers } = await import("./shutdown.js");
+    killOrphanedContainers();
+
+    // Should call killRunnerContainers with the runner name (without -svc-cache-db)
+    const rmCalls = execSyncMock.mock.calls.filter(([cmd]: string[]) =>
+      cmd.includes("docker rm -f agent-ci-2307-j2"),
+    );
+    expect(rmCalls.length).toBeGreaterThan(0);
+  });
+
+  it("deduplicates cleanup when runner and svc containers share a PID", async () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("docker ps")) {
+        // Both runner and its svc container listed, both with dead PID
+        return (
+          ["aaa111 agent-ci-500-j1 99999", "bbb222 agent-ci-500-j1-svc-redis 99999"].join("\n") +
+          "\n"
+        );
+      }
+      return "";
+    });
+    killSpy.mockImplementation(((pid: number, signal?: string | number) => {
+      if (signal === 0 && pid === 99999) {
+        throw new Error("ESRCH");
+      }
+      return true;
+    }) as typeof process.kill);
+
+    const { killOrphanedContainers } = await import("./shutdown.js");
+    killOrphanedContainers();
+
+    // killRunnerContainers should only be called once for the runner name
+    const rmCalls = execSyncMock.mock.calls.filter(([cmd]: string[]) =>
+      cmd.includes("docker rm -f agent-ci-500-j1"),
+    );
+    // One call for the runner rm, one for the svc filter — but NOT a second
+    // full killRunnerContainers pass for the svc container
+    expect(rmCalls.length).toBe(1);
   });
 
   it("handles Docker not reachable gracefully", async () => {

--- a/packages/cli/src/docker/shutdown.test.ts
+++ b/packages/cli/src/docker/shutdown.test.ts
@@ -350,7 +350,7 @@ describe.skipIf(!dockerAvailable())("killOrphanedContainers (Docker integration)
   // so exercising the real module resolution path is a feature, not a hack.
   function runKillOrphanedContainers() {
     execSync(
-      `npx tsx -e "import { killOrphanedContainers } from './packages/cli/src/docker/shutdown.ts'; killOrphanedContainers();"`,
+      `npx tsx -e "import { killOrphanedContainers } from './src/docker/shutdown.ts'; killOrphanedContainers();"`,
       { stdio: "pipe" },
     );
   }

--- a/packages/cli/src/docker/shutdown.test.ts
+++ b/packages/cli/src/docker/shutdown.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { execSync } from "node:child_process";
 
 // ── Signal handling cleanup ───────────────────────────────────────────────────
 
@@ -324,5 +325,114 @@ describe("containerWorkDir cleanup on exit", () => {
     expect(fs.existsSync(containerWorkDir)).toBe(true);
     expect(fs.existsSync(shimsDir)).toBe(true);
     expect(fs.existsSync(diagDir)).toBe(true);
+  });
+});
+
+// ── Integration: orphan cleanup against real Docker ──────────────────────────
+
+function dockerAvailable(): boolean {
+  try {
+    execSync("docker info", { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe.skipIf(!dockerAvailable())("killOrphanedContainers (Docker integration)", () => {
+  const containerName = "agent-ci-orphan-smoke-svc-testdb";
+  const runnerName = "agent-ci-orphan-smoke";
+
+  // Import the real function eagerly, outside vitest's mock system.
+  // The unit tests above use vi.doMock("node:child_process") which poisons
+  // dynamic imports even after vi.resetModules()/vi.unmock(). Spawning a
+  // fresh node process sidesteps that entirely — and this IS a smoke test,
+  // so exercising the real module resolution path is a feature, not a hack.
+  function runKillOrphanedContainers() {
+    execSync(
+      `npx tsx -e "import { killOrphanedContainers } from './packages/cli/src/docker/shutdown.ts'; killOrphanedContainers();"`,
+      { stdio: "pipe" },
+    );
+  }
+
+  afterEach(() => {
+    // Belt-and-suspenders: ensure we don't leak the test container
+    try {
+      execSync(`docker rm -f ${containerName}`, { stdio: "pipe" });
+    } catch {
+      // already gone — good
+    }
+    try {
+      execSync(`docker network rm agent-ci-net-${runnerName}`, { stdio: "pipe" });
+    } catch {
+      // already gone
+    }
+  });
+
+  it("cleans up an unlabeled service container", () => {
+    // Create a container that mimics a leaked pre-fix service container: no agent-ci.pid label
+    execSync(`docker create --name ${containerName} busybox sleep 300`, { stdio: "pipe" });
+    execSync(`docker start ${containerName}`, { stdio: "pipe" });
+
+    // Confirm it's running
+    const before = execSync(
+      `docker ps -q --filter "name=${containerName}" --filter "status=running"`,
+      { encoding: "utf8", stdio: "pipe" },
+    ).trim();
+    expect(before).not.toBe("");
+
+    runKillOrphanedContainers();
+
+    // Container should be gone
+    const after = execSync(`docker ps -aq --filter "name=${containerName}"`, {
+      encoding: "utf8",
+      stdio: "pipe",
+    }).trim();
+    expect(after).toBe("");
+  });
+
+  it("cleans up a labeled service container whose parent PID is dead", () => {
+    // Use a PID that's guaranteed dead (PID 2^22 - 1 is extremely unlikely to exist)
+    const deadPid = "4194303";
+
+    execSync(
+      `docker create --name ${containerName} --label "agent-ci.pid=${deadPid}" busybox sleep 300`,
+      { stdio: "pipe" },
+    );
+    execSync(`docker start ${containerName}`, { stdio: "pipe" });
+
+    const before = execSync(
+      `docker ps -q --filter "name=${containerName}" --filter "status=running"`,
+      { encoding: "utf8", stdio: "pipe" },
+    ).trim();
+    expect(before).not.toBe("");
+
+    runKillOrphanedContainers();
+
+    const after = execSync(`docker ps -aq --filter "name=${containerName}"`, {
+      encoding: "utf8",
+      stdio: "pipe",
+    }).trim();
+    expect(after).toBe("");
+  });
+
+  it("does NOT kill a service container whose parent PID is alive", () => {
+    // Label with our own PID — should be left alone
+    const myPid = String(process.pid);
+
+    execSync(
+      `docker create --name ${containerName} --label "agent-ci.pid=${myPid}" busybox sleep 300`,
+      { stdio: "pipe" },
+    );
+    execSync(`docker start ${containerName}`, { stdio: "pipe" });
+
+    runKillOrphanedContainers();
+
+    // Container should still be running
+    const after = execSync(
+      `docker ps -q --filter "name=${containerName}" --filter "status=running"`,
+      { encoding: "utf8", stdio: "pipe" },
+    ).trim();
+    expect(after).not.toBe("");
   });
 });

--- a/packages/cli/src/docker/shutdown.ts
+++ b/packages/cli/src/docker/shutdown.ts
@@ -56,11 +56,12 @@ export function killRunnerContainers(runnerName: string): void {
  * exhausting its address pool ("all predefined address pools have been fully subnetted").
  */
 export function pruneOrphanedDockerResources(): void {
-  // 1. Remove stopped agent-ci-* containers (runners + sidecars) so their
+  // 1. Remove stopped/stale agent-ci-* containers (runners + sidecars) so their
   //    network references are released before we try to prune networks.
+  //    Includes both "exited" and "created" (never started) containers.
   try {
     const stoppedIds = execSync(
-      `docker ps -aq --filter "name=agent-ci-" --filter "status=exited"`,
+      `docker ps -aq --filter "name=agent-ci-" --filter "status=exited" --filter "status=created"`,
       { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
     ).trim();
     if (stoppedIds) {
@@ -110,12 +111,14 @@ export function pruneOrphanedDockerResources(): void {
 /**
  * Find and kill running `agent-ci-*` containers whose parent process is dead.
  *
- * Every container created by `executeLocalJob` is labelled with
- * `agent-ci.pid=<PID>`. If the process that spawned the container is no
- * longer alive, the container is an orphan and should be killed — along with
- * its svc-* sidecars and bridge network (via `killRunnerContainers`).
+ * Every container created by `executeLocalJob` (and its service containers)
+ * is labelled with `agent-ci.pid=<PID>`. If the process that spawned the
+ * container is no longer alive, the container is an orphan and should be
+ * killed — along with its svc-* sidecars and bridge network (via
+ * `killRunnerContainers`).
  *
- * Containers without the label (created before this feature) are skipped.
+ * Containers without the label are also cleaned up — they're either pre-label
+ * containers or service containers created before the label was added.
  */
 export function killOrphanedContainers(): void {
   let lines: string[];
@@ -134,22 +137,38 @@ export function killOrphanedContainers(): void {
     return;
   }
 
+  // Track runner names we've already cleaned up to avoid double-cleaning
+  const cleaned = new Set<string>();
+
   for (const line of lines) {
     const [, containerName, pidStr] = line.split(" ");
-    if (!containerName || !pidStr) {
+    if (!containerName) {
       continue;
     }
 
-    const pid = Number(pidStr);
-    if (!Number.isFinite(pid) || pid <= 0) {
-      continue;
+    // Containers with the pid label: check if the parent is still alive
+    if (pidStr) {
+      const pid = Number(pidStr);
+      if (!Number.isFinite(pid) || pid <= 0) {
+        continue;
+      }
+
+      try {
+        process.kill(pid, 0); // signal 0 = liveness check, throws if dead
+        continue; // Parent alive — not an orphan
+      } catch {
+        // Parent is dead — this container is an orphan.
+      }
     }
 
-    try {
-      process.kill(pid, 0); // signal 0 = liveness check, throws if dead
-    } catch {
-      // Parent is dead — this container is an orphan.
-      killRunnerContainers(containerName);
+    // Derive the runner name: for svc containers (e.g. "agent-ci-2307-j2-svc-cache-db"),
+    // extract the runner prefix before "-svc-"; for runner containers, use the name as-is.
+    const svcIdx = containerName.indexOf("-svc-");
+    const runnerName = svcIdx !== -1 ? containerName.substring(0, svcIdx) : containerName;
+
+    if (!cleaned.has(runnerName)) {
+      cleaned.add(runnerName);
+      killRunnerContainers(runnerName);
     }
   }
 }

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -270,6 +270,7 @@ export async function executeLocalJob(
   };
   process.on("SIGINT", signalCleanup);
   process.on("SIGTERM", signalCleanup);
+  process.on("SIGHUP", signalCleanup);
 
   try {
     // 1. Seed the job to Local DTU
@@ -972,5 +973,6 @@ export async function executeLocalJob(
     await ephemeralDtu?.close().catch(() => {});
     process.removeListener("SIGINT", signalCleanup);
     process.removeListener("SIGTERM", signalCleanup);
+    process.removeListener("SIGHUP", signalCleanup);
   }
 }


### PR DESCRIPTION
## Summary

- **Problem:** Service containers (`agent-ci-*-svc-*`) were created without the `agent-ci.pid` label, making them invisible to bootstrap orphan cleanup. When the parent died without cleanly hitting its signal handler (crash, SIGKILL, Bash tool timeout, etc.), these containers leaked permanently. SIGHUP wasn't handled either, so closing a tmux pane or SSH disconnect also leaked runner containers. Containers stuck in `created` state were missed by the prune logic entirely.

- **Solution:** Label service containers with `agent-ci.pid` at creation. Update `killOrphanedContainers` to clean up unlabeled containers and derive runner names from svc container names (`agent-ci-2307-j2-svc-cache-db` → `agent-ci-2307-j2`) with deduplication. Add SIGHUP to signal handlers. Extend prune to cover `status=created` containers.

## Changes

- `service-containers.ts` — Add `agent-ci.pid` label to `createContainer` call
- `shutdown.ts` — `killOrphanedContainers`: clean unlabeled containers, extract runner name from svc names, deduplicate. `pruneOrphanedDockerResources`: also filter `status=created`
- `local-job.ts` + `cli.ts` — Add SIGHUP to signal handler registration/removal
- Tests — verify label is set on service containers, verify unlabeled containers are cleaned, verify svc→runner name derivation, verify deduplication

## Test plan

- [x] `vitest run packages/cli/src/docker/shutdown.test.ts` — 13 tests pass
- [x] `vitest run packages/cli/src/docker/service-containers.test.ts` — 20 tests pass
- [ ] Manual: verify orphaned svc containers from previous runs get cleaned on next `agent-ci run`

Fixes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)