### PR TITLE
fix: setup-bun cache collision

### DIFF
--- a/.github/workflows/smoke-bun-setup.yml
+++ b/.github/workflows/smoke-bun-setup.yml
@@ -1,0 +1,100 @@
+name: "Smoke: oven-sh/setup-bun cache collision"
+
+# Reproduces #212 — oven-sh/setup-bun@v2 fails in bun projects because
+# virtualCachePatterns returns a fake cache hit for setup-bun's binary cache.
+#
+# When a project uses bun (bun.lock detected), virtualCachePatterns is set to
+# ["bun"]. The setup-bun action uses cache keys of the form `bun-<sha1>`, and
+# since "bun" is a substring of that key, the DTU returns a synthetic 45-byte
+# cache hit. The action thinks the binary is cached but no bun executable
+# exists, so it fails with:
+#
+#   Error: Unable to locate executable file: /home/runner/.bun/bin/bun.
+#
+# A second issue compounds the failure: the bind mount for
+# .bun/install/cache creates /home/runner/.bun as root, so even if the
+# virtual cache issue were bypassed, setup-bun would fail with EACCES
+# when trying to mkdir /home/runner/.bun/bin.
+#
+# This smoke test creates a temporary bun project (with bun.lock at the
+# repo root so PM detection returns "bun") and runs agent-ci against a
+# workflow that uses oven-sh/setup-bun@v2.
+
+on:
+  pull_request_target:
+    types: [opened, labeled, synchronize]
+
+jobs:
+  bun-setup:
+    if: '!github.event.pull_request.draft && (contains(fromJSON(''["MEMBER", "OWNER", "COLLABORATOR"]''), github.event.pull_request.author_association) || contains(github.event.pull_request.labels.*.name, ''safe-to-run''))'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - run: pnpm install
+
+      - name: Build agent-ci
+        run: pnpm --filter @redwoodjs/agent-ci... -r build
+
+      - name: Create temp bun project
+        run: |
+          mkdir -p /tmp/bun-repro/.github/workflows
+
+          # Minimal bun.lock so detectPackageManager() returns "bun"
+          cat > /tmp/bun-repro/bun.lock << 'LOCK'
+          {
+            "lockfileVersion": 1,
+            "workspaces": {
+              "": { "name": "bun-repro" }
+            },
+            "packages": {}
+          }
+          LOCK
+
+          cat > /tmp/bun-repro/package.json << 'PKG'
+          { "name": "bun-repro", "private": true }
+          PKG
+
+          # Inner workflow: the one agent-ci will execute inside a container
+          cat > /tmp/bun-repro/.github/workflows/test.yml << 'WF'
+          name: Test
+          on: push
+          jobs:
+            test:
+              runs-on: ubuntu-latest
+              steps:
+                - uses: oven-sh/setup-bun@v2
+                  with:
+                    bun-version: "1.2.12"
+                - name: Verify bun
+                  run: |
+                    bun --version
+                    echo "bun is working"
+          WF
+
+          # agent-ci needs a git repo with a remote to resolve the repo slug
+          cd /tmp/bun-repro
+          git init
+          git remote add origin https://github.com/test-org/bun-repro.git
+          git add -A
+          git -c user.name="test" -c user.email="test@test.com" commit -m "init"
+
+      - name: Run agent-ci against bun project
+        working-directory: /tmp/bun-repro
+        run: |
+          node "$GITHUB_WORKSPACE/packages/cli/dist/cli.js" \
+            run --workflow .github/workflows/test.yml --quiet

--- a/packages/cli/src/docker/container-config.test.ts
+++ b/packages/cli/src/docker/container-config.test.ts
@@ -73,7 +73,7 @@ describe("buildContainerBinds", () => {
     expect(binds).toContain("/tmp/warm:/home/runner/_work/repo/repo/node_modules");
     expect(binds).toContain("/tmp/pnpm:/home/runner/_work/.pnpm-store");
     expect(binds).toContain("/tmp/npm:/home/runner/.npm");
-    expect(binds).toContain("/tmp/bun:/home/runner/.bun/install/cache");
+    expect(binds).toContain("/tmp/bun:/home/runner/.bun");
     // Standard mode should NOT include runner home bind (but _work bind is expected)
     expect(binds.some((b) => b.endsWith(":/home/runner"))).toBe(false);
   });
@@ -95,7 +95,7 @@ describe("buildContainerBinds", () => {
     expect(binds).toContain("/tmp/work:/home/runner/_work");
     expect(binds.some((b) => b.includes(".pnpm-store"))).toBe(false);
     expect(binds.some((b) => b.includes("/.npm"))).toBe(false);
-    expect(binds.some((b) => b.includes(".bun"))).toBe(false);
+    expect(binds.some((b) => b.includes("/.bun"))).toBe(false);
   });
 
   it("includes only the npm bind mount when only npmCacheDir is provided", async () => {

--- a/packages/cli/src/docker/container-config.ts
+++ b/packages/cli/src/docker/container-config.ts
@@ -116,7 +116,7 @@ export function buildContainerBinds(opts: ContainerBindsOpts): string[] {
     // Package manager caches (persist across runs, only for detected PM)
     ...(pnpmStoreDir ? [`${h(pnpmStoreDir)}:/home/runner/_work/.pnpm-store`] : []),
     ...(npmCacheDir ? [`${h(npmCacheDir)}:/home/runner/.npm`] : []),
-    ...(bunCacheDir ? [`${h(bunCacheDir)}:/home/runner/.bun/install/cache`] : []),
+    ...(bunCacheDir ? [`${h(bunCacheDir)}:/home/runner/.bun`] : []),
     `${h(playwrightCacheDir)}:/home/runner/.cache/ms-playwright`,
     // Warm node_modules: mounted directly at the workspace node_modules path
     // so pnpm/esbuild path resolution sees a real directory (not a symlink).

--- a/packages/cli/src/runner/directory-setup.test.ts
+++ b/packages/cli/src/runner/directory-setup.test.ts
@@ -196,7 +196,7 @@ describe("buildContainerBinds — PM-scoped mounts", () => {
 
     expect(binds).toContain("/tmp/npm-cache:/home/runner/.npm");
     expect(binds.some((b) => b.includes(".pnpm-store"))).toBe(false);
-    expect(binds.some((b) => b.includes(".bun/install"))).toBe(false);
+    expect(binds.some((b) => b.includes("/.bun"))).toBe(false);
   });
 
   it("pnpm project: only mounts .pnpm-store, no .npm or .bun", async () => {
@@ -218,7 +218,7 @@ describe("buildContainerBinds — PM-scoped mounts", () => {
 
     expect(binds).toContain("/tmp/pnpm-store:/home/runner/_work/.pnpm-store");
     expect(binds.some((b) => b.includes("/.npm"))).toBe(false);
-    expect(binds.some((b) => b.includes(".bun/install"))).toBe(false);
+    expect(binds.some((b) => b.includes("/.bun"))).toBe(false);
   });
 
   it("bun project: only mounts .bun, no .pnpm-store or .npm", async () => {
@@ -238,7 +238,7 @@ describe("buildContainerBinds — PM-scoped mounts", () => {
       githubRepo: "org/repo",
     });
 
-    expect(binds).toContain("/tmp/bun-cache:/home/runner/.bun/install/cache");
+    expect(binds).toContain("/tmp/bun-cache:/home/runner/.bun");
     expect(binds.some((b) => b.includes(".pnpm-store"))).toBe(false);
     expect(binds.some((b) => b.includes("/.npm"))).toBe(false);
   });
@@ -261,6 +261,6 @@ describe("buildContainerBinds — PM-scoped mounts", () => {
 
     expect(binds.some((b) => b.includes(".pnpm-store"))).toBe(false);
     expect(binds.some((b) => b.includes("/.npm"))).toBe(false);
-    expect(binds.some((b) => b.includes(".bun/install"))).toBe(false);
+    expect(binds.some((b) => b.includes("/.bun"))).toBe(false);
   });
 });

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -232,7 +232,13 @@ export async function executeLocalJob(
       // no need for the runner to tar/gzip them. Tell the DTU to return a
       // synthetic hit for any cache key matching these patterns — skipping the
       // 60s+ tar entirely.
-      virtualCachePatterns: dirs.detectedPM ? [dirs.detectedPM] : ["pnpm", "npm", "yarn", "bun"],
+      // "bun" is excluded: it collides with oven-sh/setup-bun cache keys
+      // (format `bun-<sha1>`), causing a fake hit that hides the real binary.
+      virtualCachePatterns: dirs.detectedPM
+        ? dirs.detectedPM === "bun"
+          ? []
+          : [dirs.detectedPM]
+        : ["pnpm", "npm", "yarn"],
     }),
   }).catch(() => {
     /* non-fatal */


### PR DESCRIPTION
Closes #212.

## Problem

`oven-sh/setup-bun@v2` fails in bun projects. Two things go wrong:

1. **Fake cache hit.** We tell the runner "if you see a cache key with `bun` in the name, don't bother — I already have it." But setup-bun also uses cache keys with `bun` in the name (for downloading the bun binary itself). So the runner thinks bun is already installed, but it's not — it got an empty file instead.

2. **Permission error.** We mount a folder deep inside `.bun/install/cache`. Docker creates the parent `.bun` folder as root to get there. When setup-bun tries to create `.bun/bin`, it gets "permission denied" because it doesn't own that folder.

## Solution

1. **Stop saying "bun" is cached.** Remove `"bun"` from `virtualCachePatterns`. The other package managers (pnpm, npm, yarn) don't have this collision because their setup actions use different names. Bun is the only one where the PM name and the tool name overlap.

2. **Mount at `.bun` instead of `.bun/install/cache`.** Docker doesn't need to create any parent folders — the mount point itself is the folder, and it has the right permissions.

## Reproduction

```
$ cd /tmp/bun-repro
$ agent-ci-dev run --workflow .github/workflows/test.yml -q

  ✗ Run oven-sh/setup-bun@v2

━━━ SUMMARY ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  Status:    ✗ 1 failed, 0 passed (1 total)
```

After the fix:

```
  Status:    ✓ 1 passed (1 total)
  Duration:  14s
```

## Test plan

- [x] Unit tests pass (508/508)
- [x] Smoke test reproduces the bug before fix, passes after
- [x] CI smoke workflow (`smoke-bun-setup.yml`) passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)