### PR TITLE
fix: exclude test files from published dist

### DIFF
--- a/.changeset/exclude-tests-dist.md
+++ b/.changeset/exclude-tests-dist.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Exclude test files from published dist by adding tsconfig exclude for `*.test.ts`.

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -10,5 +10,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*", "scripts/**/*"]
+  "include": ["src/**/*", "scripts/**/*"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/dtu-github-actions/tsconfig.json
+++ b/packages/dtu-github-actions/tsconfig.json
@@ -11,5 +11,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- Add `"exclude": ["src/**/*.test.ts"]` to `packages/cli/tsconfig.json` and `packages/dtu-github-actions/tsconfig.json`
- Previously 35 test files were compiled into `dist/` and shipped in the npm package

## Test plan
- [x] `pnpm check` passes
- [x] All 563 tests pass
- [x] Clean rebuild confirms no `*.test.*` files in `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)