### PR TITLE
fix: nested agent-ci crashes and global concurrency limiter

### DIFF
--- a/apps/website/src/app/components/CopyAgentInstructions.tsx
+++ b/apps/website/src/app/components/CopyAgentInstructions.tsx
@@ -5,6 +5,24 @@ import { Copy, Check } from "lucide-react";
 
 const AGENT_INSTRUCTIONS = `## CI
 
+If this is a Node.js project, install Agent CI as a dev dependency using the project's package manager (npm, pnpm, yarn, or bun):
+
+\`\`\`bash
+<package-manager> install -D @redwoodjs/agent-ci
+\`\`\`
+
+If this is not a Node.js project, you can run Agent CI directly with npx:
+
+\`\`\`bash
+npx @redwoodjs/agent-ci
+\`\`\`
+
+Install the agent skill:
+
+\`\`\`bash
+npx skills add redwoodjs/agent-ci --skill agent-ci
+\`\`\`
+
 Before completing any work, run the \`agent-ci\` skill to validate your changes locally. If it fails, fix the issue and re-run. Do not report work as done until it passes.`;
 
 export function CopyAgentInstructions() {

--- a/apps/website/src/app/pages/home.tsx
+++ b/apps/website/src/app/pages/home.tsx
@@ -532,7 +532,7 @@ export const Home = () => {
             <Terminal
               title="Agent Instructions"
               language="markdown"
-              code={`## CI\n\nBefore completing any work, run the \`agent-ci\` skill to validate your changes locally. If it fails, fix the issue and re-run. Do not report work as done until it passes.`}
+              code={`## CI\n\nIf this is a Node.js project, install Agent CI as a dev dependency\nusing the project's package manager (npm, pnpm, yarn, or bun):\n\n\`\`\`bash\n<package-manager> install -D @redwoodjs/agent-ci\n\`\`\`\n\nIf this is not a Node.js project, you can run Agent CI directly\nwith npx:\n\n\`\`\`bash\nnpx @redwoodjs/agent-ci\n\`\`\`\n\nInstall the agent skill:\n\n\`\`\`bash\nnpx skills add redwoodjs/agent-ci --skill agent-ci\n\`\`\`\n\nBefore completing any work, run the \`agent-ci\` skill to validate\nyour changes locally. If it fails, fix the issue and re-run.\nDo not report work as done until it passes.`}
             />
 
             <p className="text-[#9bc5b3] mt-6 leading-relaxed">

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -68,6 +68,7 @@ Run GitHub Actions workflow jobs locally.
 | -------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `--workflow <path>`        | `-w`  | Path to the workflow file                                                                                                                                    |
 | `--all`                    | `-a`  | Discover and run all relevant workflows for the current branch                                                                                               |
+| `--jobs <n>`               | `-j`  | Max concurrent containers (overrides auto-detection)                                                                                                         |
 | `--pause-on-failure`       | `-p`  | Pause on step failure for interactive debugging                                                                                                              |
 | `--quiet`                  | `-q`  | Suppress animated rendering (also enabled by `AI_AGENT=1`)                                                                                                   |
 | `--no-matrix`              |       | Collapse all matrix combinations into a single job (uses first value of each key)                                                                            |
@@ -93,6 +94,29 @@ Abort a paused runner and tear down its container.
 | Flag            | Short | Description                                   |
 | --------------- | ----- | --------------------------------------------- |
 | `--name <name>` | `-n`  | Name of the paused runner to abort (required) |
+
+## Concurrency
+
+When running multiple workflows (`--all`), Agent CI limits how many containers run at the same time to avoid running out of memory.
+
+The limit is auto-detected using two factors:
+
+- **CPU**: `floor(cpuCount / 2)`
+- **Memory**: `floor(availableDockerMemory / 4GB)`
+
+Whichever is lower wins. For example, on a machine with 14 CPUs and a Docker VM with 12 GB of RAM, the CPU limit is 7 and the memory limit is 2 — so 2 containers run at a time.
+
+To check available memory, Agent CI reads `MemAvailable` from `/proc/meminfo` inside the Docker VM. This accounts for the VM's kernel, daemon, and any other running containers. If that fails, it falls back to `docker info` total memory minus 4 GB.
+
+You can override the auto-detected limit with `--jobs`:
+
+```bash
+# Run at most 4 containers at a time
+npx agent-ci run --all --jobs 4
+
+# Run one at a time (safest, slowest)
+npx agent-ci run --all --jobs 1
+```
 
 ## YAML Compatibility
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -463,6 +463,12 @@ async function runWorkflows(options: {
   pruneStaleWorkspaces(getWorkingDirectory(), 24 * 60 * 60 * 1000);
   await prefetchRunnerImages(workflowPaths);
 
+  // Global concurrency limiter shared across all workflows. Without this,
+  // --all mode launches every workflow in parallel — leading to 20+
+  // simultaneous containers that exhaust available memory and trigger
+  // OOM kills (exit 137). See issue #225.
+  const globalLimiter = createConcurrencyLimiter(getDefaultMaxConcurrentJobs());
+
   try {
     const allResults: JobResult[] = [];
 
@@ -475,6 +481,7 @@ async function runWorkflows(options: {
         noMatrix,
         store,
         githubToken,
+        globalLimiter,
       });
       allResults.push(...results);
     } else {
@@ -513,6 +520,7 @@ async function runWorkflows(options: {
           store,
           baseRunNum: runNums[0],
           githubToken,
+          globalLimiter,
         });
         allResults.push(...firstResults);
 
@@ -526,6 +534,7 @@ async function runWorkflows(options: {
               store,
               baseRunNum: runNums[i + 1],
               githubToken,
+              globalLimiter,
             }),
           ),
         );
@@ -547,6 +556,7 @@ async function runWorkflows(options: {
               store,
               baseRunNum: runNums[i],
               githubToken,
+              globalLimiter,
             }),
           ),
         );
@@ -592,6 +602,7 @@ async function handleWorkflow(options: {
   store: RunStateStore;
   baseRunNum?: number;
   githubToken?: string;
+  globalLimiter: ReturnType<typeof createConcurrencyLimiter>;
 }): Promise<JobResult[]> {
   const { sha, pauseOnFailure, noMatrix = false, store, githubToken } = options;
   let workflowPath = options.workflowPath;
@@ -744,12 +755,14 @@ async function handleWorkflow(options: {
       taskId: ej.taskName,
     };
 
-    const result = await executeLocalJob(job, { pauseOnFailure, store });
+    const result = await options.globalLimiter.run(() =>
+      executeLocalJob(job, { pauseOnFailure, store }),
+    );
     return [result];
   }
 
   // ── Multi-job orchestration ────────────────────────────────────────────────
-  const maxJobs = getDefaultMaxConcurrentJobs();
+  const limiter = options.globalLimiter;
 
   // ── Warm-cache check ───────────────────────────────────────────────────────
   const repoSlug = githubRepo.replace("/", "-");
@@ -890,7 +903,6 @@ async function handleWorkflow(options: {
     return result;
   };
 
-  const limiter = createConcurrencyLimiter(maxJobs);
   const allResults: JobResult[] = [];
   // Accumulate job outputs across waves for needs.*.outputs.* resolution
   const jobOutputs = new Map<string, Record<string, string>>();
@@ -1061,7 +1073,7 @@ async function handleWorkflow(options: {
     // ── Warm-cache serialization for the first wave ────────────────────────
     if (!warm && wi === 0 && waveJobs.length > 1) {
       debugCli("Cold cache — running first job to populate warm modules...");
-      const firstResult = await runOrSkipJob(waveJobs[0]);
+      const firstResult = await limiter.run(() => runOrSkipJob(waveJobs[0]));
       allResults.push(firstResult);
 
       const results = await Promise.allSettled(

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -87,6 +87,7 @@ async function run() {
     let noMatrix = false;
     let githubToken: string | undefined;
     let commitStatus = false;
+    let maxJobs: number | undefined;
 
     for (let i = 1; i < args.length; i++) {
       if ((args[i] === "--workflow" || args[i] === "-w") && args[i + 1]) {
@@ -100,6 +101,13 @@ async function run() {
         setQuietMode(true);
       } else if (args[i] === "--no-matrix") {
         noMatrix = true;
+      } else if ((args[i] === "--jobs" || args[i] === "-j") && args[i + 1]) {
+        maxJobs = parseInt(args[i + 1], 10);
+        if (!Number.isFinite(maxJobs) || maxJobs < 1) {
+          console.error("[Agent CI] Error: --jobs must be a positive integer");
+          process.exit(1);
+        }
+        i++;
       } else if (args[i] === "--commit-status") {
         commitStatus = true;
       } else if (args[i] === "--github-token") {
@@ -197,6 +205,7 @@ async function run() {
         pauseOnFailure,
         noMatrix,
         githubToken,
+        maxJobs,
       });
       if (results.length > 0) {
         printSummary(results);
@@ -237,6 +246,7 @@ async function run() {
       pauseOnFailure,
       noMatrix,
       githubToken,
+      maxJobs,
     });
     if (results.length > 0) {
       printSummary(results);
@@ -366,6 +376,7 @@ async function runWorkflows(options: {
   pauseOnFailure: boolean;
   noMatrix?: boolean;
   githubToken?: string;
+  maxJobs?: number;
 }): Promise<JobResult[]> {
   const { workflowPaths, sha, pauseOnFailure, noMatrix = false, githubToken } = options;
 
@@ -467,7 +478,7 @@ async function runWorkflows(options: {
   // --all mode launches every workflow in parallel — leading to 20+
   // simultaneous containers that exhaust available memory and trigger
   // OOM kills (exit 137). See issue #225.
-  const globalLimiter = createConcurrencyLimiter(getDefaultMaxConcurrentJobs());
+  const globalLimiter = createConcurrencyLimiter(options.maxJobs ?? getDefaultMaxConcurrentJobs());
 
   try {
     const allResults: JobResult[] = [];
@@ -1170,6 +1181,9 @@ function printUsage() {
   console.log("Options:");
   console.log("  -w, --workflow <path>         Path to the workflow file");
   console.log("  -a, --all                     Discover and run all relevant workflows");
+  console.log(
+    "  -j, --jobs <n>                Max concurrent containers (auto-detected from CPU/memory)",
+  );
   console.log("  -p, --pause-on-failure         Pause on step failure for interactive debugging");
   console.log(
     "  -q, --quiet                   Suppress animated rendering (also enabled by AI_AGENT=1)",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -452,8 +452,14 @@ async function runWorkflows(options: {
   // parallel, running these inside handleWorkflow() hammered the Docker
   // daemon (N× `docker volume prune`, N× cold-start image pulls) and
   // serialized work that should have been free. See issue #211.
-  pruneOrphanedDockerResources();
-  killOrphanedContainers();
+  // Skip Docker cleanup when running nested inside a container (e.g.
+  // smoke-bun-setup step 8). The shared Docker socket exposes the host's
+  // containers, and killOrphanedContainers would kill our parent container
+  // because host PIDs don't exist in the container's PID namespace.
+  if (!fs.existsSync("/.dockerenv")) {
+    pruneOrphanedDockerResources();
+    killOrphanedContainers();
+  }
   pruneStaleWorkspaces(getWorkingDirectory(), 24 * 60 * 60 * 1000);
   await prefetchRunnerImages(workflowPaths);
 

--- a/packages/cli/src/docker/container-config.ts
+++ b/packages/cli/src/docker/container-config.ts
@@ -194,12 +194,18 @@ function parseCsvEnv(value: string): string[] {
 }
 
 export async function resolveDtuHost(): Promise<string> {
+  const isInsideDocker = fs.existsSync("/.dockerenv");
+
+  // When running inside a container (nested agent-ci), ignore the inherited
+  // AGENT_CI_DTU_HOST — it points to the parent's DTU host (e.g.
+  // "host.docker.internal") which isn't reachable from sibling containers.
+  // Instead, resolve this container's own IP so the inner container can
+  // connect back to our DTU.
   const configuredHost = process.env.AGENT_CI_DTU_HOST?.trim();
-  if (configuredHost) {
+  if (configuredHost && !isInsideDocker) {
     return configuredHost;
   }
 
-  const isInsideDocker = fs.existsSync("/.dockerenv");
   if (isInsideDocker) {
     try {
       const ip = execSync("hostname -I 2>/dev/null | awk '{print $1}'", {

--- a/packages/cli/src/docker/shutdown.test.ts
+++ b/packages/cli/src/docker/shutdown.test.ts
@@ -350,100 +350,109 @@ function dockerAvailable(): boolean {
   }
 }
 
-describe.skipIf(!dockerAvailable())("killOrphanedContainers (Docker integration)", () => {
-  const containerName = "agent-ci-orphan-smoke-svc-testdb";
-  const runnerName = "agent-ci-orphan-smoke";
+function insideDocker(): boolean {
+  return fs.existsSync("/.dockerenv");
+}
 
-  // Import the real function eagerly, outside vitest's mock system.
-  // The unit tests above use vi.doMock("node:child_process") which poisons
-  // dynamic imports even after vi.resetModules()/vi.unmock(). Spawning a
-  // fresh node process sidesteps that entirely — and this IS a smoke test,
-  // so exercising the real module resolution path is a feature, not a hack.
-  function runKillOrphanedContainers() {
-    execSync(
-      `npx tsx -e "import { killOrphanedContainers } from './src/docker/shutdown.ts'; killOrphanedContainers();"`,
-      { stdio: "pipe" },
-    );
-  }
+// Skip inside containers: killOrphanedContainers bails when /.dockerenv
+// exists (PID namespace mismatch), so integration tests can't exercise it.
+describe.skipIf(!dockerAvailable() || insideDocker())(
+  "killOrphanedContainers (Docker integration)",
+  () => {
+    const containerName = "agent-ci-orphan-smoke-svc-testdb";
+    const runnerName = "agent-ci-orphan-smoke";
 
-  afterEach(() => {
-    // Belt-and-suspenders: ensure we don't leak the test container
-    try {
-      execSync(`docker rm -f ${containerName}`, { stdio: "pipe" });
-    } catch {
-      // already gone — good
+    // Import the real function eagerly, outside vitest's mock system.
+    // The unit tests above use vi.doMock("node:child_process") which poisons
+    // dynamic imports even after vi.resetModules()/vi.unmock(). Spawning a
+    // fresh node process sidesteps that entirely — and this IS a smoke test,
+    // so exercising the real module resolution path is a feature, not a hack.
+    function runKillOrphanedContainers() {
+      execSync(
+        `npx tsx -e "import { killOrphanedContainers } from './src/docker/shutdown.ts'; killOrphanedContainers();"`,
+        { stdio: "pipe" },
+      );
     }
-    try {
-      execSync(`docker network rm agent-ci-net-${runnerName}`, { stdio: "pipe" });
-    } catch {
-      // already gone
-    }
-  });
 
-  it("cleans up an unlabeled service container", () => {
-    // Create a container that mimics a leaked pre-fix service container: no agent-ci.pid label
-    execSync(`docker create --name ${containerName} busybox sleep 300`, { stdio: "pipe" });
-    execSync(`docker start ${containerName}`, { stdio: "pipe" });
+    afterEach(() => {
+      // Belt-and-suspenders: ensure we don't leak the test container
+      try {
+        execSync(`docker rm -f ${containerName}`, { stdio: "pipe" });
+      } catch {
+        // already gone — good
+      }
+      try {
+        execSync(`docker network rm agent-ci-net-${runnerName}`, { stdio: "pipe" });
+      } catch {
+        // already gone
+      }
+    });
 
-    // Confirm it's running
-    const before = execSync(
-      `docker ps -q --filter "name=${containerName}" --filter "status=running"`,
-      { encoding: "utf8", stdio: "pipe" },
-    ).trim();
-    expect(before).not.toBe("");
+    it("cleans up an unlabeled service container", () => {
+      // Create a container that mimics a leaked pre-fix service container: no agent-ci.pid label
+      execSync(`docker create --name ${containerName} busybox sleep 300`, { stdio: "pipe" });
+      execSync(`docker start ${containerName}`, { stdio: "pipe" });
 
-    runKillOrphanedContainers();
+      // Confirm it's running
+      const before = execSync(
+        `docker ps -q --filter "name=${containerName}" --filter "status=running"`,
+        { encoding: "utf8", stdio: "pipe" },
+      ).trim();
+      expect(before).not.toBe("");
 
-    // Container should be gone
-    const after = execSync(`docker ps -aq --filter "name=${containerName}"`, {
-      encoding: "utf8",
-      stdio: "pipe",
-    }).trim();
-    expect(after).toBe("");
-  });
+      runKillOrphanedContainers();
 
-  it("cleans up a labeled service container whose parent PID is dead", () => {
-    // Use a PID that's guaranteed dead (PID 2^22 - 1 is extremely unlikely to exist)
-    const deadPid = "4194303";
+      // Container should be gone
+      const after = execSync(`docker ps -aq --filter "name=${containerName}"`, {
+        encoding: "utf8",
+        stdio: "pipe",
+      }).trim();
+      expect(after).toBe("");
+    });
 
-    execSync(
-      `docker create --name ${containerName} --label "agent-ci.pid=${deadPid}" busybox sleep 300`,
-      { stdio: "pipe" },
-    );
-    execSync(`docker start ${containerName}`, { stdio: "pipe" });
+    it("cleans up a labeled service container whose parent PID is dead", () => {
+      // Use a PID that's guaranteed dead (PID 2^22 - 1 is extremely unlikely to exist)
+      const deadPid = "4194303";
 
-    const before = execSync(
-      `docker ps -q --filter "name=${containerName}" --filter "status=running"`,
-      { encoding: "utf8", stdio: "pipe" },
-    ).trim();
-    expect(before).not.toBe("");
+      execSync(
+        `docker create --name ${containerName} --label "agent-ci.pid=${deadPid}" busybox sleep 300`,
+        { stdio: "pipe" },
+      );
+      execSync(`docker start ${containerName}`, { stdio: "pipe" });
 
-    runKillOrphanedContainers();
+      const before = execSync(
+        `docker ps -q --filter "name=${containerName}" --filter "status=running"`,
+        { encoding: "utf8", stdio: "pipe" },
+      ).trim();
+      expect(before).not.toBe("");
 
-    const after = execSync(`docker ps -aq --filter "name=${containerName}"`, {
-      encoding: "utf8",
-      stdio: "pipe",
-    }).trim();
-    expect(after).toBe("");
-  });
+      runKillOrphanedContainers();
 
-  it("does NOT kill a service container whose parent PID is alive", () => {
-    // Label with our own PID — should be left alone
-    const myPid = String(process.pid);
+      const after = execSync(`docker ps -aq --filter "name=${containerName}"`, {
+        encoding: "utf8",
+        stdio: "pipe",
+      }).trim();
+      expect(after).toBe("");
+    });
 
-    execSync(
-      `docker create --name ${containerName} --label "agent-ci.pid=${myPid}" busybox sleep 300`,
-      { stdio: "pipe" },
-    );
-    execSync(`docker start ${containerName}`, { stdio: "pipe" });
+    it("does NOT kill a service container whose parent PID is alive", () => {
+      // Label with our own PID — should be left alone
+      const myPid = String(process.pid);
 
-    runKillOrphanedContainers();
+      execSync(
+        `docker create --name ${containerName} --label "agent-ci.pid=${myPid}" busybox sleep 300`,
+        { stdio: "pipe" },
+      );
+      execSync(`docker start ${containerName}`, { stdio: "pipe" });
 
-    // Container should still be running
-    const after = execSync(
-      `docker ps -q --filter "name=${containerName}" --filter "status=running"`,
-      { encoding: "utf8", stdio: "pipe" },
-    ).trim();
-    expect(after).not.toBe("");
-  });
-});
+      runKillOrphanedContainers();
+
+      // Container should still be running
+      const after = execSync(
+        `docker ps -q --filter "name=${containerName}" --filter "status=running"`,
+        { encoding: "utf8", stdio: "pipe" },
+      ).trim();
+      expect(after).not.toBe("");
+    });
+  },
+);

--- a/packages/cli/src/docker/shutdown.test.ts
+++ b/packages/cli/src/docker/shutdown.test.ts
@@ -123,12 +123,23 @@ describe("Stale workspace pruning", () => {
 describe("killOrphanedContainers", () => {
   const execSyncMock = vi.fn();
   const killSpy = vi.spyOn(process, "kill");
+  const existsSyncMock = vi.fn();
 
   beforeEach(() => {
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
       execSync: execSyncMock,
     }));
+    // Mock fs so /.dockerenv check doesn't skip the function inside containers
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        default: { ...actual, existsSync: existsSyncMock },
+        existsSync: existsSyncMock,
+      };
+    });
+    existsSyncMock.mockReturnValue(false);
     execSyncMock.mockReset();
     killSpy.mockReset();
   });

--- a/packages/cli/src/docker/shutdown.ts
+++ b/packages/cli/src/docker/shutdown.ts
@@ -56,6 +56,12 @@ export function killRunnerContainers(runnerName: string): void {
  * exhausting its address pool ("all predefined address pools have been fully subnetted").
  */
 export function pruneOrphanedDockerResources(): void {
+  // Skip when running inside a Docker container — we share the host's
+  // Docker socket, so pruning would remove the host's containers/networks.
+  if (fs.existsSync("/.dockerenv")) {
+    return;
+  }
+
   // 1. Remove stopped/stale agent-ci-* containers (runners + sidecars) so their
   //    network references are released before we try to prune networks.
   //    Includes both "exited" and "created" (never started) containers.
@@ -121,6 +127,14 @@ export function pruneOrphanedDockerResources(): void {
  * containers or service containers created before the label was added.
  */
 export function killOrphanedContainers(): void {
+  // Skip when running inside a Docker container (e.g. nested agent-ci or
+  // integration tests inside a runner container). The pid labels reference
+  // host PIDs which don't exist in the container's PID namespace — every
+  // container would look like an orphan, including our own parent.
+  if (fs.existsSync("/.dockerenv")) {
+    return;
+  }
+
   let lines: string[];
   try {
     // Format: "containerId containerName pid-label"

--- a/packages/cli/src/docker/shutdown.ts
+++ b/packages/cli/src/docker/shutdown.ts
@@ -56,6 +56,13 @@ export function killRunnerContainers(runnerName: string): void {
  * exhausting its address pool ("all predefined address pools have been fully subnetted").
  */
 export function pruneOrphanedDockerResources(): void {
+  // Skip when running inside a Docker container (e.g. nested agent-ci).
+  // We share the host's Docker socket, so pruning would remove containers
+  // and networks that belong to the host's agent-ci process.
+  if (fs.existsSync("/.dockerenv")) {
+    return;
+  }
+
   // 1. Remove stopped/stale agent-ci-* containers (runners + sidecars) so their
   //    network references are released before we try to prune networks.
   //    Includes both "exited" and "created" (never started) containers.
@@ -121,6 +128,14 @@ export function pruneOrphanedDockerResources(): void {
  * containers or service containers created before the label was added.
  */
 export function killOrphanedContainers(): void {
+  // Skip when running inside a Docker container (e.g. nested agent-ci).
+  // The pid labels reference host PIDs which don't exist in the container's
+  // PID namespace — every container would look like an orphan, and we'd
+  // kill our own parent container.
+  if (fs.existsSync("/.dockerenv")) {
+    return;
+  }
+
   let lines: string[];
   try {
     // Format: "containerId containerName pid-label"

--- a/packages/cli/src/docker/shutdown.ts
+++ b/packages/cli/src/docker/shutdown.ts
@@ -56,13 +56,6 @@ export function killRunnerContainers(runnerName: string): void {
  * exhausting its address pool ("all predefined address pools have been fully subnetted").
  */
 export function pruneOrphanedDockerResources(): void {
-  // Skip when running inside a Docker container (e.g. nested agent-ci).
-  // We share the host's Docker socket, so pruning would remove containers
-  // and networks that belong to the host's agent-ci process.
-  if (fs.existsSync("/.dockerenv")) {
-    return;
-  }
-
   // 1. Remove stopped/stale agent-ci-* containers (runners + sidecars) so their
   //    network references are released before we try to prune networks.
   //    Includes both "exited" and "created" (never started) containers.
@@ -128,14 +121,6 @@ export function pruneOrphanedDockerResources(): void {
  * containers or service containers created before the label was added.
  */
 export function killOrphanedContainers(): void {
-  // Skip when running inside a Docker container (e.g. nested agent-ci).
-  // The pid labels reference host PIDs which don't exist in the container's
-  // PID namespace — every container would look like an orphan, and we'd
-  // kill our own parent container.
-  if (fs.existsSync("/.dockerenv")) {
-    return;
-  }
-
   let lines: string[];
   try {
     // Format: "containerId containerName pid-label"

--- a/packages/cli/src/output/concurrency.test.ts
+++ b/packages/cli/src/output/concurrency.test.ts
@@ -106,10 +106,10 @@ describe("getDefaultMaxConcurrentJobs", () => {
     expect(result).toBeGreaterThanOrEqual(1);
   });
 
-  it("returns a reasonable number for the current host", () => {
+  it("returns at most floor(cpuCount / 2)", () => {
     const result = getDefaultMaxConcurrentJobs();
     const os = require("os");
-    const expected = Math.max(1, Math.floor(os.cpus().length / 2));
-    expect(result).toBe(expected);
+    const cpuLimit = Math.max(1, Math.floor(os.cpus().length / 2));
+    expect(result).toBeLessThanOrEqual(cpuLimit);
   });
 });

--- a/packages/cli/src/output/concurrency.ts
+++ b/packages/cli/src/output/concurrency.ts
@@ -1,4 +1,5 @@
 import os from "node:os";
+import { execSync } from "node:child_process";
 
 /**
  * A simple Promise-based semaphore that limits how many async tasks
@@ -52,10 +53,66 @@ export function createConcurrencyLimiter(max: number) {
 }
 
 /**
- * Determine the default max concurrent jobs based on the host CPU count.
- * Returns floor(cpuCount / 2), with a minimum of 1.
+ * Read MemAvailable from inside the Docker VM via /proc/meminfo.
+ * This reflects actual free memory accounting for kernel, daemon, caches,
+ * and any already-running containers — no hardcoded reserve needed.
+ *
+ * Falls back to `docker info` MemTotal with a conservative reserve if
+ * the busybox approach fails (e.g. busybox not pulled).
+ */
+function getDockerAvailableMemoryBytes(): number | undefined {
+  try {
+    const raw = execSync("docker run --rm busybox grep MemAvailable /proc/meminfo", {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 10_000,
+    }).trim();
+    const match = raw.match(/MemAvailable:\s+(\d+)\s+kB/);
+    if (match) {
+      return Number(match[1]) * 1024;
+    }
+  } catch {
+    // busybox not available — fall back to docker info
+  }
+
+  try {
+    const raw = execSync("docker info --format '{{.MemTotal}}'", {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 5_000,
+    }).trim();
+    const bytes = Number(raw);
+    if (Number.isFinite(bytes) && bytes > 0) {
+      return Math.max(0, bytes - 4 * 1024 * 1024 * 1024);
+    }
+  } catch {
+    // Docker not reachable
+  }
+
+  return undefined;
+}
+
+/** Estimated memory per container: runner binary + Ubuntu + typical workload. */
+const BYTES_PER_CONTAINER = 3 * 1024 * 1024 * 1024; // 3 GB
+
+/**
+ * Determine the default max concurrent jobs based on CPU count and available
+ * Docker memory. Takes the minimum of both to avoid OOM kills.
+ *
+ * - CPU-based: floor(cpuCount / 2)
+ * - Memory-based: floor(availableMemory / perContainer)
+ *
+ * Minimum of 1.
  */
 export function getDefaultMaxConcurrentJobs(): number {
   const cpuCount = os.cpus().length;
-  return Math.max(1, Math.floor(cpuCount / 2));
+  const cpuLimit = Math.floor(cpuCount / 2);
+
+  const availableMem = getDockerAvailableMemoryBytes();
+  if (availableMem == null) {
+    return Math.max(1, cpuLimit);
+  }
+
+  const memLimit = Math.floor(availableMem / BYTES_PER_CONTAINER);
+  return Math.max(1, Math.min(cpuLimit, memLimit));
 }

--- a/packages/cli/src/output/concurrency.ts
+++ b/packages/cli/src/output/concurrency.ts
@@ -92,8 +92,8 @@ function getDockerAvailableMemoryBytes(): number | undefined {
   return undefined;
 }
 
-/** Estimated memory per container: runner binary + Ubuntu + typical workload. */
-const BYTES_PER_CONTAINER = 3 * 1024 * 1024 * 1024; // 3 GB
+/** Estimated memory per container: runner binary + Ubuntu + heavy workloads (vitest, full builds). */
+const BYTES_PER_CONTAINER = 4 * 1024 * 1024 * 1024; // 4 GB
 
 /**
  * Determine the default max concurrent jobs based on CPU count and available


### PR DESCRIPTION
## Problem

Running `agent-ci --all` crashes containers that work fine individually. Three things go wrong:

**1. Nested agent-ci kills its own parent container**

Some smoke tests (like `smoke-bun-setup`) run agent-ci *inside* a container. On startup, agent-ci checks for orphaned containers by looking at PID labels. But inside a container, host PIDs don't exist — so every container looks like an orphan. Agent-ci kills them all, including the container it's running in.

**2. Nested containers can't reach the DTU server**

The outer container tells the inner container to connect to `host.docker.internal` for the DTU. But the DTU is running inside the outer container, not on the host. The inner container gets "Connection refused" and retries forever.

**3. Too many containers run at once**

In `--all` mode, every workflow launches in parallel. Each workflow has its own concurrency limit, but there's nothing stopping all 17 workflows from starting at the same time. 20+ containers fight for 12 GB of RAM and the kernel kills them (exit 137).

## Solution

**1.** Skip orphan cleanup when `/.dockerenv` exists — PID checks are meaningless across namespaces.

**2.** When inside a container, ignore the inherited `AGENT_CI_DTU_HOST` and use the container's own IP instead. Sibling containers can reach it directly.

**3.** One shared concurrency limiter across all workflows. The limit is auto-detected from Docker VM memory: `floor(availableMemory / 4GB per container)`. On a 12 GB setup this gives 2 concurrent containers.

## Test plan

- [x] `pnpm check` passes
- [x] All 511 unit tests pass
- [x] `pnpm agent-ci-dev run --all` — 24/24 passed

Closes #225, closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)