### PR TITLE
docs: simplify usage to npx @redwoodjs/agent-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,14 @@ Agent CI does not re-implement GitHub Actions. It emulates the **server-side API
   - **macOS:** [OrbStack](https://orbstack.dev/) (recommended) or Docker Desktop
   - **Linux:** Native Docker Engine
 
-### Install
-
-```bash
-npm install -D @redwoodjs/agent-ci
-```
-
 ### Run
 
 ```bash
 # Run a specific workflow
-npx agent-ci run --workflow .github/workflows/ci.yml
+npx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml
 
 # Run all relevant workflows for the current branch
-npx agent-ci run --all
+npx @redwoodjs/agent-ci run --all
 ```
 
 Agent CI runs against your **current working tree** — uncommitted changes are included automatically. No need to commit or stash before running.
@@ -70,7 +64,7 @@ Agent CI runs against your **current working tree** — uncommitted changes are 
 ### Retry a failed step
 
 ```bash
-npx agent-ci retry --name <runner-name>
+npx @redwoodjs/agent-ci retry --name <runner-name>
 ```
 
 ---
@@ -116,7 +110,7 @@ Abort a paused runner and tear down its container.
 Agent CI connects to Docker via `DOCKER_HOST`. By default it uses the local socket, but you can point it at any remote daemon:
 
 ```bash
-DOCKER_HOST=ssh://user@remote-server npx agent-ci run --workflow .github/workflows/ci.yml
+DOCKER_HOST=ssh://user@remote-server npx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml
 ```
 
 ### Docker host resolution for job containers
@@ -193,7 +187,7 @@ Set `DEBUG` to enable verbose logging. It accepts comma-separated glob patterns:
 | `DEBUG=agent-ci:cli,agent-ci:dtu` | Multiple namespaces           |
 
 ```bash
-DEBUG=agent-ci:* npx agent-ci run --workflow .github/workflows/ci.yml
+DEBUG=agent-ci:* npx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml
 ```
 
 Output goes to **stderr**. If `DEBUG` is unset, debug loggers are no-ops with zero overhead.
@@ -212,6 +206,12 @@ This works with Claude Code, Cursor, Codex, and [40+ other agents](https://agent
 
 ```markdown
 ## CI
+
+Install the agent-ci skill (one-time setup):
+
+\`\`\`bash
+npx skills add redwoodjs/agent-ci --skill agent-ci
+\`\`\`
 
 Before completing any work, run the `agent-ci` skill to validate your changes locally. If it fails, fix the issue and re-run. Do not report work as done until it passes.
 ```

--- a/apps/website/src/app/components/CopyAgentInstructions.tsx
+++ b/apps/website/src/app/components/CopyAgentInstructions.tsx
@@ -5,19 +5,7 @@ import { Copy, Check } from "lucide-react";
 
 const AGENT_INSTRUCTIONS = `## CI
 
-If this is a Node.js project, install Agent CI as a dev dependency using the project's package manager (npm, pnpm, yarn, or bun):
-
-\`\`\`bash
-<package-manager> install -D @redwoodjs/agent-ci
-\`\`\`
-
-If this is not a Node.js project, you can run Agent CI directly with npx:
-
-\`\`\`bash
-npx @redwoodjs/agent-ci
-\`\`\`
-
-Install the agent skill:
+Install the agent-ci skill (one-time setup):
 
 \`\`\`bash
 npx skills add redwoodjs/agent-ci --skill agent-ci

--- a/apps/website/src/app/components/CopyAgentInstructions.tsx
+++ b/apps/website/src/app/components/CopyAgentInstructions.tsx
@@ -5,6 +5,24 @@ import { Copy, Check } from "lucide-react";
 
 const AGENT_INSTRUCTIONS = `## CI
 
+If this is a Node.js project, install Agent CI as a dev dependency using the project's package manager (npm, pnpm, yarn, or bun):
+
+\`\`\`bash
+<package-manager> install -D @redwoodjs/agent-ci
+\`\`\`
+
+If this is not a Node.js project, you can run Agent CI directly with npx:
+
+\`\`\`bash
+npx @redwoodjs/agent-ci
+\`\`\`
+
+Install the agent skill:
+
+\`\`\`bash
+npx skills add redwoodjs/agent-ci --skill agent-ci
+\`\`\`
+
 Before completing any work, run the \`agent-ci\` skill to validate your changes locally. If it fails, fix the issue and re-run. Do not report work as done until it passes.`;
 
 export function CopyAgentInstructions() {

--- a/apps/website/src/app/components/HeroSection.tsx
+++ b/apps/website/src/app/components/HeroSection.tsx
@@ -29,7 +29,7 @@ export function HeroSection() {
         <Panel title="agent-ci-terminal" glow className="flex flex-col">
           <div className="font-mono text-sm text-[#9bc5b3] space-y-2 flex-1 overflow-y-auto">
             <p>
-              <span className="text-[#528b76]">❯</span> npx agent-ci run --workflow
+              <span className="text-[#528b76]">❯</span> npx @redwoodjs/agent-ci run --workflow
               .github/workflows/ci.yml
             </p>
             <p className="text-[#71a792]">Initializing local runner environment...</p>
@@ -46,7 +46,7 @@ export function HeroSection() {
             <p className="text-yellow-400 font-bold">⚠️ Step failed. Runner paused.</p>
             <p className="text-[#71a792]">Container state preserved. Fix the issue and run:</p>
             <p className="text-[#e0eee5] bg-[#243c34] inline-block px-2 py-1 mt-1">
-              npx agent-ci retry --name runner-test-and-build
+              npx @redwoodjs/agent-ci retry --name runner-test-and-build
             </p>
             <div className="w-2 h-4 bg-[#528b76] inline-block ml-2 align-middle animate-blink" />
           </div>

--- a/apps/website/src/app/pages/home.tsx
+++ b/apps/website/src/app/pages/home.tsx
@@ -532,7 +532,7 @@ export const Home = () => {
             <Terminal
               title="Agent Instructions"
               language="markdown"
-              code={`## CI\n\nBefore completing any work, run the \`agent-ci\` skill to validate your changes locally. If it fails, fix the issue and re-run. Do not report work as done until it passes.`}
+              code={`## CI\n\nIf this is a Node.js project, install Agent CI as a dev dependency\nusing the project's package manager (npm, pnpm, yarn, or bun):\n\n\`\`\`bash\n<package-manager> install -D @redwoodjs/agent-ci\n\`\`\`\n\nIf this is not a Node.js project, you can run Agent CI directly\nwith npx:\n\n\`\`\`bash\nnpx @redwoodjs/agent-ci\n\`\`\`\n\nInstall the agent skill:\n\n\`\`\`bash\nnpx skills add redwoodjs/agent-ci --skill agent-ci\n\`\`\`\n\nBefore completing any work, run the \`agent-ci\` skill to validate\nyour changes locally. If it fails, fix the issue and re-run.\nDo not report work as done until it passes.`}
             />
 
             <p className="text-[#9bc5b3] mt-6 leading-relaxed">

--- a/apps/website/src/app/pages/home.tsx
+++ b/apps/website/src/app/pages/home.tsx
@@ -457,10 +457,10 @@ export const Home = () => {
             <div className="space-y-6 mb-16">
               <div>
                 <h4 className="font-mono text-sm text-[#71a792] uppercase tracking-wider mb-2">
-                  1. Install
+                  1. Run
                 </h4>
                 <Terminal
-                  code="npm install -D @redwoodjs/agent-ci"
+                  code={`# Run a specific workflow\nnpx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml\n\n# Run all relevant workflows for current branch\nnpx @redwoodjs/agent-ci run --all`}
                   language="bash"
                   title="Terminal"
                 />
@@ -468,21 +468,10 @@ export const Home = () => {
 
               <div>
                 <h4 className="font-mono text-sm text-[#71a792] uppercase tracking-wider mb-2">
-                  2. Run
+                  2. Retry
                 </h4>
                 <Terminal
-                  code={`# Run a specific workflow\nnpx agent-ci run --workflow .github/workflows/ci.yml\n\n# Run all relevant workflows for current branch\nnpx agent-ci run --all`}
-                  language="bash"
-                  title="Terminal"
-                />
-              </div>
-
-              <div>
-                <h4 className="font-mono text-sm text-[#71a792] uppercase tracking-wider mb-2">
-                  3. Retry
-                </h4>
-                <Terminal
-                  code="npx agent-ci retry --name <runner-name>"
+                  code="npx @redwoodjs/agent-ci retry --name <runner-name>"
                   language="bash"
                   title="Terminal"
                 />
@@ -532,7 +521,7 @@ export const Home = () => {
             <Terminal
               title="Agent Instructions"
               language="markdown"
-              code={`## CI\n\nIf this is a Node.js project, install Agent CI as a dev dependency\nusing the project's package manager (npm, pnpm, yarn, or bun):\n\n\`\`\`bash\n<package-manager> install -D @redwoodjs/agent-ci\n\`\`\`\n\nIf this is not a Node.js project, you can run Agent CI directly\nwith npx:\n\n\`\`\`bash\nnpx @redwoodjs/agent-ci\n\`\`\`\n\nInstall the agent skill:\n\n\`\`\`bash\nnpx skills add redwoodjs/agent-ci --skill agent-ci\n\`\`\`\n\nBefore completing any work, run the \`agent-ci\` skill to validate\nyour changes locally. If it fails, fix the issue and re-run.\nDo not report work as done until it passes.`}
+              code={`## CI\n\nInstall the agent-ci skill (one-time setup):\n\n\`\`\`bash\nnpx skills add redwoodjs/agent-ci --skill agent-ci\n\`\`\`\n\nBefore completing any work, run the \`agent-ci\` skill to validate\nyour changes locally. If it fails, fix the issue and re-run.\nDo not report work as done until it passes.`}
             />
 
             <p className="text-[#9bc5b3] mt-6 leading-relaxed">

--- a/apps/website/src/blog/content/the-agentic-dev-loop.md
+++ b/apps/website/src/blog/content/the-agentic-dev-loop.md
@@ -46,12 +46,12 @@ Here's what the agentic dev loop looks like in practice:
 1. You ask Claude Code to implement something (or fix something)
 2. Claude makes changes and runs:
    ```bash
-   npx agent-ci run --workflow .github/workflows/ci.yml
+   npx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml
    ```
 3. agent-ci executes the full local CI pipeline
 4. If it fails, the run pauses automatically. Claude reads the output, fixes the issue in place, and retries just the failed step:
    ```bash
-   npx agent-ci retry --name <runner-name>
+   npx @redwoodjs/agent-ci retry --name <runner-name>
    ```
 5. When everything is green, Claude commits and you push
 
@@ -68,13 +68,11 @@ The agentic dev loop tightens that to: run locally → fail → fix → run agai
 A fake local runner just gives agents a new way to confidently produce broken code. The loop works because agent-ci is real, and fast enough to run repeatedly without breaking the flow. Fidelity plus speed — that's what makes it viable.
 
 ```bash
-npm install -D @redwoodjs/agent-ci
-
 # Run a specific workflow
-npx agent-ci run --workflow .github/workflows/ci.yml
+npx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml
 
 # Run all workflows for the current branch
-npx agent-ci run --all
+npx @redwoodjs/agent-ci run --all
 ```
 
 The first run is slow while caches warm up. After that, it's the loop.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -68,6 +68,7 @@ Run GitHub Actions workflow jobs locally.
 | -------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `--workflow <path>`        | `-w`  | Path to the workflow file                                                                                                                                    |
 | `--all`                    | `-a`  | Discover and run all relevant workflows for the current branch                                                                                               |
+| `--jobs <n>`               | `-j`  | Max concurrent containers (overrides auto-detection)                                                                                                         |
 | `--pause-on-failure`       | `-p`  | Pause on step failure for interactive debugging                                                                                                              |
 | `--quiet`                  | `-q`  | Suppress animated rendering (also enabled by `AI_AGENT=1`)                                                                                                   |
 | `--no-matrix`              |       | Collapse all matrix combinations into a single job (uses first value of each key)                                                                            |
@@ -93,6 +94,29 @@ Abort a paused runner and tear down its container.
 | Flag            | Short | Description                                   |
 | --------------- | ----- | --------------------------------------------- |
 | `--name <name>` | `-n`  | Name of the paused runner to abort (required) |
+
+## Concurrency
+
+When running multiple workflows (`--all`), Agent CI limits how many containers run at the same time to avoid running out of memory.
+
+The limit is auto-detected using two factors:
+
+- **CPU**: `floor(cpuCount / 2)`
+- **Memory**: `floor(availableDockerMemory / 4GB)`
+
+Whichever is lower wins. For example, on a machine with 14 CPUs and a Docker VM with 12 GB of RAM, the CPU limit is 7 and the memory limit is 2 — so 2 containers run at a time.
+
+To check available memory, Agent CI reads `MemAvailable` from `/proc/meminfo` inside the Docker VM. This accounts for the VM's kernel, daemon, and any other running containers. If that fails, it falls back to `docker info` total memory minus 4 GB.
+
+You can override the auto-detected limit with `--jobs`:
+
+```bash
+# Run at most 4 containers at a time
+npx agent-ci run --all --jobs 4
+
+# Run one at a time (safest, slowest)
+npx agent-ci run --all --jobs 1
+```
 
 ## YAML Compatibility
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,20 +18,14 @@ Agent CI runs on any machine that can run a container. When a step fails the run
   - **macOS:** [OrbStack](https://orbstack.dev/) (recommended) or Docker Desktop
   - **Linux:** Native Docker Engine or Docker Desktop
 
-## Installation
-
-```bash
-npm install -D @redwoodjs/agent-ci
-```
-
 ## Usage
 
 ```bash
 # Run a specific workflow
-npx agent-ci run --workflow .github/workflows/ci.yml
+npx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml
 
 # Run all relevant workflows for the current branch
-npx agent-ci run --all
+npx @redwoodjs/agent-ci run --all
 ```
 
 ### Remote Docker
@@ -39,7 +33,7 @@ npx agent-ci run --all
 Agent CI connects to Docker via the `DOCKER_HOST` environment variable. By default it uses the local socket (`unix:///var/run/docker.sock`), but you can point it at any remote Docker daemon:
 
 ```bash
-DOCKER_HOST=ssh://user@remote-server npx agent-ci run --workflow .github/workflows/ci.yml
+DOCKER_HOST=ssh://user@remote-server npx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml
 ```
 
 ### Docker host resolution for job containers
@@ -112,10 +106,10 @@ You can override the auto-detected limit with `--jobs`:
 
 ```bash
 # Run at most 4 containers at a time
-npx agent-ci run --all --jobs 4
+npx @redwoodjs/agent-ci run --all --jobs 4
 
 # Run one at a time (safest, slowest)
-npx agent-ci run --all --jobs 1
+npx @redwoodjs/agent-ci run --all --jobs 1
 ```
 
 ## YAML Compatibility
@@ -140,5 +134,5 @@ Set the `DEBUG` environment variable to enable verbose debug logging. It accepts
 - Pattern matching uses [minimatch](https://github.com/isaacs/minimatch) globs, so `agent-ci:*` matches all four namespaces.
 
 ```bash
-DEBUG=agent-ci:* npx agent-ci run
+DEBUG=agent-ci:* npx @redwoodjs/agent-ci run
 ```

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -463,6 +463,12 @@ async function runWorkflows(options: {
   pruneStaleWorkspaces(getWorkingDirectory(), 24 * 60 * 60 * 1000);
   await prefetchRunnerImages(workflowPaths);
 
+  // Global concurrency limiter shared across all workflows. Without this,
+  // --all mode launches every workflow in parallel — leading to 20+
+  // simultaneous containers that exhaust available memory and trigger
+  // OOM kills (exit 137). See issue #225.
+  const globalLimiter = createConcurrencyLimiter(getDefaultMaxConcurrentJobs());
+
   try {
     const allResults: JobResult[] = [];
 
@@ -475,6 +481,7 @@ async function runWorkflows(options: {
         noMatrix,
         store,
         githubToken,
+        globalLimiter,
       });
       allResults.push(...results);
     } else {
@@ -513,6 +520,7 @@ async function runWorkflows(options: {
           store,
           baseRunNum: runNums[0],
           githubToken,
+          globalLimiter,
         });
         allResults.push(...firstResults);
 
@@ -526,6 +534,7 @@ async function runWorkflows(options: {
               store,
               baseRunNum: runNums[i + 1],
               githubToken,
+              globalLimiter,
             }),
           ),
         );
@@ -547,6 +556,7 @@ async function runWorkflows(options: {
               store,
               baseRunNum: runNums[i],
               githubToken,
+              globalLimiter,
             }),
           ),
         );
@@ -592,6 +602,7 @@ async function handleWorkflow(options: {
   store: RunStateStore;
   baseRunNum?: number;
   githubToken?: string;
+  globalLimiter: ReturnType<typeof createConcurrencyLimiter>;
 }): Promise<JobResult[]> {
   const { sha, pauseOnFailure, noMatrix = false, store, githubToken } = options;
   let workflowPath = options.workflowPath;
@@ -744,12 +755,14 @@ async function handleWorkflow(options: {
       taskId: ej.taskName,
     };
 
-    const result = await executeLocalJob(job, { pauseOnFailure, store });
+    const result = await options.globalLimiter.run(() =>
+      executeLocalJob(job, { pauseOnFailure, store }),
+    );
     return [result];
   }
 
   // ── Multi-job orchestration ────────────────────────────────────────────────
-  const maxJobs = getDefaultMaxConcurrentJobs();
+  const limiter = options.globalLimiter;
 
   // ── Warm-cache check ───────────────────────────────────────────────────────
   const repoSlug = githubRepo.replace("/", "-");
@@ -890,7 +903,6 @@ async function handleWorkflow(options: {
     return result;
   };
 
-  const limiter = createConcurrencyLimiter(maxJobs);
   const allResults: JobResult[] = [];
   // Accumulate job outputs across waves for needs.*.outputs.* resolution
   const jobOutputs = new Map<string, Record<string, string>>();
@@ -1061,7 +1073,7 @@ async function handleWorkflow(options: {
     // ── Warm-cache serialization for the first wave ────────────────────────
     if (!warm && wi === 0 && waveJobs.length > 1) {
       debugCli("Cold cache — running first job to populate warm modules...");
-      const firstResult = await runOrSkipJob(waveJobs[0]);
+      const firstResult = await limiter.run(() => runOrSkipJob(waveJobs[0]));
       allResults.push(firstResult);
 
       const results = await Promise.allSettled(

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -87,6 +87,7 @@ async function run() {
     let noMatrix = false;
     let githubToken: string | undefined;
     let commitStatus = false;
+    let maxJobs: number | undefined;
 
     for (let i = 1; i < args.length; i++) {
       if ((args[i] === "--workflow" || args[i] === "-w") && args[i + 1]) {
@@ -100,6 +101,13 @@ async function run() {
         setQuietMode(true);
       } else if (args[i] === "--no-matrix") {
         noMatrix = true;
+      } else if ((args[i] === "--jobs" || args[i] === "-j") && args[i + 1]) {
+        maxJobs = parseInt(args[i + 1], 10);
+        if (!Number.isFinite(maxJobs) || maxJobs < 1) {
+          console.error("[Agent CI] Error: --jobs must be a positive integer");
+          process.exit(1);
+        }
+        i++;
       } else if (args[i] === "--commit-status") {
         commitStatus = true;
       } else if (args[i] === "--github-token") {
@@ -197,6 +205,7 @@ async function run() {
         pauseOnFailure,
         noMatrix,
         githubToken,
+        maxJobs,
       });
       if (results.length > 0) {
         printSummary(results);
@@ -237,6 +246,7 @@ async function run() {
       pauseOnFailure,
       noMatrix,
       githubToken,
+      maxJobs,
     });
     if (results.length > 0) {
       printSummary(results);
@@ -366,6 +376,7 @@ async function runWorkflows(options: {
   pauseOnFailure: boolean;
   noMatrix?: boolean;
   githubToken?: string;
+  maxJobs?: number;
 }): Promise<JobResult[]> {
   const { workflowPaths, sha, pauseOnFailure, noMatrix = false, githubToken } = options;
 
@@ -467,7 +478,7 @@ async function runWorkflows(options: {
   // --all mode launches every workflow in parallel — leading to 20+
   // simultaneous containers that exhaust available memory and trigger
   // OOM kills (exit 137). See issue #225.
-  const globalLimiter = createConcurrencyLimiter(getDefaultMaxConcurrentJobs());
+  const globalLimiter = createConcurrencyLimiter(options.maxJobs ?? getDefaultMaxConcurrentJobs());
 
   try {
     const allResults: JobResult[] = [];
@@ -1170,6 +1181,9 @@ function printUsage() {
   console.log("Options:");
   console.log("  -w, --workflow <path>         Path to the workflow file");
   console.log("  -a, --all                     Discover and run all relevant workflows");
+  console.log(
+    "  -j, --jobs <n>                Max concurrent containers (auto-detected from CPU/memory)",
+  );
   console.log("  -p, --pause-on-failure         Pause on step failure for interactive debugging");
   console.log(
     "  -q, --quiet                   Suppress animated rendering (also enabled by AI_AGENT=1)",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -452,8 +452,14 @@ async function runWorkflows(options: {
   // parallel, running these inside handleWorkflow() hammered the Docker
   // daemon (N× `docker volume prune`, N× cold-start image pulls) and
   // serialized work that should have been free. See issue #211.
-  pruneOrphanedDockerResources();
-  killOrphanedContainers();
+  // Skip Docker cleanup when running nested inside a container (e.g.
+  // smoke-bun-setup step 8). The shared Docker socket exposes the host's
+  // containers, and killOrphanedContainers would kill our parent container
+  // because host PIDs don't exist in the container's PID namespace.
+  if (!fs.existsSync("/.dockerenv")) {
+    pruneOrphanedDockerResources();
+    killOrphanedContainers();
+  }
   pruneStaleWorkspaces(getWorkingDirectory(), 24 * 60 * 60 * 1000);
   await prefetchRunnerImages(workflowPaths);
 

--- a/packages/cli/src/docker/container-config.ts
+++ b/packages/cli/src/docker/container-config.ts
@@ -194,12 +194,18 @@ function parseCsvEnv(value: string): string[] {
 }
 
 export async function resolveDtuHost(): Promise<string> {
+  const isInsideDocker = fs.existsSync("/.dockerenv");
+
+  // When running inside a container (nested agent-ci), ignore the inherited
+  // AGENT_CI_DTU_HOST — it points to the parent's DTU host (e.g.
+  // "host.docker.internal") which isn't reachable from sibling containers.
+  // Instead, resolve this container's own IP so the inner container can
+  // connect back to our DTU.
   const configuredHost = process.env.AGENT_CI_DTU_HOST?.trim();
-  if (configuredHost) {
+  if (configuredHost && !isInsideDocker) {
     return configuredHost;
   }
 
-  const isInsideDocker = fs.existsSync("/.dockerenv");
   if (isInsideDocker) {
     try {
       const ip = execSync("hostname -I 2>/dev/null | awk '{print $1}'", {

--- a/packages/cli/src/docker/shutdown.test.ts
+++ b/packages/cli/src/docker/shutdown.test.ts
@@ -350,100 +350,109 @@ function dockerAvailable(): boolean {
   }
 }
 
-describe.skipIf(!dockerAvailable())("killOrphanedContainers (Docker integration)", () => {
-  const containerName = "agent-ci-orphan-smoke-svc-testdb";
-  const runnerName = "agent-ci-orphan-smoke";
+function insideDocker(): boolean {
+  return fs.existsSync("/.dockerenv");
+}
 
-  // Import the real function eagerly, outside vitest's mock system.
-  // The unit tests above use vi.doMock("node:child_process") which poisons
-  // dynamic imports even after vi.resetModules()/vi.unmock(). Spawning a
-  // fresh node process sidesteps that entirely — and this IS a smoke test,
-  // so exercising the real module resolution path is a feature, not a hack.
-  function runKillOrphanedContainers() {
-    execSync(
-      `npx tsx -e "import { killOrphanedContainers } from './src/docker/shutdown.ts'; killOrphanedContainers();"`,
-      { stdio: "pipe" },
-    );
-  }
+// Skip inside containers: killOrphanedContainers bails when /.dockerenv
+// exists (PID namespace mismatch), so integration tests can't exercise it.
+describe.skipIf(!dockerAvailable() || insideDocker())(
+  "killOrphanedContainers (Docker integration)",
+  () => {
+    const containerName = "agent-ci-orphan-smoke-svc-testdb";
+    const runnerName = "agent-ci-orphan-smoke";
 
-  afterEach(() => {
-    // Belt-and-suspenders: ensure we don't leak the test container
-    try {
-      execSync(`docker rm -f ${containerName}`, { stdio: "pipe" });
-    } catch {
-      // already gone — good
+    // Import the real function eagerly, outside vitest's mock system.
+    // The unit tests above use vi.doMock("node:child_process") which poisons
+    // dynamic imports even after vi.resetModules()/vi.unmock(). Spawning a
+    // fresh node process sidesteps that entirely — and this IS a smoke test,
+    // so exercising the real module resolution path is a feature, not a hack.
+    function runKillOrphanedContainers() {
+      execSync(
+        `npx tsx -e "import { killOrphanedContainers } from './src/docker/shutdown.ts'; killOrphanedContainers();"`,
+        { stdio: "pipe" },
+      );
     }
-    try {
-      execSync(`docker network rm agent-ci-net-${runnerName}`, { stdio: "pipe" });
-    } catch {
-      // already gone
-    }
-  });
 
-  it("cleans up an unlabeled service container", () => {
-    // Create a container that mimics a leaked pre-fix service container: no agent-ci.pid label
-    execSync(`docker create --name ${containerName} busybox sleep 300`, { stdio: "pipe" });
-    execSync(`docker start ${containerName}`, { stdio: "pipe" });
+    afterEach(() => {
+      // Belt-and-suspenders: ensure we don't leak the test container
+      try {
+        execSync(`docker rm -f ${containerName}`, { stdio: "pipe" });
+      } catch {
+        // already gone — good
+      }
+      try {
+        execSync(`docker network rm agent-ci-net-${runnerName}`, { stdio: "pipe" });
+      } catch {
+        // already gone
+      }
+    });
 
-    // Confirm it's running
-    const before = execSync(
-      `docker ps -q --filter "name=${containerName}" --filter "status=running"`,
-      { encoding: "utf8", stdio: "pipe" },
-    ).trim();
-    expect(before).not.toBe("");
+    it("cleans up an unlabeled service container", () => {
+      // Create a container that mimics a leaked pre-fix service container: no agent-ci.pid label
+      execSync(`docker create --name ${containerName} busybox sleep 300`, { stdio: "pipe" });
+      execSync(`docker start ${containerName}`, { stdio: "pipe" });
 
-    runKillOrphanedContainers();
+      // Confirm it's running
+      const before = execSync(
+        `docker ps -q --filter "name=${containerName}" --filter "status=running"`,
+        { encoding: "utf8", stdio: "pipe" },
+      ).trim();
+      expect(before).not.toBe("");
 
-    // Container should be gone
-    const after = execSync(`docker ps -aq --filter "name=${containerName}"`, {
-      encoding: "utf8",
-      stdio: "pipe",
-    }).trim();
-    expect(after).toBe("");
-  });
+      runKillOrphanedContainers();
 
-  it("cleans up a labeled service container whose parent PID is dead", () => {
-    // Use a PID that's guaranteed dead (PID 2^22 - 1 is extremely unlikely to exist)
-    const deadPid = "4194303";
+      // Container should be gone
+      const after = execSync(`docker ps -aq --filter "name=${containerName}"`, {
+        encoding: "utf8",
+        stdio: "pipe",
+      }).trim();
+      expect(after).toBe("");
+    });
 
-    execSync(
-      `docker create --name ${containerName} --label "agent-ci.pid=${deadPid}" busybox sleep 300`,
-      { stdio: "pipe" },
-    );
-    execSync(`docker start ${containerName}`, { stdio: "pipe" });
+    it("cleans up a labeled service container whose parent PID is dead", () => {
+      // Use a PID that's guaranteed dead (PID 2^22 - 1 is extremely unlikely to exist)
+      const deadPid = "4194303";
 
-    const before = execSync(
-      `docker ps -q --filter "name=${containerName}" --filter "status=running"`,
-      { encoding: "utf8", stdio: "pipe" },
-    ).trim();
-    expect(before).not.toBe("");
+      execSync(
+        `docker create --name ${containerName} --label "agent-ci.pid=${deadPid}" busybox sleep 300`,
+        { stdio: "pipe" },
+      );
+      execSync(`docker start ${containerName}`, { stdio: "pipe" });
 
-    runKillOrphanedContainers();
+      const before = execSync(
+        `docker ps -q --filter "name=${containerName}" --filter "status=running"`,
+        { encoding: "utf8", stdio: "pipe" },
+      ).trim();
+      expect(before).not.toBe("");
 
-    const after = execSync(`docker ps -aq --filter "name=${containerName}"`, {
-      encoding: "utf8",
-      stdio: "pipe",
-    }).trim();
-    expect(after).toBe("");
-  });
+      runKillOrphanedContainers();
 
-  it("does NOT kill a service container whose parent PID is alive", () => {
-    // Label with our own PID — should be left alone
-    const myPid = String(process.pid);
+      const after = execSync(`docker ps -aq --filter "name=${containerName}"`, {
+        encoding: "utf8",
+        stdio: "pipe",
+      }).trim();
+      expect(after).toBe("");
+    });
 
-    execSync(
-      `docker create --name ${containerName} --label "agent-ci.pid=${myPid}" busybox sleep 300`,
-      { stdio: "pipe" },
-    );
-    execSync(`docker start ${containerName}`, { stdio: "pipe" });
+    it("does NOT kill a service container whose parent PID is alive", () => {
+      // Label with our own PID — should be left alone
+      const myPid = String(process.pid);
 
-    runKillOrphanedContainers();
+      execSync(
+        `docker create --name ${containerName} --label "agent-ci.pid=${myPid}" busybox sleep 300`,
+        { stdio: "pipe" },
+      );
+      execSync(`docker start ${containerName}`, { stdio: "pipe" });
 
-    // Container should still be running
-    const after = execSync(
-      `docker ps -q --filter "name=${containerName}" --filter "status=running"`,
-      { encoding: "utf8", stdio: "pipe" },
-    ).trim();
-    expect(after).not.toBe("");
-  });
-});
+      runKillOrphanedContainers();
+
+      // Container should still be running
+      const after = execSync(
+        `docker ps -q --filter "name=${containerName}" --filter "status=running"`,
+        { encoding: "utf8", stdio: "pipe" },
+      ).trim();
+      expect(after).not.toBe("");
+    });
+  },
+);

--- a/packages/cli/src/docker/shutdown.test.ts
+++ b/packages/cli/src/docker/shutdown.test.ts
@@ -123,12 +123,23 @@ describe("Stale workspace pruning", () => {
 describe("killOrphanedContainers", () => {
   const execSyncMock = vi.fn();
   const killSpy = vi.spyOn(process, "kill");
+  const existsSyncMock = vi.fn();
 
   beforeEach(() => {
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
       execSync: execSyncMock,
     }));
+    // Mock fs so /.dockerenv check doesn't skip the function inside containers
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        default: { ...actual, existsSync: existsSyncMock },
+        existsSync: existsSyncMock,
+      };
+    });
+    existsSyncMock.mockReturnValue(false);
     execSyncMock.mockReset();
     killSpy.mockReset();
   });

--- a/packages/cli/src/docker/shutdown.ts
+++ b/packages/cli/src/docker/shutdown.ts
@@ -56,6 +56,12 @@ export function killRunnerContainers(runnerName: string): void {
  * exhausting its address pool ("all predefined address pools have been fully subnetted").
  */
 export function pruneOrphanedDockerResources(): void {
+  // Skip when running inside a Docker container — we share the host's
+  // Docker socket, so pruning would remove the host's containers/networks.
+  if (fs.existsSync("/.dockerenv")) {
+    return;
+  }
+
   // 1. Remove stopped/stale agent-ci-* containers (runners + sidecars) so their
   //    network references are released before we try to prune networks.
   //    Includes both "exited" and "created" (never started) containers.
@@ -121,6 +127,14 @@ export function pruneOrphanedDockerResources(): void {
  * containers or service containers created before the label was added.
  */
 export function killOrphanedContainers(): void {
+  // Skip when running inside a Docker container (e.g. nested agent-ci or
+  // integration tests inside a runner container). The pid labels reference
+  // host PIDs which don't exist in the container's PID namespace — every
+  // container would look like an orphan, including our own parent.
+  if (fs.existsSync("/.dockerenv")) {
+    return;
+  }
+
   let lines: string[];
   try {
     // Format: "containerId containerName pid-label"

--- a/packages/cli/src/docker/shutdown.ts
+++ b/packages/cli/src/docker/shutdown.ts
@@ -56,6 +56,13 @@ export function killRunnerContainers(runnerName: string): void {
  * exhausting its address pool ("all predefined address pools have been fully subnetted").
  */
 export function pruneOrphanedDockerResources(): void {
+  // Skip when running inside a Docker container (e.g. nested agent-ci).
+  // We share the host's Docker socket, so pruning would remove containers
+  // and networks that belong to the host's agent-ci process.
+  if (fs.existsSync("/.dockerenv")) {
+    return;
+  }
+
   // 1. Remove stopped/stale agent-ci-* containers (runners + sidecars) so their
   //    network references are released before we try to prune networks.
   //    Includes both "exited" and "created" (never started) containers.
@@ -121,6 +128,14 @@ export function pruneOrphanedDockerResources(): void {
  * containers or service containers created before the label was added.
  */
 export function killOrphanedContainers(): void {
+  // Skip when running inside a Docker container (e.g. nested agent-ci).
+  // The pid labels reference host PIDs which don't exist in the container's
+  // PID namespace — every container would look like an orphan, and we'd
+  // kill our own parent container.
+  if (fs.existsSync("/.dockerenv")) {
+    return;
+  }
+
   let lines: string[];
   try {
     // Format: "containerId containerName pid-label"

--- a/packages/cli/src/docker/shutdown.ts
+++ b/packages/cli/src/docker/shutdown.ts
@@ -56,13 +56,6 @@ export function killRunnerContainers(runnerName: string): void {
  * exhausting its address pool ("all predefined address pools have been fully subnetted").
  */
 export function pruneOrphanedDockerResources(): void {
-  // Skip when running inside a Docker container (e.g. nested agent-ci).
-  // We share the host's Docker socket, so pruning would remove containers
-  // and networks that belong to the host's agent-ci process.
-  if (fs.existsSync("/.dockerenv")) {
-    return;
-  }
-
   // 1. Remove stopped/stale agent-ci-* containers (runners + sidecars) so their
   //    network references are released before we try to prune networks.
   //    Includes both "exited" and "created" (never started) containers.
@@ -128,14 +121,6 @@ export function pruneOrphanedDockerResources(): void {
  * containers or service containers created before the label was added.
  */
 export function killOrphanedContainers(): void {
-  // Skip when running inside a Docker container (e.g. nested agent-ci).
-  // The pid labels reference host PIDs which don't exist in the container's
-  // PID namespace — every container would look like an orphan, and we'd
-  // kill our own parent container.
-  if (fs.existsSync("/.dockerenv")) {
-    return;
-  }
-
   let lines: string[];
   try {
     // Format: "containerId containerName pid-label"

--- a/packages/cli/src/output/concurrency.test.ts
+++ b/packages/cli/src/output/concurrency.test.ts
@@ -106,10 +106,10 @@ describe("getDefaultMaxConcurrentJobs", () => {
     expect(result).toBeGreaterThanOrEqual(1);
   });
 
-  it("returns a reasonable number for the current host", () => {
+  it("returns at most floor(cpuCount / 2)", () => {
     const result = getDefaultMaxConcurrentJobs();
     const os = require("os");
-    const expected = Math.max(1, Math.floor(os.cpus().length / 2));
-    expect(result).toBe(expected);
+    const cpuLimit = Math.max(1, Math.floor(os.cpus().length / 2));
+    expect(result).toBeLessThanOrEqual(cpuLimit);
   });
 });

--- a/packages/cli/src/output/concurrency.ts
+++ b/packages/cli/src/output/concurrency.ts
@@ -1,4 +1,5 @@
 import os from "node:os";
+import { execSync } from "node:child_process";
 
 /**
  * A simple Promise-based semaphore that limits how many async tasks
@@ -52,10 +53,66 @@ export function createConcurrencyLimiter(max: number) {
 }
 
 /**
- * Determine the default max concurrent jobs based on the host CPU count.
- * Returns floor(cpuCount / 2), with a minimum of 1.
+ * Read MemAvailable from inside the Docker VM via /proc/meminfo.
+ * This reflects actual free memory accounting for kernel, daemon, caches,
+ * and any already-running containers — no hardcoded reserve needed.
+ *
+ * Falls back to `docker info` MemTotal with a conservative reserve if
+ * the busybox approach fails (e.g. busybox not pulled).
+ */
+function getDockerAvailableMemoryBytes(): number | undefined {
+  try {
+    const raw = execSync("docker run --rm busybox grep MemAvailable /proc/meminfo", {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 10_000,
+    }).trim();
+    const match = raw.match(/MemAvailable:\s+(\d+)\s+kB/);
+    if (match) {
+      return Number(match[1]) * 1024;
+    }
+  } catch {
+    // busybox not available — fall back to docker info
+  }
+
+  try {
+    const raw = execSync("docker info --format '{{.MemTotal}}'", {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 5_000,
+    }).trim();
+    const bytes = Number(raw);
+    if (Number.isFinite(bytes) && bytes > 0) {
+      return Math.max(0, bytes - 4 * 1024 * 1024 * 1024);
+    }
+  } catch {
+    // Docker not reachable
+  }
+
+  return undefined;
+}
+
+/** Estimated memory per container: runner binary + Ubuntu + typical workload. */
+const BYTES_PER_CONTAINER = 3 * 1024 * 1024 * 1024; // 3 GB
+
+/**
+ * Determine the default max concurrent jobs based on CPU count and available
+ * Docker memory. Takes the minimum of both to avoid OOM kills.
+ *
+ * - CPU-based: floor(cpuCount / 2)
+ * - Memory-based: floor(availableMemory / perContainer)
+ *
+ * Minimum of 1.
  */
 export function getDefaultMaxConcurrentJobs(): number {
   const cpuCount = os.cpus().length;
-  return Math.max(1, Math.floor(cpuCount / 2));
+  const cpuLimit = Math.floor(cpuCount / 2);
+
+  const availableMem = getDockerAvailableMemoryBytes();
+  if (availableMem == null) {
+    return Math.max(1, cpuLimit);
+  }
+
+  const memLimit = Math.floor(availableMem / BYTES_PER_CONTAINER);
+  return Math.max(1, Math.min(cpuLimit, memLimit));
 }

--- a/packages/cli/src/output/concurrency.ts
+++ b/packages/cli/src/output/concurrency.ts
@@ -92,8 +92,8 @@ function getDockerAvailableMemoryBytes(): number | undefined {
   return undefined;
 }
 
-/** Estimated memory per container: runner binary + Ubuntu + typical workload. */
-const BYTES_PER_CONTAINER = 3 * 1024 * 1024 * 1024; // 3 GB
+/** Estimated memory per container: runner binary + Ubuntu + heavy workloads (vitest, full builds). */
+const BYTES_PER_CONTAINER = 4 * 1024 * 1024 * 1024; // 4 GB
 
 /**
  * Determine the default max concurrent jobs based on CPU count and available


### PR DESCRIPTION
## Summary

- Removed the `npm install -D` step from all docs, README, and website
- All commands now use `npx @redwoodjs/agent-ci` (full package name) so users can run it without installing anything
- Updated the "Copy agent instructions" button to just include skill setup + run instructions
- Simpler for agents: no package manager detection, no install step, just works

## Test plan

- [x] CI passes
- [ ] Verify website renders correctly at agent-ci.dev after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)