### PR TITLE
docs: simplify usage to npx @redwoodjs/agent-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,14 @@ Agent CI does not re-implement GitHub Actions. It emulates the **server-side API
   - **macOS:** [OrbStack](https://orbstack.dev/) (recommended) or Docker Desktop
   - **Linux:** Native Docker Engine
 
-### Install
-
-```bash
-npm install -D @redwoodjs/agent-ci
-```
-
 ### Run
 
 ```bash
 # Run a specific workflow
-npx agent-ci run --workflow .github/workflows/ci.yml
+npx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml
 
 # Run all relevant workflows for the current branch
-npx agent-ci run --all
+npx @redwoodjs/agent-ci run --all
 ```
 
 Agent CI runs against your **current working tree** — uncommitted changes are included automatically. No need to commit or stash before running.
@@ -70,7 +64,7 @@ Agent CI runs against your **current working tree** — uncommitted changes are 
 ### Retry a failed step
 
 ```bash
-npx agent-ci retry --name <runner-name>
+npx @redwoodjs/agent-ci retry --name <runner-name>
 ```
 
 ---
@@ -116,7 +110,7 @@ Abort a paused runner and tear down its container.
 Agent CI connects to Docker via `DOCKER_HOST`. By default it uses the local socket, but you can point it at any remote daemon:
 
 ```bash
-DOCKER_HOST=ssh://user@remote-server npx agent-ci run --workflow .github/workflows/ci.yml
+DOCKER_HOST=ssh://user@remote-server npx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml
 ```
 
 ### Docker host resolution for job containers
@@ -193,7 +187,7 @@ Set `DEBUG` to enable verbose logging. It accepts comma-separated glob patterns:
 | `DEBUG=agent-ci:cli,agent-ci:dtu` | Multiple namespaces           |
 
 ```bash
-DEBUG=agent-ci:* npx agent-ci run --workflow .github/workflows/ci.yml
+DEBUG=agent-ci:* npx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml
 ```
 
 Output goes to **stderr**. If `DEBUG` is unset, debug loggers are no-ops with zero overhead.
@@ -212,6 +206,12 @@ This works with Claude Code, Cursor, Codex, and [40+ other agents](https://agent
 
 ```markdown
 ## CI
+
+Install the agent-ci skill (one-time setup):
+
+\`\`\`bash
+npx skills add redwoodjs/agent-ci --skill agent-ci
+\`\`\`
 
 Before completing any work, run the `agent-ci` skill to validate your changes locally. If it fails, fix the issue and re-run. Do not report work as done until it passes.
 ```

--- a/apps/website/src/app/components/CopyAgentInstructions.tsx
+++ b/apps/website/src/app/components/CopyAgentInstructions.tsx
@@ -5,19 +5,7 @@ import { Copy, Check } from "lucide-react";
 
 const AGENT_INSTRUCTIONS = `## CI
 
-If this is a Node.js project, install Agent CI as a dev dependency using the project's package manager (npm, pnpm, yarn, or bun):
-
-\`\`\`bash
-<package-manager> install -D @redwoodjs/agent-ci
-\`\`\`
-
-If this is not a Node.js project, you can run Agent CI directly with npx:
-
-\`\`\`bash
-npx @redwoodjs/agent-ci
-\`\`\`
-
-Install the agent skill:
+Install the agent-ci skill (one-time setup):
 
 \`\`\`bash
 npx skills add redwoodjs/agent-ci --skill agent-ci

--- a/apps/website/src/app/components/HeroSection.tsx
+++ b/apps/website/src/app/components/HeroSection.tsx
@@ -29,7 +29,7 @@ export function HeroSection() {
         <Panel title="agent-ci-terminal" glow className="flex flex-col">
           <div className="font-mono text-sm text-[#9bc5b3] space-y-2 flex-1 overflow-y-auto">
             <p>
-              <span className="text-[#528b76]">❯</span> npx agent-ci run --workflow
+              <span className="text-[#528b76]">❯</span> npx @redwoodjs/agent-ci run --workflow
               .github/workflows/ci.yml
             </p>
             <p className="text-[#71a792]">Initializing local runner environment...</p>
@@ -46,7 +46,7 @@ export function HeroSection() {
             <p className="text-yellow-400 font-bold">⚠️ Step failed. Runner paused.</p>
             <p className="text-[#71a792]">Container state preserved. Fix the issue and run:</p>
             <p className="text-[#e0eee5] bg-[#243c34] inline-block px-2 py-1 mt-1">
-              npx agent-ci retry --name runner-test-and-build
+              npx @redwoodjs/agent-ci retry --name runner-test-and-build
             </p>
             <div className="w-2 h-4 bg-[#528b76] inline-block ml-2 align-middle animate-blink" />
           </div>

--- a/apps/website/src/app/pages/home.tsx
+++ b/apps/website/src/app/pages/home.tsx
@@ -457,10 +457,10 @@ export const Home = () => {
             <div className="space-y-6 mb-16">
               <div>
                 <h4 className="font-mono text-sm text-[#71a792] uppercase tracking-wider mb-2">
-                  1. Install
+                  1. Run
                 </h4>
                 <Terminal
-                  code="npm install -D @redwoodjs/agent-ci"
+                  code={`# Run a specific workflow\nnpx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml\n\n# Run all relevant workflows for current branch\nnpx @redwoodjs/agent-ci run --all`}
                   language="bash"
                   title="Terminal"
                 />
@@ -468,21 +468,10 @@ export const Home = () => {
 
               <div>
                 <h4 className="font-mono text-sm text-[#71a792] uppercase tracking-wider mb-2">
-                  2. Run
+                  2. Retry
                 </h4>
                 <Terminal
-                  code={`# Run a specific workflow\nnpx agent-ci run --workflow .github/workflows/ci.yml\n\n# Run all relevant workflows for current branch\nnpx agent-ci run --all`}
-                  language="bash"
-                  title="Terminal"
-                />
-              </div>
-
-              <div>
-                <h4 className="font-mono text-sm text-[#71a792] uppercase tracking-wider mb-2">
-                  3. Retry
-                </h4>
-                <Terminal
-                  code="npx agent-ci retry --name <runner-name>"
+                  code="npx @redwoodjs/agent-ci retry --name <runner-name>"
                   language="bash"
                   title="Terminal"
                 />
@@ -532,7 +521,7 @@ export const Home = () => {
             <Terminal
               title="Agent Instructions"
               language="markdown"
-              code={`## CI\n\nIf this is a Node.js project, install Agent CI as a dev dependency\nusing the project's package manager (npm, pnpm, yarn, or bun):\n\n\`\`\`bash\n<package-manager> install -D @redwoodjs/agent-ci\n\`\`\`\n\nIf this is not a Node.js project, you can run Agent CI directly\nwith npx:\n\n\`\`\`bash\nnpx @redwoodjs/agent-ci\n\`\`\`\n\nInstall the agent skill:\n\n\`\`\`bash\nnpx skills add redwoodjs/agent-ci --skill agent-ci\n\`\`\`\n\nBefore completing any work, run the \`agent-ci\` skill to validate\nyour changes locally. If it fails, fix the issue and re-run.\nDo not report work as done until it passes.`}
+              code={`## CI\n\nInstall the agent-ci skill (one-time setup):\n\n\`\`\`bash\nnpx skills add redwoodjs/agent-ci --skill agent-ci\n\`\`\`\n\nBefore completing any work, run the \`agent-ci\` skill to validate\nyour changes locally. If it fails, fix the issue and re-run.\nDo not report work as done until it passes.`}
             />
 
             <p className="text-[#9bc5b3] mt-6 leading-relaxed">

--- a/apps/website/src/blog/content/the-agentic-dev-loop.md
+++ b/apps/website/src/blog/content/the-agentic-dev-loop.md
@@ -46,12 +46,12 @@ Here's what the agentic dev loop looks like in practice:
 1. You ask Claude Code to implement something (or fix something)
 2. Claude makes changes and runs:
    ```bash
-   npx agent-ci run --workflow .github/workflows/ci.yml
+   npx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml
    ```
 3. agent-ci executes the full local CI pipeline
 4. If it fails, the run pauses automatically. Claude reads the output, fixes the issue in place, and retries just the failed step:
    ```bash
-   npx agent-ci retry --name <runner-name>
+   npx @redwoodjs/agent-ci retry --name <runner-name>
    ```
 5. When everything is green, Claude commits and you push
 
@@ -68,13 +68,11 @@ The agentic dev loop tightens that to: run locally → fail → fix → run agai
 A fake local runner just gives agents a new way to confidently produce broken code. The loop works because agent-ci is real, and fast enough to run repeatedly without breaking the flow. Fidelity plus speed — that's what makes it viable.
 
 ```bash
-npm install -D @redwoodjs/agent-ci
-
 # Run a specific workflow
-npx agent-ci run --workflow .github/workflows/ci.yml
+npx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml
 
 # Run all workflows for the current branch
-npx agent-ci run --all
+npx @redwoodjs/agent-ci run --all
 ```
 
 The first run is slow while caches warm up. After that, it's the loop.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,20 +18,14 @@ Agent CI runs on any machine that can run a container. When a step fails the run
   - **macOS:** [OrbStack](https://orbstack.dev/) (recommended) or Docker Desktop
   - **Linux:** Native Docker Engine or Docker Desktop
 
-## Installation
-
-```bash
-npm install -D @redwoodjs/agent-ci
-```
-
 ## Usage
 
 ```bash
 # Run a specific workflow
-npx agent-ci run --workflow .github/workflows/ci.yml
+npx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml
 
 # Run all relevant workflows for the current branch
-npx agent-ci run --all
+npx @redwoodjs/agent-ci run --all
 ```
 
 ### Remote Docker
@@ -39,7 +33,7 @@ npx agent-ci run --all
 Agent CI connects to Docker via the `DOCKER_HOST` environment variable. By default it uses the local socket (`unix:///var/run/docker.sock`), but you can point it at any remote Docker daemon:
 
 ```bash
-DOCKER_HOST=ssh://user@remote-server npx agent-ci run --workflow .github/workflows/ci.yml
+DOCKER_HOST=ssh://user@remote-server npx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml
 ```
 
 ### Docker host resolution for job containers
@@ -112,10 +106,10 @@ You can override the auto-detected limit with `--jobs`:
 
 ```bash
 # Run at most 4 containers at a time
-npx agent-ci run --all --jobs 4
+npx @redwoodjs/agent-ci run --all --jobs 4
 
 # Run one at a time (safest, slowest)
-npx agent-ci run --all --jobs 1
+npx @redwoodjs/agent-ci run --all --jobs 1
 ```
 
 ## YAML Compatibility
@@ -140,5 +134,5 @@ Set the `DEBUG` environment variable to enable verbose debug logging. It accepts
 - Pattern matching uses [minimatch](https://github.com/isaacs/minimatch) globs, so `agent-ci:*` matches all four namespaces.
 
 ```bash
-DEBUG=agent-ci:* npx agent-ci run
+DEBUG=agent-ci:* npx @redwoodjs/agent-ci run
 ```


### PR DESCRIPTION
## Summary

- Drop the `npm install -D` step everywhere — just use `npx @redwoodjs/agent-ci` directly
- Simplified "Copy agent instructions" to: install the skill, then run it
- Updated README, CLI README, website Quick Start, hero demo, blog post, and agent instructions

## Test plan

- [x] CI passes
- [ ] Verify website after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)