### PR TITLE
fix: Cypress install fails with EACCES on /home/runner/.cache

### DIFF
--- a/.changeset/shy-bears-wave.md
+++ b/.changeset/shy-bears-wave.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Fix Cypress install failing with EACCES on `/home/runner/.cache/Cypress`.

--- a/.github/workflows/smoke-cypress-cache.yml
+++ b/.github/workflows/smoke-cypress-cache.yml
@@ -1,0 +1,97 @@
+name: "Smoke: Cypress cache directory permissions"
+
+# Reproduces #234 — Cypress postinstall fails with EACCES because
+# /home/runner/.cache is created as root by the Playwright bind mount.
+#
+# The Playwright cache is bind-mounted at /home/runner/.cache/ms-playwright,
+# which causes Docker to create the parent /home/runner/.cache as root:root.
+# When Cypress's postinstall script runs `mkdir /home/runner/.cache/Cypress`,
+# it fails with:
+#
+#   EACCES: permission denied, mkdir '/home/runner/.cache/Cypress'
+#
+# This smoke test creates a minimal npm project whose inner workflow
+# verifies that /home/runner/.cache is writable — the same operation
+# Cypress needs during its postinstall.
+
+on:
+  pull_request_target:
+    types: [opened, labeled, synchronize]
+
+jobs:
+  cypress-cache:
+    if: '!github.event.pull_request.draft && (contains(fromJSON(''["MEMBER", "OWNER", "COLLABORATOR"]''), github.event.pull_request.author_association) || contains(github.event.pull_request.labels.*.name, ''safe-to-run''))'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - run: pnpm install
+
+      - name: Build agent-ci
+        run: pnpm --filter @redwoodjs/agent-ci... -r build
+
+      - name: Create temp npm project
+        run: |
+          mkdir -p /tmp/cypress-repro/.github/workflows
+
+          cat > /tmp/cypress-repro/package.json << 'PKG'
+          { "name": "cypress-repro", "private": true }
+          PKG
+
+          # Minimal package-lock.json so detectPackageManager() returns "npm"
+          cat > /tmp/cypress-repro/package-lock.json << 'LOCK'
+          {
+            "name": "cypress-repro",
+            "lockfileVersion": 3,
+            "requires": true,
+            "packages": {
+              "": { "name": "cypress-repro" }
+            }
+          }
+          LOCK
+
+          # Inner workflow: reproduce the mkdir that Cypress postinstall performs
+          cat > /tmp/cypress-repro/.github/workflows/test.yml << 'WF'
+          name: Test
+          on: push
+          jobs:
+            test:
+              runs-on: ubuntu-latest
+              steps:
+                - name: Verify .cache is writable (Cypress postinstall needs this)
+                  run: |
+                    echo "Parent .cache owner:"
+                    ls -la /home/runner/ | grep .cache || echo ".cache does not exist"
+                    echo "---"
+                    # This is what Cypress postinstall does — mkdir its cache dir
+                    mkdir -p /home/runner/.cache/Cypress
+                    echo "Successfully created /home/runner/.cache/Cypress"
+                    touch /home/runner/.cache/Cypress/test-file
+                    echo "Successfully wrote to /home/runner/.cache/Cypress"
+          WF
+
+          cd /tmp/cypress-repro
+          git init
+          git remote add origin https://github.com/test-org/cypress-repro.git
+          git add -A
+          git -c user.name="test" -c user.email="test@test.com" commit -m "init"
+
+      - name: Run agent-ci against npm project
+        working-directory: /tmp/cypress-repro
+        run: |
+          node "$GITHUB_WORKSPACE/packages/cli/dist/cli.js" \
+            run --workflow .github/workflows/test.yml --quiet

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @redwoodjs/agent-ci
 
+## 0.10.4
+
+### Patch Changes
+
+- Fix Cypress install failing with EACCES on `/home/runner/.cache/Cypress` (#234).
+
 ## 0.10.3
 
 ### Patch Changes

--- a/packages/cli/src/docker/container-config.ts
+++ b/packages/cli/src/docker/container-config.ts
@@ -157,6 +157,9 @@ export function buildContainerCmd(opts: ContainerCmdOpts): string[] {
     T("git-shim"),
     `${svcPortForwardSnippet}chmod 666 /var/run/docker.sock 2>/dev/null || true`,
     T("docker-sock"),
+    // The Playwright bind mount creates /home/runner/.cache as root — make it
+    // world-writable so tools like Cypress can mkdir inside it (#234).
+    `MAYBE_SUDO chmod 1777 /home/runner/.cache 2>/dev/null || true`,
     `cd /home/runner`,
     `${credentialSnippet}true`,
     T("credentials"),


### PR DESCRIPTION
## Problem

Cypress needs to create `/home/runner/.cache/Cypress` during install. But `/home/runner/.cache` is owned by root, so it gets `permission denied`.

Root cause: the Playwright bind mount at `/home/runner/.cache/ms-playwright` makes Docker create the parent `.cache` as `root:root 755`. The runner user can read it but can't create new folders inside it.

## Solution

`chmod 1777 /home/runner/.cache` in the container entrypoint — same pattern we use for the Docker socket. Now any tool that needs `.cache` just works.

## Test plan

- [x] Added `smoke-cypress-cache.yml` — reproduces the `mkdir` failure
- [x] All 25 jobs pass locally with the fix

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)