### PR TITLE
fix: always show workflows and jobs in --all mode

### DIFF
--- a/.changeset/bright-jobs-show.md
+++ b/.changeset/bright-jobs-show.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+fix: always show workflows and jobs in --all mode, fix duplicate matrix jobs

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -54,7 +54,7 @@ import { computeDirtySha } from "./runner/dirty-sha.js";
 import { RunStateStore } from "./output/run-state.js";
 import { renderRunState } from "./output/state-renderer.js";
 import { isAgentMode, setQuietMode } from "./output/agent-mode.js";
-import logUpdate from "log-update";
+import { createDiffRenderer } from "./output/diff-renderer.js";
 import { createFailedJobResult, wrapJobError, isJobError } from "./runner/job-result.js";
 import { postCommitStatus } from "./commit-status.js";
 
@@ -393,6 +393,7 @@ async function runWorkflows(options: {
   // In agent mode (AI_AGENT=1 or --quiet), skip animated rendering to avoid token waste
   // but register a synchronous callback for important state changes.
   let renderInterval: ReturnType<typeof setInterval> | null = null;
+  let renderer: ReturnType<typeof createDiffRenderer> | null = null;
   if (isAgentMode()) {
     const reportedPauses = new Set<string>();
     const reportedSteps = new Map<string, Set<string>>();
@@ -438,10 +439,12 @@ async function runWorkflows(options: {
       }
     });
   } else {
+    renderer = createDiffRenderer();
+    const render = renderer;
     renderInterval = setInterval(() => {
       const state = store.getState();
       if (state.workflows.length > 0) {
-        logUpdate(renderRunState(state));
+        render.update(renderRunState(state));
       }
     }, 80);
   }
@@ -596,13 +599,13 @@ async function runWorkflows(options: {
     if (renderInterval) {
       clearInterval(renderInterval);
     }
-    if (!isAgentMode()) {
+    if (renderer) {
       // Final render — show the completed state
       const finalState = store.getState();
       if (finalState.workflows.length > 0) {
-        logUpdate(renderRunState(finalState));
+        renderer.update(renderRunState(finalState));
       }
-      logUpdate.done();
+      renderer.done();
     }
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -457,6 +457,12 @@ async function runWorkflows(options: {
   process.on("SIGTERM", exitOnSignal);
   process.on("SIGHUP", exitOnSignal);
 
+  // Pre-register all workflows so they appear immediately in the render
+  // loop (as "queued") before any bootstrap or execution starts.
+  for (const wp of workflowPaths) {
+    store.addWorkflow(wp);
+  }
+
   // ── Session bootstrap ─────────────────────────────────────────────────────
   // Global Docker/workspace cleanup + image prefetch run once per session
   // instead of per-workflow. With `--all` launching many workflows in
@@ -704,6 +710,29 @@ async function handleWorkflow(options: {
     }
   }
 
+  // Pre-register all jobs so they appear as "queued" in the render loop
+  // before execution starts. Uses the same naming convention as buildJob.
+  // Only in multi-workflow mode (baseRunNum is set) where naming is deterministic.
+  if (expandedJobs.length > 1 && options.baseRunNum != null) {
+    for (let i = 0; i < expandedJobs.length; i++) {
+      const ej = expandedJobs[i];
+      let suffix = `-j${i + 1}`;
+      if (ej.matrixContext) {
+        const shardIdx = parseInt(ej.matrixContext.__job_index ?? "0", 10) + 1;
+        suffix += `-m${shardIdx}`;
+      }
+      const runnerId = `agent-ci-${options.baseRunNum}${suffix}`;
+      const storeWfPath = ej.callerJobId ? workflowPath : ej.workflowPath;
+      store.addJob(storeWfPath, ej.taskName, runnerId, {
+        matrixValues: ej.matrixContext
+          ? Object.fromEntries(
+              Object.entries(ej.matrixContext).filter(([k]) => !k.startsWith("__")),
+            )
+          : undefined,
+      });
+    }
+  }
+
   // For single-job workflows, run directly without extra orchestration
   if (expandedJobs.length === 1) {
     const ej = expandedJobs[0];
@@ -763,6 +792,7 @@ async function handleWorkflow(options: {
       services,
       container: container ?? undefined,
       workflowPath: ej.workflowPath,
+      parentWorkflowPath: ej.callerJobId ? workflowPath : undefined,
       taskId: ej.taskName,
     };
 
@@ -792,7 +822,6 @@ async function handleWorkflow(options: {
 
   // Naming convention: agent-ci-<N>[-j<idx>][-m<shardIdx>]
   const baseRunNum = options.baseRunNum ?? getNextLogNum("agent-ci");
-  let globalIdx = 0;
 
   const buildJob = (ej: ExpandedJob): Job => {
     const actualTaskName = ej.sourceTaskName ?? ej.taskName;
@@ -804,7 +833,9 @@ async function handleWorkflow(options: {
     const secretsFilePath = path.join(repoRoot, ".env.agent-ci");
     validateSecrets(ej.workflowPath, actualTaskName, secrets, secretsFilePath);
 
-    const idx = globalIdx++;
+    // Use the job's position in expandedJobs (not a mutable counter) so the
+    // runnerId is deterministic and matches the pre-registration at line 716.
+    const idx = expandedJobs.indexOf(ej);
     let suffix = `-j${idx + 1}`;
     if (ej.matrixContext) {
       const shardIdx = parseInt(ej.matrixContext.__job_index ?? "0", 10) + 1;
@@ -835,6 +866,7 @@ async function handleWorkflow(options: {
       services: undefined as any,
       container: undefined,
       workflowPath: ej.workflowPath,
+      parentWorkflowPath: ej.callerJobId ? workflowPath : undefined,
       taskId: ej.taskName,
     };
   };

--- a/packages/cli/src/output/diff-renderer.ts
+++ b/packages/cli/src/output/diff-renderer.ts
@@ -1,0 +1,83 @@
+// ─── Diff Renderer ────────────────────────────────────────────────────────────
+// Lightweight terminal renderer that diffs output line-by-line and only
+// rewrites changed lines. For a 30-line tree where only 2–3 spinner chars
+// change per frame, this skips ~90% of the ANSI escape traffic that
+// log-update's full erase-and-rewrite approach would produce.
+//
+// Cursor movement uses explicit CSI sequences (CUU/CUD) instead of \n to
+// avoid ambiguity with terminal onlcr/raw-mode settings.
+
+const ESC = "\x1b";
+const CUD1 = `${ESC}[1B`; // cursor down 1 row (no scroll, no CR)
+
+export interface DiffRenderer {
+  /** Diff-render the output, only updating changed lines. */
+  update(output: string): void;
+  /** Persist the current output and restore the cursor. */
+  done(): void;
+}
+
+export function createDiffRenderer(): DiffRenderer {
+  let prevLines: string[] = [];
+  let lastOutput = "";
+
+  // Ensure cursor is always restored, even on unexpected exit
+  const restoreCursor = () => process.stdout.write(`${ESC}[?25h`);
+  process.on("exit", restoreCursor);
+
+  return {
+    update(output: string) {
+      // Completely identical → skip all work
+      if (output === lastOutput) {
+        return;
+      }
+      lastOutput = output;
+
+      const newLines = output.split("\n");
+
+      // First render: hide cursor, write everything
+      if (prevLines.length === 0) {
+        process.stdout.write(`${ESC}[?25l${output}\n`);
+        prevLines = newLines;
+        return;
+      }
+
+      // Move cursor to the top of the previous output
+      let buf = `${ESC}[${prevLines.length}A\r`;
+
+      // Diff lines that exist in both old and new output.
+      // Use CUD1+\r for movement — never bare \n — so column is always 0.
+      const commonLen = Math.min(prevLines.length, newLines.length);
+      for (let i = 0; i < commonLen; i++) {
+        if (prevLines[i] === newLines[i]) {
+          buf += `${CUD1}\r`; // skip unchanged line
+        } else {
+          buf += `${ESC}[2K${newLines[i]}${CUD1}\r`; // clear, write, next row col 0
+        }
+      }
+
+      // Output grew — append new lines (need \n to create new terminal rows)
+      for (let i = commonLen; i < newLines.length; i++) {
+        buf += `${ESC}[2K${newLines[i]}\n`;
+      }
+
+      // Output shrank — clear leftover lines, then reposition cursor
+      if (newLines.length < prevLines.length) {
+        for (let i = commonLen; i < prevLines.length; i++) {
+          buf += `${ESC}[2K${CUD1}\r`;
+        }
+        buf += `${ESC}[${prevLines.length - newLines.length}A\r`;
+      }
+
+      process.stdout.write(buf);
+      prevLines = newLines;
+    },
+
+    done() {
+      process.stdout.write(`${ESC}[?25h\n`);
+      process.removeListener("exit", restoreCursor);
+      prevLines = [];
+      lastOutput = "";
+    },
+  };
+}

--- a/packages/cli/src/output/diff-renderer.ts
+++ b/packages/cli/src/output/diff-renderer.ts
@@ -9,6 +9,8 @@
 
 const ESC = "\x1b";
 const CUD1 = `${ESC}[1B`; // cursor down 1 row (no scroll, no CR)
+const SYNC_START = `${ESC}[?2026h`; // DEC synchronized output — begin
+const SYNC_END = `${ESC}[?2026l`; // DEC synchronized output — end
 
 export interface DiffRenderer {
   /** Diff-render the output, only updating changed lines. */
@@ -42,8 +44,10 @@ export function createDiffRenderer(): DiffRenderer {
         return;
       }
 
-      // Move cursor to the top of the previous output
-      let buf = `${ESC}[${prevLines.length}A\r`;
+      // Begin synchronized update — terminal buffers all changes and
+      // repaints once at SYNC_END, eliminating mid-frame flicker.
+      // Terminals that don't support DEC sync silently ignore the markers.
+      let buf = `${SYNC_START}${ESC}[${prevLines.length}A\r`;
 
       // Diff lines that exist in both old and new output.
       // Use CUD1+\r for movement — never bare \n — so column is always 0.
@@ -69,6 +73,7 @@ export function createDiffRenderer(): DiffRenderer {
         buf += `${ESC}[${prevLines.length - newLines.length}A\r`;
       }
 
+      buf += SYNC_END;
       process.stdout.write(buf);
       prevLines = newLines;
     },

--- a/packages/cli/src/output/run-state.test.ts
+++ b/packages/cli/src/output/run-state.test.ts
@@ -123,10 +123,10 @@ describe("RunStateStore", () => {
   });
 
   describe("atomic persistence", () => {
-    it("save writes a valid JSON file", () => {
+    it("save writes a valid JSON file", async () => {
       const store = makeStore("persist-test");
       store.addJob("/repo/.github/workflows/ci.yml", "test", "agent-ci-1");
-      store.save();
+      await store.save();
 
       const filePath = path.join(tmpDir, "persist-test", "run-state.json");
       expect(fs.existsSync(filePath)).toBe(true);
@@ -135,11 +135,11 @@ describe("RunStateStore", () => {
       expect(parsed.workflows).toHaveLength(1);
     });
 
-    it("load round-trips the state from disk", () => {
+    it("load round-trips the state from disk", async () => {
       const store = makeStore("roundtrip");
       store.addJob("/repo/.github/workflows/ci.yml", "test", "agent-ci-1");
       store.updateJob("agent-ci-1", { status: "running" });
-      store.save();
+      await store.save();
 
       const filePath = path.join(tmpDir, "roundtrip", "run-state.json");
       const loaded = RunStateStore.load(filePath);
@@ -147,9 +147,9 @@ describe("RunStateStore", () => {
       expect(loaded.workflows[0].jobs[0].status).toBe("running");
     });
 
-    it("save does not leave .tmp files behind", () => {
+    it("save does not leave .tmp files behind", async () => {
       const store = makeStore("no-tmp");
-      store.save();
+      await store.save();
       const dir = path.join(tmpDir, "no-tmp");
       const files = fs.readdirSync(dir);
       expect(files.some((f) => f.endsWith(".tmp"))).toBe(false);

--- a/packages/cli/src/output/run-state.ts
+++ b/packages/cli/src/output/run-state.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import fsp from "fs/promises";
 import path from "path";
 
 // ─── Status types ─────────────────────────────────────────────────────────────
@@ -216,17 +217,18 @@ export class RunStateStore {
   }
 
   /**
-   * Atomically write state to disk.
+   * Atomically write state to disk (async, non-blocking).
    * Uses write-tmp-then-rename to prevent corruption on concurrent reads.
    */
   save(): void {
-    try {
-      const tmp = this.filePath + ".tmp";
-      fs.writeFileSync(tmp, JSON.stringify(this.state, null, 2));
-      fs.renameSync(tmp, this.filePath);
-    } catch {
-      // Best-effort — rendering uses in-memory state, not disk
-    }
+    const tmp = this.filePath + ".tmp";
+    const data = JSON.stringify(this.state, null, 2);
+    fsp
+      .writeFile(tmp, data)
+      .then(() => fsp.rename(tmp, this.filePath))
+      .catch(() => {
+        // Best-effort — rendering uses in-memory state, not disk
+      });
   }
 
   /** Load a previously-written RunState from disk. */

--- a/packages/cli/src/output/run-state.ts
+++ b/packages/cli/src/output/run-state.ts
@@ -91,6 +91,8 @@ export class RunStateStore {
   private state: RunState;
   private filePath: string;
   private listeners: StoreListener[] = [];
+  private saveTimer: ReturnType<typeof setTimeout> | null = null;
+  private saveDirty = false;
 
   constructor(runId: string, filePath: string) {
     this.state = {
@@ -110,6 +112,22 @@ export class RunStateStore {
 
   getState(): RunState {
     return this.state;
+  }
+
+  /**
+   * Pre-register a workflow so it appears in the render loop immediately
+   * (e.g. as "queued") before any jobs have been added.
+   */
+  addWorkflow(workflowPath: string): void {
+    if (!this.state.workflows.some((w) => w.path === workflowPath)) {
+      this.state.workflows.push({
+        id: path.basename(workflowPath),
+        path: workflowPath,
+        status: "queued",
+        jobs: [],
+      });
+      this.notify();
+    }
   }
 
   /**
@@ -163,15 +181,38 @@ export class RunStateStore {
         break;
       }
     }
-    this.save();
+    this.debouncedSave();
     this.notify();
   }
 
-  /** Mark the overall run complete and persist. */
+  /** Mark the overall run complete and persist immediately. */
   complete(status: RunStatus): void {
     this.state.status = status;
     this.state.completedAt = new Date().toISOString();
+    // Flush any pending debounced save, then write final state
+    if (this.saveTimer) {
+      clearTimeout(this.saveTimer);
+      this.saveTimer = null;
+    }
     this.save();
+  }
+
+  /**
+   * Debounced save — coalesces rapid state updates into a single disk write.
+   * The in-memory state is always current; only the disk persistence is batched
+   * to avoid blocking the event loop (and stalling the render interval).
+   */
+  private debouncedSave(): void {
+    this.saveDirty = true;
+    if (!this.saveTimer) {
+      this.saveTimer = setTimeout(() => {
+        this.saveTimer = null;
+        if (this.saveDirty) {
+          this.saveDirty = false;
+          this.save();
+        }
+      }, 200);
+    }
   }
 
   /**

--- a/packages/cli/src/output/run-state.ts
+++ b/packages/cli/src/output/run-state.ts
@@ -220,10 +220,10 @@ export class RunStateStore {
    * Atomically write state to disk (async, non-blocking).
    * Uses write-tmp-then-rename to prevent corruption on concurrent reads.
    */
-  save(): void {
+  save(): Promise<void> {
     const tmp = this.filePath + ".tmp";
     const data = JSON.stringify(this.state, null, 2);
-    fsp
+    return fsp
       .writeFile(tmp, data)
       .then(() => fsp.rename(tmp, this.filePath))
       .catch(() => {

--- a/packages/cli/src/output/state-renderer.test.ts
+++ b/packages/cli/src/output/state-renderer.test.ts
@@ -456,13 +456,15 @@ describe("renderRunState", () => {
   });
 
   describe("multi-workflow (--all mode)", () => {
-    it("renders multiple workflow roots", () => {
+    it("collapses completed workflow to a single line with ✓ and duration", () => {
       const state = makeState({
         workflows: [
           {
             id: "ci.yml",
             path: "/repo/.github/workflows/ci.yml",
             status: "completed",
+            startedAt: "1970-01-01T00:00:00.000Z",
+            completedAt: "1970-01-01T00:00:15.000Z",
             jobs: [
               {
                 id: "test",
@@ -477,6 +479,7 @@ describe("renderRunState", () => {
             id: "deploy.yml",
             path: "/repo/.github/workflows/deploy.yml",
             status: "running",
+            startedAt: "1970-01-01T00:00:00.000Z",
             jobs: [
               {
                 id: "deploy",
@@ -491,14 +494,422 @@ describe("renderRunState", () => {
       });
 
       const output = renderRunState(state);
-      expect(output).toContain("ci.yml");
-      expect(output).toContain("deploy.yml");
-      expect(output).toContain("✓ test");
-      expect(output).toContain("agent-ci-5-j1");
-      expect(output).toContain("⠋ Starting runner agent-ci-5-j2 (0s)");
+      // Completed workflow collapsed to one line
+      expect(output).toContain("✓ ci.yml (15s)");
+      // No individual job details for either workflow
+      expect(output).not.toContain("agent-ci-5-j1");
+      expect(output).not.toContain("agent-ci-5-j2");
+      // Running workflow is a single line with spinner and booting hint
+      expect(output).toContain("⠋ deploy.yml");
+      expect(output).toContain("booting");
     });
 
-    it("groups multiple jobs under their respective workflow", () => {
+    it("collapses failed workflow to a single red line with ✗", () => {
+      const state = makeState({
+        workflows: [
+          {
+            id: "ci.yml",
+            path: "/repo/.github/workflows/ci.yml",
+            status: "failed",
+            startedAt: "1970-01-01T00:00:00.000Z",
+            completedAt: "1970-01-01T00:00:10.000Z",
+            jobs: [
+              {
+                id: "test",
+                runnerId: "agent-ci-5-j1",
+                status: "failed",
+                failedStep: "Run tests",
+                durationMs: 10000,
+                steps: [],
+              },
+            ],
+          },
+          {
+            id: "lint.yml",
+            path: "/repo/.github/workflows/lint.yml",
+            status: "completed",
+            startedAt: "1970-01-01T00:00:00.000Z",
+            completedAt: "1970-01-01T00:00:05.000Z",
+            jobs: [
+              {
+                id: "lint",
+                runnerId: "agent-ci-6-j1",
+                status: "completed",
+                durationMs: 5000,
+                steps: [],
+              },
+            ],
+          },
+        ],
+      });
+
+      const output = renderRunState(state);
+      // Single-job workflows collapse to one line (no job children)
+      expect(output).toContain("✗ ci.yml");
+      expect(output).toContain("(10s)");
+      expect(output).toContain("✓ lint.yml (5s)");
+      expect(output).not.toContain("agent-ci-5-j1");
+      expect(output).not.toContain("agent-ci-6-j1");
+    });
+
+    it("keeps completed multi-job workflow expanded to show jobs", () => {
+      const state = makeState({
+        workflows: [
+          {
+            id: "ci.yml",
+            path: "/repo/.github/workflows/ci.yml",
+            status: "completed",
+            startedAt: "1970-01-01T00:00:00.000Z",
+            completedAt: "1970-01-01T00:00:20.000Z",
+            jobs: [
+              {
+                id: "lint",
+                runnerId: "agent-ci-5-j1",
+                status: "completed",
+                durationMs: 5000,
+                steps: [],
+              },
+              {
+                id: "test",
+                runnerId: "agent-ci-5-j2",
+                status: "completed",
+                durationMs: 15000,
+                steps: [],
+              },
+            ],
+          },
+          {
+            id: "lint.yml",
+            path: "/repo/.github/workflows/lint.yml",
+            status: "completed",
+            startedAt: "1970-01-01T00:00:00.000Z",
+            completedAt: "1970-01-01T00:00:05.000Z",
+            jobs: [
+              {
+                id: "lint",
+                runnerId: "agent-ci-6-j1",
+                status: "completed",
+                durationMs: 5000,
+                steps: [],
+              },
+            ],
+          },
+        ],
+      });
+
+      const output = renderRunState(state);
+      // Multi-job workflow shows jobs even when completed
+      expect(output).toContain("✓ ci.yml (20s)");
+      expect(output).toContain("✓ lint.yml (5s)");
+      // Individual job names are visible
+      expect(output).toContain("✓ lint (5s)");
+      expect(output).toContain("✓ test (15s)");
+    });
+
+    it("shows queued jobs before workflow has started", () => {
+      const state = makeState({
+        workflows: [
+          {
+            id: "cache.yml",
+            path: "/repo/.github/workflows/cache.yml",
+            status: "queued",
+            jobs: [
+              {
+                id: "install-a",
+                runnerId: "agent-ci-5-j1",
+                status: "queued",
+                steps: [],
+              },
+              {
+                id: "install-b",
+                runnerId: "agent-ci-5-j2",
+                status: "queued",
+                steps: [],
+              },
+              {
+                id: "install-c",
+                runnerId: "agent-ci-5-j3",
+                status: "queued",
+                steps: [],
+              },
+            ],
+          },
+          {
+            id: "ci.yml",
+            path: "/repo/.github/workflows/ci.yml",
+            status: "running",
+            jobs: [
+              {
+                id: "test",
+                runnerId: "agent-ci-6-j1",
+                status: "running",
+                steps: [
+                  {
+                    name: "Run tests",
+                    index: 1,
+                    status: "running",
+                    startedAt: "1970-01-01T00:00:00.000Z",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      const output = renderRunState(state);
+      // All three queued jobs visible under the queued workflow
+      expect(output).toContain("○ cache.yml");
+      expect(output).toContain("○ install-a");
+      expect(output).toContain("○ install-b");
+      expect(output).toContain("○ install-c");
+    });
+
+    it("shows queued workflow with ○ icon", () => {
+      const state = makeState({
+        workflows: [
+          {
+            id: "ci.yml",
+            path: "/repo/.github/workflows/ci.yml",
+            status: "running",
+            startedAt: "1970-01-01T00:00:00.000Z",
+            jobs: [
+              {
+                id: "test",
+                runnerId: "agent-ci-5-j1",
+                status: "running",
+                steps: [
+                  {
+                    name: "Run tests",
+                    index: 1,
+                    status: "running",
+                    startedAt: "1970-01-01T00:00:00.000Z",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: "deploy.yml",
+            path: "/repo/.github/workflows/deploy.yml",
+            status: "queued",
+            jobs: [],
+          },
+        ],
+      });
+
+      const output = renderRunState(state);
+      expect(output).toContain("○ deploy.yml");
+      // Running workflow shows current step hint inline
+      expect(output).toContain("⠋ ci.yml");
+      expect(output).toContain('step 1/1 "Run tests" (0s...)');
+    });
+
+    it("keeps workflow with paused job expanded (not collapsed)", () => {
+      const state = makeState({
+        workflows: [
+          {
+            id: "ci.yml",
+            path: "/repo/.github/workflows/ci.yml",
+            status: "running",
+            jobs: [
+              {
+                id: "test",
+                runnerId: "agent-ci-5-j1",
+                status: "paused",
+                pausedAtStep: "Run tests",
+                pausedAtMs: "1970-01-01T00:00:05.000Z",
+                attempt: 1,
+                lastOutputLines: ["Error: test failed"],
+                steps: [
+                  {
+                    name: "Run tests",
+                    index: 1,
+                    status: "paused",
+                    startedAt: "1970-01-01T00:00:03.000Z",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: "lint.yml",
+            path: "/repo/.github/workflows/lint.yml",
+            status: "completed",
+            startedAt: "1970-01-01T00:00:00.000Z",
+            completedAt: "1970-01-01T00:00:05.000Z",
+            jobs: [
+              {
+                id: "lint",
+                runnerId: "agent-ci-6-j1",
+                status: "completed",
+                durationMs: 5000,
+                steps: [],
+              },
+            ],
+          },
+        ],
+      });
+
+      const output = renderRunState(state);
+      // Paused workflow stays expanded with spinner
+      expect(output).toContain("⠋ ci.yml");
+      expect(output).toContain("⏸ 1. Run tests (2s)");
+      expect(output).toContain("↻ To retry:");
+      // Completed workflow still collapsed
+      expect(output).toContain("✓ lint.yml (5s)");
+    });
+
+    it("formats workflow duration with minutes for long runs", () => {
+      const state = makeState({
+        workflows: [
+          {
+            id: "ci.yml",
+            path: "/repo/.github/workflows/ci.yml",
+            status: "completed",
+            startedAt: "1970-01-01T00:00:00.000Z",
+            completedAt: "1970-01-01T00:01:25.000Z", // 85 seconds
+            jobs: [
+              {
+                id: "test",
+                runnerId: "agent-ci-5-j1",
+                status: "completed",
+                durationMs: 85000,
+                steps: [],
+              },
+            ],
+          },
+          {
+            id: "lint.yml",
+            path: "/repo/.github/workflows/lint.yml",
+            status: "running",
+            jobs: [
+              {
+                id: "lint",
+                runnerId: "agent-ci-6-j1",
+                status: "running",
+                steps: [
+                  {
+                    name: "Lint",
+                    index: 1,
+                    status: "running",
+                    startedAt: "1970-01-01T00:00:00.000Z",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      const output = renderRunState(state);
+      expect(output).toContain("✓ ci.yml (1m 25s)");
+    });
+
+    it("sorts workflows alphabetically", () => {
+      const state = makeState({
+        workflows: [
+          {
+            id: "tests.yml",
+            path: "/repo/.github/workflows/tests.yml",
+            status: "completed",
+            startedAt: "1970-01-01T00:00:00.000Z",
+            completedAt: "1970-01-01T00:00:10.000Z",
+            jobs: [
+              {
+                id: "test",
+                runnerId: "agent-ci-5-j1",
+                status: "completed",
+                durationMs: 10000,
+                steps: [],
+              },
+            ],
+          },
+          {
+            id: "ci.yml",
+            path: "/repo/.github/workflows/ci.yml",
+            status: "completed",
+            startedAt: "1970-01-01T00:00:00.000Z",
+            completedAt: "1970-01-01T00:00:05.000Z",
+            jobs: [
+              {
+                id: "lint",
+                runnerId: "agent-ci-6-j1",
+                status: "completed",
+                durationMs: 5000,
+                steps: [],
+              },
+            ],
+          },
+        ],
+      });
+
+      const output = renderRunState(state);
+      const ciPos = output.indexOf("ci.yml");
+      const testsPos = output.indexOf("tests.yml");
+      expect(ciPos).toBeLessThan(testsPos);
+    });
+
+    it("expands running multi-job workflow to show each job", () => {
+      const state = makeState({
+        workflows: [
+          {
+            id: "ci.yml",
+            path: "/repo/.github/workflows/ci.yml",
+            status: "running",
+            startedAt: "1970-01-01T00:00:00.000Z",
+            jobs: [
+              {
+                id: "lint",
+                runnerId: "agent-ci-5-j1",
+                status: "completed",
+                durationMs: 5000,
+                steps: [],
+              },
+              {
+                id: "test",
+                runnerId: "agent-ci-5-j2",
+                status: "running",
+                steps: [
+                  { name: "Checkout", index: 1, status: "completed", durationMs: 500 },
+                  {
+                    name: "Run tests",
+                    index: 2,
+                    status: "running",
+                    startedAt: "1970-01-01T00:00:00.000Z",
+                  },
+                  { name: "Upload results", index: 3, status: "pending" },
+                ],
+              },
+              {
+                id: "build",
+                runnerId: "agent-ci-5-j3",
+                status: "queued",
+                steps: [],
+              },
+            ],
+          },
+          {
+            id: "lint.yml",
+            path: "/repo/.github/workflows/lint.yml",
+            status: "queued",
+            jobs: [],
+          },
+        ],
+      });
+
+      const output = renderRunState(state);
+      // Workflow expands with spinner
+      expect(output).toContain("⠋ ci.yml");
+      // Each job shown as a compact child
+      expect(output).toContain("✓ lint (5s)");
+      expect(output).toContain('step 2/3 "Run tests" (0s...)');
+      expect(output).toContain("○ build");
+      // No full step detail (step nodes like "1. Checkout" should not appear)
+      expect(output).not.toContain("Checkout");
+    });
+
+    it("groups multiple jobs under their respective workflow (single-workflow)", () => {
       const state = makeState({
         workflows: [
           {
@@ -526,7 +937,7 @@ describe("renderRunState", () => {
       });
 
       const output = renderRunState(state);
-      // ci.yml appears exactly once as root
+      // Single workflow — no collapsing, no status icon prefix
       expect(output.split("ci.yml").length).toBe(2); // 1 occurrence → 2 parts
       expect(output).toContain("✓ lint");
       expect(output).toContain("agent-ci-5-j1");

--- a/packages/cli/src/output/state-renderer.ts
+++ b/packages/cli/src/output/state-renderer.ts
@@ -9,6 +9,7 @@ import type { RunState, JobState, StepState } from "./run-state.js";
 
 // ─── ANSI helpers ─────────────────────────────────────────────────────────────
 
+const RED = `${String.fromCharCode(27)}[31m`;
 const YELLOW = `${String.fromCharCode(27)}[33m`;
 const DIM = `${String.fromCharCode(27)}[2m`;
 const RESET = `${String.fromCharCode(27)}[0m`;
@@ -25,6 +26,16 @@ function getSpinnerFrame(): string {
 
 function fmtMs(ms: number): string {
   return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms}ms`;
+}
+
+function fmtDuration(ms: number): string {
+  const s = Math.round(ms / 1000);
+  if (s < 60) {
+    return `${s}s`;
+  }
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return rem > 0 ? `${m}m ${rem}s` : `${m}m`;
 }
 
 function fmtBytes(bytes: number): string {
@@ -54,9 +65,13 @@ function buildStepNode(step: StepState, job: JobState, padW: number): TreeNode {
       const frame = getSpinnerFrame();
       // Retrying (was paused, now running again on same step)
       if ((job.attempt ?? 0) > 0 && job.pausedAtStep === step.name) {
-        return { label: `${frame} ${pad(step.index)}. ${step.name} — retrying (${elapsed}s...)` };
+        return {
+          label: `${frame} ${pad(step.index)}. ${step.name} — retrying (${elapsed}s...)`,
+        };
       }
-      return { label: `${frame} ${pad(step.index)}. ${step.name} (${elapsed}s...)` };
+      return {
+        label: `${frame} ${pad(step.index)}. ${step.name} (${elapsed}s...)`,
+      };
     }
 
     case "paused": {
@@ -70,7 +85,11 @@ function buildStepNode(step: StepState, job: JobState, padW: number): TreeNode {
             : 0;
       return {
         label: `⏸ ${pad(step.index)}. ${step.name} (${frozenElapsed}s)`,
-        children: [{ label: `${YELLOW}Step failed attempt #${job.attempt ?? 1}${RESET}` }],
+        children: [
+          {
+            label: `${YELLOW}Step failed attempt #${job.attempt ?? 1}${RESET}`,
+          },
+        ],
       };
     }
 
@@ -128,9 +147,15 @@ function buildJobNodes(job: JobState, singleJobMode: boolean): TreeNode[] {
 
   // ── Completed / failed in multi-job mode → collapse to one line ────────────
   if (!singleJobMode && (job.status === "completed" || job.status === "failed")) {
-    const icon = job.failedStep ? "✗" : "✓";
     const dur = job.durationMs !== undefined ? ` (${Math.round(job.durationMs / 1000)}s)` : "";
-    return [{ label: `${icon} ${job.id} ${DIM}${job.runnerId}${RESET}${dur}` }];
+    if (job.failedStep) {
+      return [
+        {
+          label: `${RED}✗ ${job.id}${RESET} ${DIM}${job.runnerId}${RESET}${dur}`,
+        },
+      ];
+    }
+    return [{ label: `✓ ${job.id} ${DIM}${job.runnerId}${RESET}${dur}` }];
   }
 
   // ── Build step nodes ───────────────────────────────────────────────────────
@@ -161,6 +186,51 @@ function buildJobNodes(job: JobState, singleJobMode: boolean): TreeNode[] {
   return [{ label: `${job.id} ${DIM}${job.runnerId}${RESET}`, children: stepNodes }];
 }
 
+// ─── Running step hint (multi-workflow mode) ─────────────────────────────────
+
+/**
+ * Build a compact one-line hint for a single job's current status.
+ * Used in multi-workflow mode to show each job with its active step.
+ */
+function getJobStepHint(job: JobState): string {
+  if (job.status === "booting") {
+    return ` ${DIM}— booting${RESET}`;
+  }
+  const runningStep = job.steps.find((s) => s.status === "running");
+  if (runningStep) {
+    const elapsed = runningStep.startedAt
+      ? Math.round((Date.now() - new Date(runningStep.startedAt).getTime()) / 1000)
+      : 0;
+    return ` ${DIM}— step ${runningStep.index}/${job.steps.length} "${runningStep.name}" (${elapsed}s...)${RESET}`;
+  }
+  return "";
+}
+
+/**
+ * Build a compact TreeNode for a job in multi-workflow mode.
+ * Each job is one line: icon + name + step hint or duration.
+ */
+function buildCompactJobNode(job: JobState): TreeNode {
+  const dur = job.durationMs !== undefined ? ` (${Math.round(job.durationMs / 1000)}s)` : "";
+  // Append matrix values to distinguish matrix-expanded jobs
+  const matrix =
+    job.matrixValues && Object.keys(job.matrixValues).length > 0
+      ? ` ${DIM}(${Object.values(job.matrixValues).join(", ")})${RESET}`
+      : "";
+  switch (job.status) {
+    case "completed":
+      return { label: `✓ ${job.id}${matrix}${dur}` };
+    case "failed":
+      return { label: `${RED}✗ ${job.id}${RESET}${matrix}${dur}` };
+    case "booting":
+    case "running":
+      return { label: `${getSpinnerFrame()} ${job.id}${matrix}${getJobStepHint(job)}` };
+    case "queued":
+    default:
+      return { label: `○ ${job.id}${matrix}` };
+  }
+}
+
 // ─── Main renderer ────────────────────────────────────────────────────────────
 
 /**
@@ -172,11 +242,71 @@ function buildJobNodes(job: JobState, singleJobMode: boolean): TreeNode[] {
 export function renderRunState(state: RunState): string {
   const totalJobs = state.workflows.reduce((sum, wf) => sum + wf.jobs.length, 0);
   const singleJobMode = state.workflows.length === 1 && totalJobs === 1;
+  const multiWorkflowMode = state.workflows.length > 1;
 
   const roots: TreeNode[] = [];
   let pausedJob: JobState | undefined;
 
-  for (const wf of state.workflows) {
+  // Sort workflows alphabetically in multi-workflow mode for stable output
+  const workflows = multiWorkflowMode
+    ? [...state.workflows].sort((a, b) =>
+        path.basename(a.path).localeCompare(path.basename(b.path)),
+      )
+    : state.workflows;
+
+  for (const wf of workflows) {
+    const wfName = path.basename(wf.path);
+    const hasPausedJob = wf.jobs.some((j) => j.status === "paused");
+
+    // ── Multi-workflow: compact GitHub Checks style ──────────────────────
+    if (multiWorkflowMode) {
+      // Paused workflows expand with full step detail for retry hints
+      if (hasPausedJob) {
+        const children: TreeNode[] = [];
+        for (const job of wf.jobs) {
+          children.push(...buildJobNodes(job, singleJobMode));
+          if (job.status === "paused" && !pausedJob) {
+            pausedJob = job;
+          }
+        }
+        roots.push({ label: `${getSpinnerFrame()} ${wfName}`, children });
+        continue;
+      }
+
+      // Build the workflow label (icon + name + optional duration)
+      let wfLabel: string;
+      if (wf.status === "completed" || wf.status === "failed") {
+        const durationMs =
+          wf.startedAt && wf.completedAt
+            ? new Date(wf.completedAt).getTime() - new Date(wf.startedAt).getTime()
+            : undefined;
+        const dur = durationMs !== undefined ? ` (${fmtDuration(durationMs)})` : "";
+        if (wf.status === "failed") {
+          wfLabel = `${RED}✗ ${wfName}${RESET}${dur}`;
+        } else {
+          wfLabel = `✓ ${wfName}${dur}`;
+        }
+      } else if (wf.status === "running") {
+        wfLabel = `${getSpinnerFrame()} ${wfName}`;
+      } else {
+        wfLabel = `○ ${wfName}`;
+      }
+
+      // Always show job children so they're visible from the start
+      // and never disappear (queued, running, completed, or failed).
+      if (wf.jobs.length > 1) {
+        const children = wf.jobs.map((job) => buildCompactJobNode(job));
+        roots.push({ label: wfLabel, children });
+      } else if (wf.jobs.length === 1) {
+        // Single-job: append step hint inline
+        roots.push({ label: `${wfLabel}${getJobStepHint(wf.jobs[0])}` });
+      } else {
+        roots.push({ label: wfLabel });
+      }
+      continue;
+    }
+
+    // ── Single-workflow mode: full expansion with job/step detail ──────────
     const children: TreeNode[] = [];
     for (const job of wf.jobs) {
       children.push(...buildJobNodes(job, singleJobMode));
@@ -186,7 +316,8 @@ export function renderRunState(state: RunState): string {
         pausedJob = job;
       }
     }
-    roots.push({ label: path.basename(wf.path), children });
+
+    roots.push({ label: wfName, children });
   }
 
   let output = renderTree(roots);

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -178,13 +178,20 @@ export async function executeLocalJob(
   } = createLogContext("agent-ci", job.runnerName);
 
   // Register the job in the store so the render loop can show the boot spinner
-  store?.addJob(job.workflowPath ?? "", job.taskId ?? "job", containerName, {
-    logDir,
-    debugLogPath,
-  });
+  store?.addJob(
+    job.parentWorkflowPath ?? job.workflowPath ?? "",
+    job.taskId ?? "job",
+    containerName,
+    {
+      logDir,
+      debugLogPath,
+    },
+  );
   store?.updateJob(containerName, {
     status: "booting",
     startedAt: new Date().toISOString(),
+    logDir,
+    debugLogPath,
   });
 
   const bootStart = Date.now();

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -1,6 +1,7 @@
 import Docker from "dockerode";
 import path from "path";
 import fs from "fs";
+import fsp from "fs/promises";
 import { execSync } from "child_process";
 import { createInterface } from "readline";
 import { config } from "../config.js";
@@ -971,18 +972,15 @@ export async function executeLocalJob(
     if (serviceCtx) {
       await cleanupServiceContainers(getDocker(), serviceCtx, (line) => debugRunner(line));
     }
-    if (fs.existsSync(dirs.shimsDir)) {
-      fs.rmSync(dirs.shimsDir, { recursive: true, force: true });
-    }
-    if (!pauseOnFailure && fs.existsSync(dirs.signalsDir)) {
-      fs.rmSync(dirs.signalsDir, { recursive: true, force: true });
-    }
-    if (fs.existsSync(dirs.diagDir)) {
-      fs.rmSync(dirs.diagDir, { recursive: true, force: true });
-    }
-    if (fs.existsSync(hostRunnerDir)) {
-      fs.rmSync(hostRunnerDir, { recursive: true, force: true });
-    }
+    // Clean up temp dirs asynchronously to avoid blocking the event loop
+    // (which would freeze spinner rendering for all other runners).
+    const rmOpts = { recursive: true, force: true } as const;
+    await Promise.all([
+      fsp.rm(dirs.shimsDir, rmOpts).catch(() => {}),
+      !pauseOnFailure ? fsp.rm(dirs.signalsDir, rmOpts).catch(() => {}) : undefined,
+      fsp.rm(dirs.diagDir, rmOpts).catch(() => {}),
+      fsp.rm(hostRunnerDir, rmOpts).catch(() => {}),
+    ]);
     await ephemeralDtu?.close().catch(() => {});
     process.removeListener("SIGINT", signalCleanup);
     process.removeListener("SIGTERM", signalCleanup);

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -2,7 +2,8 @@ import Docker from "dockerode";
 import path from "path";
 import fs from "fs";
 import fsp from "fs/promises";
-import { execSync } from "child_process";
+import { exec, execSync } from "child_process";
+import { promisify } from "util";
 import { createInterface } from "readline";
 import { config } from "../config.js";
 import { Job } from "../types.js";
@@ -337,7 +338,7 @@ export async function executeLocalJob(
     const workspacePrepStart = Date.now();
     const workspacePrepPromise = (async () => {
       try {
-        prepareWorkspace({
+        await prepareWorkspace({
           workflowPath: job.workflowPath,
           headSha: job.headSha,
           githubRepo: job.githubRepo,
@@ -348,7 +349,8 @@ export async function executeLocalJob(
       }
 
       try {
-        execSync(`chmod -R 777 "${dirs.containerWorkDir}" "${dirs.diagDir}"`, { stdio: "pipe" });
+        const execAsync = promisify(exec);
+        await execAsync(`chmod -R 777 "${dirs.containerWorkDir}" "${dirs.diagDir}"`);
       } catch {
         // Non-fatal: entrypoint has a fallback
       }

--- a/packages/cli/src/runner/workspace.ts
+++ b/packages/cli/src/runner/workspace.ts
@@ -1,6 +1,9 @@
-import { execSync } from "child_process";
+import { exec, execSync } from "child_process";
+import { promisify } from "util";
 import { copyWorkspace } from "../output/cleanup.js";
 import { findRepoRoot } from "./metadata.js";
+
+const execAsync = promisify(exec);
 
 // ─── Workspace preparation ────────────────────────────────────────────────────
 
@@ -15,7 +18,7 @@ export interface PrepareWorkspaceOpts {
  * Copy source files into the workspace directory, then initialise a fake
  * git repo so `actions/checkout` finds a valid workspace.
  */
-export function prepareWorkspace(opts: PrepareWorkspaceOpts): void {
+export async function prepareWorkspace(opts: PrepareWorkspaceOpts): Promise<void> {
   const { workflowPath, headSha, githubRepo, workspaceDir } = opts;
 
   // Resolve repo root — needed for both archive and rsync paths.
@@ -31,8 +34,7 @@ export function prepareWorkspace(opts: PrepareWorkspaceOpts): void {
 
   if (headSha && headSha !== "HEAD") {
     // Specific SHA requested — use git archive (clean snapshot)
-    execSync(`git archive ${headSha} | tar -x -C ${workspaceDir}`, {
-      stdio: "pipe",
+    await execAsync(`git archive ${headSha} | tar -x -C ${workspaceDir}`, {
       cwd: repoRoot,
     });
   } else {
@@ -43,7 +45,7 @@ export function prepareWorkspace(opts: PrepareWorkspaceOpts): void {
   }
 
   if (githubRepo) {
-    initFakeGitRepo(workspaceDir, githubRepo);
+    await initFakeGitRepo(workspaceDir, githubRepo);
   }
 }
 
@@ -52,30 +54,22 @@ export function prepareWorkspace(opts: PrepareWorkspaceOpts): void {
 /**
  * Initialise a fake git repository in `dir` so that `actions/checkout`
  * finds a valid workspace with a remote origin and detached HEAD.
+ *
+ * Each command is awaited individually so the event loop can service the
+ * render timer between git process spawns (avoids freezing all spinners).
  */
-export function initFakeGitRepo(dir: string, githubRepo: string): void {
+async function initFakeGitRepo(dir: string, githubRepo: string): Promise<void> {
+  const opts = { cwd: dir };
   // The remote URL must exactly match what actions/checkout computes via URL.origin.
   // Node.js URL.origin strips the default port (80), so we must NOT include :80.
-  execSync(`git init`, { cwd: dir, stdio: "pipe" });
-  execSync(`git config user.name "agent-ci"`, { cwd: dir, stdio: "pipe" });
-  execSync(`git config user.email "agent-ci@example.com"`, {
-    cwd: dir,
-    stdio: "pipe",
-  });
-  execSync(`git remote add origin http://127.0.0.1/${githubRepo}`, {
-    cwd: dir,
-    stdio: "pipe",
-  });
-  execSync(`git add . && git commit -m "workspace" || true`, {
-    cwd: dir,
-    stdio: "pipe",
-  });
+  await execAsync(`git init`, opts);
+  await execAsync(`git config user.name "agent-ci"`, opts);
+  await execAsync(`git config user.email "agent-ci@example.com"`, opts);
+  await execAsync(`git remote add origin http://127.0.0.1/${githubRepo}`, opts);
+  await execAsync(`git add . && git commit -m "workspace" || true`, opts);
   // Create main and refs/remotes/origin/main pointing to this commit
-  execSync(`git branch -M main`, { cwd: dir, stdio: "pipe" });
-  execSync(`git update-ref refs/remotes/origin/main HEAD`, {
-    cwd: dir,
-    stdio: "pipe",
-  });
+  await execAsync(`git branch -M main`, opts);
+  await execAsync(`git update-ref refs/remotes/origin/main HEAD`, opts);
   // Detach HEAD so checkout can freely delete ALL branches (it can't delete the current branch)
-  execSync(`git checkout --detach HEAD`, { cwd: dir, stdio: "pipe" });
+  await execAsync(`git checkout --detach HEAD`, opts);
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -24,5 +24,7 @@ export interface Job {
   container?: WorkflowContainer;
   taskId?: string;
   workflowPath?: string;
+  /** Top-level workflow path for display grouping (when workflowPath is a reusable callee) */
+  parentWorkflowPath?: string;
   [key: string]: any;
 }


### PR DESCRIPTION
## Problem

Two things were broken when running `--all`:

1. **Jobs would disappear.** Say you have a workflow called `cache.yml` with three jobs: `install-a`, `install-b`, and `install-c`. You'd expect to always see all three — but they'd only show up while the workflow was running. Before it started, they were missing. After it finished, they'd vanish. You couldn't tell what was going on.

2. **Matrix jobs showed up twice.** If a workflow had 3 matrix shards, you'd see 5 entries instead of 3. Two ghosts. This happened because each job got two different names — one when we reserved its spot in line, and a different one when it actually started running. Since the names didn't match, the system thought they were different jobs and showed both.

## Solution

1. **Always show jobs.** Removed the rule that said "only show job children when the workflow is running." Now jobs are visible the moment they're registered — whether the workflow is queued, running, completed, or failed. They never go away.

2. **Give each job the same name both times.** The old code used a counter that ticked up each time a job started running. But jobs don't always start in the same order they were registered (they run in parallel!). So the counter gave them different numbers. Fixed by looking up each job's position in the original list instead of using a counter. Same position = same name, every time.

## Test plan

- [x] New test: queued jobs appear under a queued workflow before execution starts
- [x] Updated test: completed multi-job workflows keep showing their jobs
- [x] All 116 output tests pass
- [x] CLI runs (`pnpm agent-ci-dev --help`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)