### PR TITLE
fix: include default_branch in event payload

### DIFF
--- a/packages/dtu-github-actions/src/server/routes/actions/generators.test.ts
+++ b/packages/dtu-github-actions/src/server/routes/actions/generators.test.ts
@@ -77,6 +77,37 @@ describe("createJobResponse", () => {
     expect(entry.v).toEqual({ t: 0, s: "from-step" });
   });
 
+  it("includes default_branch in event.repository (issue #241)", () => {
+    const payload = {
+      ...basePayload,
+      repository: {
+        full_name: "owner/repo",
+        name: "repo",
+        owner: { login: "owner" },
+        default_branch: "develop",
+      },
+    };
+
+    const response = createJobResponse("1", payload, "http://localhost:3000", "plan-1");
+    const body = JSON.parse(response.Body);
+    const github = body.ContextData.github;
+
+    function findKey(node: any, key: string): any {
+      if (node?.t === 2 && Array.isArray(node.d)) {
+        const entry = node.d.find((e: any) => e.k === key);
+        return entry?.v;
+      }
+      return undefined;
+    }
+
+    const event = findKey(github, "event");
+    const repo = findKey(event, "repository");
+    const defaultBranch = findKey(repo, "default_branch");
+
+    expect(defaultBranch).toBeDefined();
+    expect(defaultBranch).toEqual({ t: 0, s: "develop" });
+  });
+
   it("omits env from ContextData when no env is provided", () => {
     const response = createJobResponse("1", basePayload, "http://localhost:3000", "plan-1");
     const body = JSON.parse(response.Body);

--- a/packages/dtu-github-actions/src/server/routes/actions/generators.ts
+++ b/packages/dtu-github-actions/src/server/routes/actions/generators.ts
@@ -264,6 +264,7 @@ export function createJobResponse(
         full_name: repoFullName,
         name: repoName,
         owner: { login: ownerName },
+        default_branch: payload.repository?.default_branch,
       },
       before: payload.baseSha || "0000000000000000000000000000000000000000",
       after: realHeadSha,


### PR DESCRIPTION
## Problem

When you use `dorny/paths-filter` (or similar actions) with agent-ci, it breaks. It says something like:

> This action requires 'base' input to be configured or 'repository.default_branch' to be set in the event payload

That's because the action needs to know which branch is the "main" branch of your repo. In real GitHub Actions, this info is always there. But in agent-ci, we forgot to put it in the right spot.

## Solution

We were already passing `default_branch` in one place (the repository resources), but we forgot to also put it in the event payload — which is where most actions actually look for it.

This adds `default_branch` to `github.event.repository` so actions like `dorny/paths-filter` can find it where they expect it.

One line added, one test added. That's it.

Closes #241

## Test plan

- [x] New test: verifies `default_branch` appears in `event.repository` context data
- [x] All existing tests pass
- [x] agent-ci `--all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)