### PR TITLE
fix: permission errors in direct-container mode on Arch Linux

### DIFF
--- a/.changeset/permission-arch-linux.md
+++ b/.changeset/permission-arch-linux.md
@@ -1,0 +1,5 @@
+---
+"@redwoodjs/agent-ci": patch
+---
+
+fix: permission errors in direct-container mode on Arch Linux

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -45,6 +45,33 @@ import {
 } from "./runner-image.js";
 import { findRepoRoot } from "./metadata.js";
 
+// Fix permissions after extracting runner from container.
+// docker cp and cp -a copy files with restrictive permissions (often root-owned),
+// which breaks the runner's ability to create files like run-helper.sh.
+// Directories get 777 (world-writable), files get 755 (world-readable + executable).
+function ensureRunnerWriteable(rootDir: string): void {
+  const stack = [rootDir];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+
+    const stat = fs.statSync(current);
+    // Directories need full write access (777), files need read+execute for all (755)
+    fs.chmodSync(current, stat.isDirectory() ? 0o777 : 0o755);
+
+    if (!stat.isDirectory()) {
+      continue;
+    }
+
+    for (const entry of fs.readdirSync(current)) {
+      stack.push(path.join(current, entry));
+    }
+  }
+}
+
 // ─── Docker setup ─────────────────────────────────────────────────────────────
 
 import { resolveDockerSocket, type DockerSocket } from "../docker/docker-socket.js";
@@ -447,6 +474,7 @@ export async function executeLocalJob(
         );
         await fs.promises.writeFile(configShPath, configSh);
         await fs.promises.writeFile(markerFile, new Date().toISOString());
+        ensureRunnerWriteable(hostRunnerSeedDir);
         debugRunner(`Runner extracted.`);
       }
       for (const staleFile of [".runner", ".credentials", ".credentials_rsaparams"]) {


### PR DESCRIPTION
## Summary

Fixes permission errors that occur when running agent-ci in direct-container mode on Arch Linux systems with stricter default permissions.

## Problem

When running jobs in direct-container mode, the runner directory retained restrictive permissions after extracting files from the seed container. The `docker cp` and `cp -a` commands preserve permissions from the container (often owned by root), causing "Permission denied" errors when the runner script tries to create files like `run-helper.sh`.

This is particularly prevalent on Arch Linux due to its stricter default umask (0022) and different Docker daemon configurations compared to Ubuntu/Debian systems.

## Changes

**`packages/cli/src/runner/local-job.ts`:**
- Added `ensureRunnerWriteable()` function that recursively applies correct permissions:
  - Directories: `777` (rwxrwxrwx) - world-writable for the runner to create files
  - Files: `755` (rwxr-xr-x) - world-readable and executable
- Applied after extracting the runner seed to ensure the runner can write to its own directories


## Testing

- ✅ smoke-binary: 1 passed (7s)
- ✅ smoke-outputs: 2 passed (7s)  
- ✅ smoke-matrix: 3 passed (11s)
- ✅ All unit tests pass (616 tests)

## Related

Fixes permission blocking local CI validation on Arch Linux systems.
