### PR TITLE
fix: setup-node "Bad credentials" + stale-toolcache hint

### DIFF
--- a/.changeset/fix-setup-node-manifest-and-toolcache-hint.md
+++ b/.changeset/fix-setup-node-manifest-and-toolcache-hint.md
@@ -1,0 +1,8 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Fix `actions/setup-node` emitting "Bad credentials" and falling back to a slow nodejs.org download. The bundled `@actions/tool-cache` hardcodes `api.github.com` for its versions-manifest fetch; the DTU now rewrites the URL in setup-node's tarball at cache time and mocks the `/repos/:owner/:repo/git/trees|blobs` endpoints so the manifest call routes through the DTU (fixes #249).
+
+Also: when a step fails with `tar: ...: Cannot open: Permission denied` (typically from a stale `/opt/hostedtoolcache` bind mount left by a previous run), surface an actionable hint showing the host-side toolcache path and an `rm -rf` command to clear it (fixes #171).

--- a/.github/workflows/smoke-node-setup.yml
+++ b/.github/workflows/smoke-node-setup.yml
@@ -1,0 +1,83 @@
+name: "Smoke: actions/setup-node manifest fetch"
+
+# Reproduces #249 — actions/setup-node@v5 printed "Bad credentials" and fell
+# back to downloading Node directly from nodejs.org because @actions/tool-cache
+# hardcodes https://api.github.com and escapes our DTU. This smoke creates a
+# throwaway project, runs agent-ci against a workflow that uses setup-node,
+# and fails if the step logs the fallback path.
+
+on:
+  pull_request_target:
+    types: [opened, labeled, synchronize]
+
+jobs:
+  node-setup:
+    if: '!github.event.pull_request.draft && (contains(fromJSON(''["MEMBER", "OWNER", "COLLABORATOR"]''), github.event.pull_request.author_association) || contains(github.event.pull_request.labels.*.name, ''safe-to-run''))'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - run: pnpm install
+
+      - name: Build agent-ci
+        run: pnpm --filter @redwoodjs/agent-ci... -r build
+
+      - name: Create temp node-setup project
+        run: |
+          mkdir -p /tmp/node-setup-repro/.github/workflows
+          cat > /tmp/node-setup-repro/package.json << 'PKG'
+          { "name": "node-setup-repro", "private": true }
+          PKG
+
+          cat > /tmp/node-setup-repro/.github/workflows/test.yml << 'WF'
+          name: Test
+          on: push
+          jobs:
+            test:
+              runs-on: ubuntu-latest
+              steps:
+                - uses: actions/setup-node@v5
+                  with:
+                    node-version: 24
+                    package-manager-cache: false
+                - name: Verify node
+                  run: |
+                    node --version
+                    corepack --version
+          WF
+
+          cd /tmp/node-setup-repro
+          git init
+          git remote add origin https://github.com/test-org/node-setup-repro.git
+          git add -A
+          git -c user.name="test" -c user.email="test@test.com" commit -m "init"
+
+      - name: Run agent-ci against node-setup project
+        id: run
+        working-directory: /tmp/node-setup-repro
+        run: |
+          node "$GITHUB_WORKSPACE/packages/cli/dist/cli.js" \
+            run --workflow .github/workflows/test.yml --quiet 2>&1 | tee /tmp/node-setup.out
+
+      - name: Assert setup-node took the manifest path (no "Bad credentials")
+        run: |
+          if grep -q "Bad credentials" /tmp/node-setup.out; then
+            echo "::error::setup-node fell back to the nodejs.org path — the DTU manifest mock is broken."
+            grep -n "Bad credentials\|Falling back\|Acquiring" /tmp/node-setup.out || true
+            exit 1
+          fi
+          echo "OK: no 'Bad credentials' in setup-node output."

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -963,6 +963,7 @@ export async function executeLocalJob(
       debugLogPath,
       stepOutputs,
       resolvedRunnerImage,
+      toolCacheDir: dirs.toolCacheDir,
     });
   } finally {
     // Cleanup: always runs even when errors occur mid-run.

--- a/packages/cli/src/runner/result-builder.ts
+++ b/packages/cli/src/runner/result-builder.ts
@@ -1,7 +1,11 @@
 import path from "path";
 import fs from "fs";
 import { type JobResult, type StepResult, tailLogFile } from "../output/reporter.js";
-import { detectMissingToolHint, type ResolvedRunnerImage } from "./runner-image.js";
+import {
+  detectMissingToolHint,
+  detectToolcacheHint,
+  type ResolvedRunnerImage,
+} from "./runner-image.js";
 
 // ─── Timeline parsing ─────────────────────────────────────────────────────────
 
@@ -265,6 +269,8 @@ export interface BuildJobResultOpts {
   stepOutputs?: Record<string, string>;
   /** The runner image the job used — used to attach actionable failure hints */
   resolvedRunnerImage?: ResolvedRunnerImage;
+  /** Host path of the toolcache bind mount — used for the toolcache-cleanup hint */
+  toolCacheDir?: string;
 }
 
 /**
@@ -313,25 +319,27 @@ export function buildJobResult(opts: BuildJobResultOpts): JobResult {
       result.lastOutputLines = tailLogFile(debugLogPath);
     }
 
-    // Attach an actionable hint if the failure matches a known missing-tool
-    // pattern (e.g. `cc`, `make`) and the user is still on the default runner
-    // image. Silent when they've already configured a custom image.
-    if (opts.resolvedRunnerImage) {
-      const errorContent =
-        (result.failedStepLogPath &&
-          (() => {
-            try {
-              return fs.readFileSync(result.failedStepLogPath, "utf-8");
-            } catch {
-              return "";
-            }
-          })()) ||
-        result.lastOutputLines?.join("\n") ||
-        "";
-      const hint = detectMissingToolHint(errorContent, opts.resolvedRunnerImage);
-      if (hint) {
-        result.hint = hint;
-      }
+    // Attach an actionable hint if the failure matches a known pattern —
+    // missing system tool on the default image, or a stale toolcache from a
+    // previous run blocking tar extraction.
+    const errorContent =
+      (result.failedStepLogPath &&
+        (() => {
+          try {
+            return fs.readFileSync(result.failedStepLogPath, "utf-8");
+          } catch {
+            return "";
+          }
+        })()) ||
+      result.lastOutputLines?.join("\n") ||
+      "";
+    const missingToolHint = opts.resolvedRunnerImage
+      ? detectMissingToolHint(errorContent, opts.resolvedRunnerImage)
+      : null;
+    const toolcacheHint = detectToolcacheHint(errorContent, opts.toolCacheDir);
+    const hint = missingToolHint ?? toolcacheHint;
+    if (hint) {
+      result.hint = hint;
     }
   }
 

--- a/packages/cli/src/runner/runner-image.test.ts
+++ b/packages/cli/src/runner/runner-image.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import {
   discoverRunnerImage,
   detectMissingToolHint,
+  detectToolcacheHint,
   UPSTREAM_RUNNER_IMAGE,
   type ResolvedRunnerImage,
 } from "./runner-image.js";
@@ -214,6 +215,37 @@ describe("detectMissingToolHint", () => {
 
   it("returns null for unrelated failures", () => {
     const hint = detectMissingToolHint("Error: assertion failed at line 42", defaultResolved);
+    expect(hint).toBeNull();
+  });
+});
+
+describe("detectToolcacheHint", () => {
+  const toolCacheDir = "/var/folders/xx/T/agent-ci/slug/cache/toolcache";
+
+  it("matches tar `Cannot open: Permission denied` and returns an rm command", () => {
+    const output = [
+      "/usr/bin/tar: bin/npm: Cannot open: Permission denied",
+      "/usr/bin/tar: bin/npx: Cannot open: Permission denied",
+      "/usr/bin/tar: Exiting with failure status due to previous errors",
+    ].join("\n");
+    const hint = detectToolcacheHint(output, toolCacheDir);
+    expect(hint).not.toBeNull();
+    expect(hint).toContain("sudo rm -rf");
+    expect(hint).toContain(toolCacheDir);
+  });
+
+  it("returns null when no toolCacheDir is supplied", () => {
+    const hint = detectToolcacheHint("tar: bin/npm: Cannot open: Permission denied", undefined);
+    expect(hint).toBeNull();
+  });
+
+  it("returns null for unrelated failures", () => {
+    const hint = detectToolcacheHint("npm ERR! code ENOENT", toolCacheDir);
+    expect(hint).toBeNull();
+  });
+
+  it("does not fire on generic Permission denied without the tar prefix", () => {
+    const hint = detectToolcacheHint("Permission denied: /home/runner/x", toolCacheDir);
     expect(hint).toBeNull();
   });
 });

--- a/packages/cli/src/runner/runner-image.ts
+++ b/packages/cli/src/runner/runner-image.ts
@@ -230,6 +230,38 @@ function formatHint(tool: string): string {
   ].join("\n");
 }
 
+// ─── Toolcache permission-denied hint ─────────────────────────────────────────
+
+// tar prints lines like `tar: bin/npm: Cannot open: Permission denied` when it
+// cannot overwrite a file left behind by an earlier run. Our hostedtoolcache
+// bind mount persists across runs, and if a previous run wrote files as a
+// different uid the current one can't replace them. See issue #171.
+const TAR_PERMISSION_DENIED_RE = /tar: .+: Cannot open: Permission denied/;
+
+/**
+ * Detect tar-extraction permission failures under `/opt/hostedtoolcache` and
+ * return a hint pointing the user at the host-side toolcache directory to
+ * remove. Returns null if the failure doesn't match.
+ */
+export function detectToolcacheHint(
+  errorContent: string,
+  toolCacheDir: string | undefined,
+): string | null {
+  if (!toolCacheDir) {
+    return null;
+  }
+  if (!TAR_PERMISSION_DENIED_RE.test(errorContent)) {
+    return null;
+  }
+  return [
+    `Hint: extraction under /opt/hostedtoolcache failed because files from a`,
+    `previous run are owned by a user this run can't overwrite. Delete the`,
+    `host-side toolcache and re-run:`,
+    ``,
+    `    sudo rm -rf ${shellQuote(toolCacheDir)}`,
+  ].join("\n");
+}
+
 // Test-only: reset the build-promise cache between tests
 export function __test_resetBuildCache(): void {
   buildPromises.clear();

--- a/packages/dtu-github-actions/src/server/routes/actions/action-tarball.test.ts
+++ b/packages/dtu-github-actions/src/server/routes/actions/action-tarball.test.ts
@@ -114,7 +114,9 @@ describe("Action Tarball Cache", () => {
     const content1 = Buffer.from("tarball-for-checkout");
     const content2 = Buffer.from("tarball-for-setup-node");
     fs.writeFileSync(path.join(dir, "actions__checkout@v4.tar.gz"), content1);
-    fs.writeFileSync(path.join(dir, "actions__setup-node@v4.tar.gz"), content2);
+    // setup-node tarballs are cached under an .rwN suffix because the DTU
+    // rewrites them in-flight to route getManifestFromRepo through itself.
+    fs.writeFileSync(path.join(dir, "actions__setup-node@v4.rw1.tar.gz"), content2);
 
     const res1 = await fetch(`${baseUrl}/_dtu/action-tarball/actions/checkout/v4`);
     const res2 = await fetch(`${baseUrl}/_dtu/action-tarball/actions/setup-node/v4`);

--- a/packages/dtu-github-actions/src/server/routes/actions/index.ts
+++ b/packages/dtu-github-actions/src/server/routes/actions/index.ts
@@ -1,8 +1,10 @@
 import { Polka } from "polka";
+import { execSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import https from "node:https";
 import http from "node:http";
+import os from "node:os";
 import path from "node:path";
 import { state, getActionTarballsDir } from "../../store.js";
 import { getBaseUrl } from "../dtu.js";
@@ -16,9 +18,125 @@ import { createJobResponse } from "./generators.js";
  *  coalesce into a single GitHub fetch instead of racing on the same tmp file. */
 const inflightDownloads = new Map<string, Promise<void>>();
 
+// Bump when the setup-node rewrite changes so stale caches invalidate (scoped
+// to setup-node only — other action caches are untouched).
+const SETUP_NODE_REWRITE_VERSION = 1;
+
 function actionTarballPath(repoPath: string, ref: string): string {
   const key = `${repoPath.replace("/", "__")}@${ref.replace(/[^a-zA-Z0-9._-]/g, "-")}`;
-  return path.join(getActionTarballsDir(), `${key}.tar.gz`);
+  const suffix = repoPath === "actions/setup-node" ? `.rw${SETUP_NODE_REWRITE_VERSION}` : "";
+  return path.join(getActionTarballsDir(), `${key}${suffix}.tar.gz`);
+}
+
+// ─── Setup-node tarball rewrite ──────────────────────────────────────────────
+// @actions/tool-cache's getManifestFromRepo() hardcodes `https://api.github.com`
+// and ignores GITHUB_API_URL, so setup-node's manifest fetch escapes the DTU
+// and hits real GitHub with our fake-token — 401 "Bad credentials", then a
+// slow fallback download from nodejs.org. We rewrite the literal URL inside
+// the bundled `dist/setup/index.js` so the call routes through the DTU. See
+// issue #249.
+function rewriteSetupNodeTarball(srcGzPath: string, destGzPath: string): void {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dtu-setup-node-rewrite-"));
+  try {
+    execSync(`tar -xzf ${JSON.stringify(srcGzPath)} -C ${JSON.stringify(tmpDir)}`);
+    const entries = fs.readdirSync(tmpDir);
+    if (entries.length !== 1) {
+      throw new Error(`unexpected tarball shape: ${entries.length} root entries`);
+    }
+    const rootEntry = entries[0];
+    const indexPath = path.join(tmpDir, rootEntry, "dist", "setup", "index.js");
+    if (fs.existsSync(indexPath)) {
+      const src = fs.readFileSync(indexPath, "utf-8");
+      const rewritten = src.replace(
+        /`https:\/\/api\.github\.com\/repos\//g,
+        "`${process.env.GITHUB_API_URL||'https://api.github.com'}/repos/",
+      );
+      if (rewritten !== src) {
+        fs.writeFileSync(indexPath, rewritten);
+      }
+    }
+    execSync(
+      `tar -czf ${JSON.stringify(destGzPath)} -C ${JSON.stringify(tmpDir)} ${JSON.stringify(rootEntry)}`,
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+// ─── Unauthenticated api.github.com proxy (for mocked manifest endpoints) ─────
+// The git-tree/blob endpoints used by @actions/tool-cache for Node/Go/Python
+// version manifests don't require auth for public repos, so we proxy them
+// without the fake GITHUB_TOKEN (which would 401). Response is cached on disk.
+interface CachedResponse {
+  statusCode: number;
+  contentType: string;
+  body: Buffer;
+}
+
+function apiProxyCachePath(cacheKey: string): string {
+  const safe = cacheKey.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return path.join(getActionTarballsDir(), "..", "api-github-proxy", `${safe}.json`);
+}
+
+function fetchApiGithubUnauth(
+  url: string,
+  headers: Record<string, string> = {},
+): Promise<CachedResponse> {
+  return new Promise((resolve, reject) => {
+    fetchWithRedirects(
+      url,
+      (upstream) => {
+        const chunks: Buffer[] = [];
+        upstream.on("data", (c: Buffer) => chunks.push(c));
+        upstream.on("end", () =>
+          resolve({
+            statusCode: upstream.statusCode ?? 502,
+            contentType: upstream.headers["content-type"] ?? "application/json",
+            body: Buffer.concat(chunks),
+          }),
+        );
+        upstream.on("error", reject);
+      },
+      0,
+      headers,
+    );
+  });
+}
+
+/** Download the setup-node tarball, rewrite its hardcoded api.github.com URL,
+ *  and atomically save the rewritten tarball to `destGzPath`. */
+function downloadAndRewriteSetupNode(githubUrl: string, destGzPath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const rawTmp = destGzPath + ".raw.tmp." + process.pid;
+    const finalTmp = destGzPath + ".tmp." + process.pid;
+    fs.mkdirSync(path.dirname(destGzPath), { recursive: true });
+    fetchWithRedirects(githubUrl, (upstream) => {
+      if (upstream.statusCode !== 200) {
+        reject(new Error(`upstream ${upstream.statusCode}`));
+        return;
+      }
+      const file = fs.createWriteStream(rawTmp);
+      upstream.pipe(file);
+      file.on("finish", () =>
+        file.close(() => {
+          try {
+            rewriteSetupNodeTarball(rawTmp, finalTmp);
+            fs.renameSync(finalTmp, destGzPath);
+            resolve();
+          } catch (err) {
+            reject(err);
+          } finally {
+            fs.rmSync(rawTmp, { force: true });
+            fs.rmSync(finalTmp, { force: true });
+          }
+        }),
+      );
+      file.on("error", (err) => {
+        fs.rmSync(rawTmp, { force: true });
+        reject(err);
+      });
+    });
+  });
 }
 
 /** Follow redirects and invoke callback with the final response. */
@@ -26,15 +144,16 @@ function fetchWithRedirects(
   url: string,
   callback: (res: http.IncomingMessage) => void,
   redirects = 0,
+  extraHeaders: Record<string, string> = {},
 ): void {
   if (redirects > 5) {
     return;
   }
   const mod = url.startsWith("https") ? https : http;
-  mod.get(url, { headers: { "User-Agent": "agent-ci/1.0" } }, (res) => {
+  mod.get(url, { headers: { "User-Agent": "agent-ci/1.0", ...extraHeaders } }, (res) => {
     if ((res.statusCode === 301 || res.statusCode === 302) && res.headers.location) {
       res.resume();
-      return fetchWithRedirects(res.headers.location, callback, redirects + 1);
+      return fetchWithRedirects(res.headers.location, callback, redirects + 1, extraHeaders);
     }
     callback(res);
   });
@@ -80,6 +199,30 @@ export function registerActionRoutes(app: Polka) {
       return;
     }
 
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    const githubUrl = `https://api.github.com/repos/${repoPath}/tarball/${ref}`;
+
+    // setup-node needs a post-download rewrite (see rewriteSetupNodeTarball),
+    // so we buffer the full tarball first, rewrite, then serve from cache.
+    // All other actions stream through to the client while caching in parallel.
+    if (repoPath === "actions/setup-node") {
+      const downloadPromise = downloadAndRewriteSetupNode(githubUrl, dest);
+      downloadPromise.catch(() => {});
+      inflightDownloads.set(dest, downloadPromise);
+      downloadPromise.then(
+        () => {
+          inflightDownloads.delete(dest);
+          serveFromDisk();
+        },
+        (err) => {
+          inflightDownloads.delete(dest);
+          res.writeHead(502);
+          res.end(String(err?.message ?? err));
+        },
+      );
+      return;
+    }
+
     // Cache miss: proxy from GitHub, write to disk simultaneously.
     // Register a promise so concurrent requests can coalesce.
     let resolveDownload: () => void;
@@ -92,8 +235,6 @@ export function registerActionRoutes(app: Polka) {
     downloadPromise.catch(() => {});
     inflightDownloads.set(dest, downloadPromise);
 
-    fs.mkdirSync(path.dirname(dest), { recursive: true });
-    const githubUrl = `https://api.github.com/repos/${repoPath}/tarball/${ref}`;
     fetchWithRedirects(githubUrl, (upstream) => {
       if (upstream.statusCode !== 200) {
         inflightDownloads.delete(dest);
@@ -124,6 +265,100 @@ export function registerActionRoutes(app: Polka) {
         rejectDownload!(new Error("write failed"));
       });
     });
+  });
+
+  // ── tool-cache manifest proxy: /repos/:owner/:repo/git/trees/:branch ────────
+  // Proxies to api.github.com *unauthenticated* (the fake GITHUB_TOKEN in the
+  // container would 401) and rewrites blob URLs to point back here, so the
+  // subsequent blob fetch also routes through the DTU. Cached on disk.
+  app.get("/repos/:owner/:repo/git/trees/:branch", async (req: any, res) => {
+    const { owner, repo, branch } = req.params;
+    const baseUrl = getBaseUrl(req);
+    const cacheKey = `tree__${owner}__${repo}__${branch}`;
+    const cachePath = apiProxyCachePath(cacheKey);
+
+    try {
+      let payload: any;
+      if (fs.existsSync(cachePath)) {
+        payload = JSON.parse(fs.readFileSync(cachePath, "utf-8"));
+      } else {
+        const upstream = await fetchApiGithubUnauth(
+          `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}`,
+        );
+        if (upstream.statusCode !== 200) {
+          res.writeHead(upstream.statusCode, { "Content-Type": upstream.contentType });
+          res.end(upstream.body);
+          return;
+        }
+        payload = JSON.parse(upstream.body.toString("utf-8"));
+        // Rewrite blob URLs to route through the DTU.
+        if (Array.isArray(payload?.tree)) {
+          for (const item of payload.tree) {
+            if (typeof item?.url === "string" && item.sha) {
+              item.url = `${baseUrl}/repos/${owner}/${repo}/git/blobs/${item.sha}`;
+            }
+          }
+        }
+        fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+        fs.writeFileSync(cachePath, JSON.stringify(payload));
+      }
+      // Even on cache hit the blob URLs need the current request's baseUrl.
+      if (Array.isArray(payload?.tree)) {
+        for (const item of payload.tree) {
+          if (typeof item?.url === "string" && item.sha) {
+            item.url = `${baseUrl}/repos/${owner}/${repo}/git/blobs/${item.sha}`;
+          }
+        }
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(payload));
+    } catch (err: any) {
+      res.writeHead(502, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ message: String(err?.message ?? err) }));
+    }
+  });
+
+  // ── tool-cache blob proxy: /repos/:owner/:repo/git/blobs/:sha ──────────────
+  // Blobs are content-addressed by SHA — cache keyed by sha + accept header
+  // since `accept: application/vnd.github.VERSION.raw` returns raw bytes
+  // while the default accept returns JSON with base64 content.
+  app.get("/repos/:owner/:repo/git/blobs/:sha", async (req: any, res) => {
+    const { owner, repo, sha } = req.params;
+    const accept = typeof req.headers.accept === "string" ? req.headers.accept : "application/json";
+    const acceptKey = accept.includes("raw") ? "raw" : "json";
+    const cacheKey = `blob__${owner}__${repo}__${sha}__${acceptKey}`;
+    const cachePath = apiProxyCachePath(cacheKey);
+
+    try {
+      if (fs.existsSync(cachePath)) {
+        const cached = JSON.parse(fs.readFileSync(cachePath, "utf-8"));
+        res.writeHead(200, { "Content-Type": cached.contentType });
+        res.end(Buffer.from(cached.bodyB64, "base64"));
+        return;
+      }
+      const upstream = await fetchApiGithubUnauth(
+        `https://api.github.com/repos/${owner}/${repo}/git/blobs/${sha}`,
+        { Accept: accept },
+      );
+      if (upstream.statusCode !== 200) {
+        res.writeHead(upstream.statusCode, { "Content-Type": upstream.contentType });
+        res.end(upstream.body);
+        return;
+      }
+      fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+      fs.writeFileSync(
+        cachePath,
+        JSON.stringify({
+          contentType: upstream.contentType,
+          bodyB64: upstream.body.toString("base64"),
+        }),
+      );
+      res.writeHead(200, { "Content-Type": upstream.contentType });
+      res.end(upstream.body);
+    } catch (err: any) {
+      res.writeHead(502, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ message: String(err?.message ?? err) }));
+    }
   });
 
   // 7. Pipeline Service Discovery Mock

--- a/packages/dtu-github-actions/src/server/routes/actions/index.ts
+++ b/packages/dtu-github-actions/src/server/routes/actions/index.ts
@@ -35,7 +35,7 @@ function actionTarballPath(repoPath: string, ref: string): string {
 // slow fallback download from nodejs.org. We rewrite the literal URL inside
 // the bundled `dist/setup/index.js` so the call routes through the DTU. See
 // issue #249.
-function rewriteSetupNodeTarball(srcGzPath: string, destGzPath: string): void {
+export function rewriteSetupNodeTarball(srcGzPath: string, destGzPath: string): void {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dtu-setup-node-rewrite-"));
   try {
     execSync(`tar -xzf ${JSON.stringify(srcGzPath)} -C ${JSON.stringify(tmpDir)}`);

--- a/packages/dtu-github-actions/src/server/routes/actions/setup-node-mock.test.ts
+++ b/packages/dtu-github-actions/src/server/routes/actions/setup-node-mock.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { AddressInfo } from "node:net";
+import type { Polka } from "polka";
+import { state, getActionTarballsDir } from "../../store.js";
+import { bootstrapAndReturnApp } from "../../index.js";
+import { rewriteSetupNodeTarball } from "./index.js";
+
+const HARDCODED_URL = "`https://api.github.com/repos/";
+const REWRITTEN_URL_FRAGMENT = "process.env.GITHUB_API_URL";
+
+function buildFakeSetupNodeTarball(destGzPath: string): void {
+  const workRoot = fs.mkdtempSync(path.join(os.tmpdir(), "dtu-fake-setup-node-"));
+  try {
+    const rootEntry = "actions-setup-node-deadbeef";
+    const setupDir = path.join(workRoot, rootEntry, "dist", "setup");
+    fs.mkdirSync(setupDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(setupDir, "index.js"),
+      // Mirror the real dist — same template-literal shape that tool-cache emits.
+      `const treeUrl = ${HARDCODED_URL}\${owner}/\${repo}/git/trees/\${branch}\`;\n`,
+    );
+    // Include a second file so we verify the rewrite leaves unrelated files alone.
+    fs.writeFileSync(path.join(workRoot, rootEntry, "README.md"), "# fake setup-node\n");
+    execSync(
+      `tar -czf ${JSON.stringify(destGzPath)} -C ${JSON.stringify(workRoot)} ${JSON.stringify(rootEntry)}`,
+    );
+  } finally {
+    fs.rmSync(workRoot, { recursive: true, force: true });
+  }
+}
+
+describe("rewriteSetupNodeTarball", () => {
+  let workDir: string;
+  beforeEach(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), "dtu-setup-node-rewrite-test-"));
+  });
+
+  it("rewrites the hardcoded api.github.com URL in dist/setup/index.js", () => {
+    const srcGz = path.join(workDir, "src.tar.gz");
+    const destGz = path.join(workDir, "dest.tar.gz");
+    buildFakeSetupNodeTarball(srcGz);
+
+    rewriteSetupNodeTarball(srcGz, destGz);
+
+    const extractDir = path.join(workDir, "extracted");
+    fs.mkdirSync(extractDir);
+    execSync(`tar -xzf ${JSON.stringify(destGz)} -C ${JSON.stringify(extractDir)}`);
+    const [rootEntry] = fs.readdirSync(extractDir);
+    const rewrittenSrc = fs.readFileSync(
+      path.join(extractDir, rootEntry, "dist", "setup", "index.js"),
+      "utf-8",
+    );
+    expect(rewrittenSrc).not.toContain(HARDCODED_URL);
+    expect(rewrittenSrc).toContain(REWRITTEN_URL_FRAGMENT);
+    // Untouched files survive the round-trip.
+    expect(fs.existsSync(path.join(extractDir, rootEntry, "README.md"))).toBe(true);
+  });
+
+  it("is a no-op for tarballs without the hardcoded URL (still produces a valid tarball)", () => {
+    const srcGz = path.join(workDir, "src.tar.gz");
+    const destGz = path.join(workDir, "dest.tar.gz");
+    const workRoot = fs.mkdtempSync(path.join(os.tmpdir(), "dtu-noop-"));
+    try {
+      const rootEntry = "actions-setup-node-noop";
+      const setupDir = path.join(workRoot, rootEntry, "dist", "setup");
+      fs.mkdirSync(setupDir, { recursive: true });
+      fs.writeFileSync(path.join(setupDir, "index.js"), "// no URL here\n");
+      execSync(
+        `tar -czf ${JSON.stringify(srcGz)} -C ${JSON.stringify(workRoot)} ${JSON.stringify(rootEntry)}`,
+      );
+    } finally {
+      fs.rmSync(workRoot, { recursive: true, force: true });
+    }
+
+    expect(() => rewriteSetupNodeTarball(srcGz, destGz)).not.toThrow();
+    expect(fs.existsSync(destGz)).toBe(true);
+  });
+});
+
+let PORT: number;
+
+describe("DTU manifest-proxy routes (setup-node mock)", () => {
+  let server: Polka;
+
+  const apiProxyDir = () => path.join(getActionTarballsDir(), "..", "api-github-proxy");
+
+  beforeAll(async () => {
+    state.reset();
+    const app = await bootstrapAndReturnApp();
+    return new Promise<void>((resolve) => {
+      server = app.listen(0, () => {
+        const address = server.server?.address() as AddressInfo;
+        PORT = address.port;
+        resolve();
+      });
+    });
+  });
+
+  beforeEach(() => {
+    state.reset();
+    fs.rmSync(apiProxyDir(), { recursive: true, force: true });
+  });
+
+  afterAll(async () => {
+    fs.rmSync(apiProxyDir(), { recursive: true, force: true });
+    await new Promise<void>((resolve) => {
+      if (server?.server) {
+        server.server.close(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+  });
+
+  it("serves cached tree responses with blob URLs rewritten to the DTU base", async () => {
+    const baseUrl = `http://localhost:${PORT}`;
+    // Pre-seed the cache with an upstream-shaped payload so no network is hit.
+    const cacheDir = apiProxyDir();
+    fs.mkdirSync(cacheDir, { recursive: true });
+    const cached = {
+      sha: "treesha",
+      tree: [
+        {
+          path: "versions-manifest.json",
+          sha: "blobsha1",
+          url: "https://api.github.com/repos/actions/node-versions/git/blobs/blobsha1",
+        },
+        { path: "README.md", sha: "blobsha2", url: "https://api.github.com/other" },
+      ],
+    };
+    fs.writeFileSync(
+      path.join(cacheDir, "tree__actions__node-versions__main.json"),
+      JSON.stringify(cached),
+    );
+
+    const res = await fetch(`${baseUrl}/repos/actions/node-versions/git/trees/main`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Blob URLs in the response should point back at this DTU instance.
+    expect(body.tree[0].url).toBe(`${baseUrl}/repos/actions/node-versions/git/blobs/blobsha1`);
+    expect(body.tree[1].url).toBe(`${baseUrl}/repos/actions/node-versions/git/blobs/blobsha2`);
+  });
+
+  it("serves cached blob responses by (sha, accept) tuple", async () => {
+    const baseUrl = `http://localhost:${PORT}`;
+    const cacheDir = apiProxyDir();
+    fs.mkdirSync(cacheDir, { recursive: true });
+    const rawManifest = '[{"version":"24.14.1","stable":true}]';
+    fs.writeFileSync(
+      path.join(cacheDir, "blob__actions__node-versions__blobsha1__raw.json"),
+      JSON.stringify({
+        contentType: "application/json; charset=utf-8",
+        bodyB64: Buffer.from(rawManifest).toString("base64"),
+      }),
+    );
+
+    const res = await fetch(`${baseUrl}/repos/actions/node-versions/git/blobs/blobsha1`, {
+      headers: { Accept: "application/vnd.github.VERSION.raw" },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toBe(rawManifest);
+  });
+
+  it("does not confuse raw and json blob variants (cache-keyed separately)", async () => {
+    const baseUrl = `http://localhost:${PORT}`;
+    const cacheDir = apiProxyDir();
+    fs.mkdirSync(cacheDir, { recursive: true });
+    // Only the `json` variant is cached. A `raw` request must miss (not serve
+    // the json payload) — if GitHub is unreachable in test env, that's fine;
+    // we only need to verify it didn't return the wrong-variant cached body.
+    const jsonPayload = '{"encoding":"base64","content":"aGk="}';
+    fs.writeFileSync(
+      path.join(cacheDir, "blob__actions__node-versions__sha__json.json"),
+      JSON.stringify({
+        contentType: "application/json",
+        bodyB64: Buffer.from(jsonPayload).toString("base64"),
+      }),
+    );
+
+    const rawRes = await fetch(`${baseUrl}/repos/actions/node-versions/git/blobs/sha`, {
+      headers: { Accept: "application/vnd.github.VERSION.raw" },
+    });
+    // Either it miss-fetches upstream (any status ≥ 200) or 502s — but it must
+    // never return the json-variant body.
+    const rawBody = await rawRes.text();
+    expect(rawBody).not.toBe(jsonPayload);
+  });
+});


### PR DESCRIPTION
Closes #171, closes #249.

## Problem 1 — `setup-node` prints "Bad credentials" and takes the slow path

Every `actions/setup-node` step under agent-ci logs:

```
Bad credentials
Falling back to download directly from Node
Acquiring 24.14.1 - arm64 from https://nodejs.org/dist/...
```

The bundled `@actions/tool-cache` has a hardcoded `https://api.github.com` URL for its versions-manifest fetch — it ignores `GITHUB_API_URL`, so the request escapes the DTU and hits real GitHub with our fake `GITHUB_TOKEN`, getting back 401. setup-node then falls back to downloading directly from `nodejs.org`, which is slower and noisier.

## Solution 1 — route the manifest call through the DTU

Two small pieces:

- When the DTU caches the `actions/setup-node` tarball, it rewrites the hardcoded `` `https://api.github.com/repos/ `` in `dist/setup/index.js` to `` `${process.env.GITHUB_API_URL||'https://api.github.com'}/repos/ ``. The cache is keyed with an `.rw1` suffix so stale tarballs from older installs get replaced.
- The DTU adds two new routes: `GET /repos/:owner/:repo/git/trees/:branch` and `GET /repos/:owner/:repo/git/blobs/:sha`. These proxy `api.github.com` **without** the fake token (these endpoints are public, so no auth is fine), rewrite blob URLs in the tree response to point back at the DTU, and cache responses on disk.

After the fix, `setup-node` downloads from `github.com/actions/node-versions/releases/...` (the fast path) instead of `nodejs.org`. No more "Bad credentials" line.

## Problem 2 — tar extraction fails on a stale toolcache and the user has no idea what to do

When a previous run leaves root-owned files in the persistent `/opt/hostedtoolcache` bind mount, a later run can't overwrite them and `tar` bails with `Cannot open: Permission denied`. The user sees a wall of tar errors and no guidance.

## Solution 2 — detect the signature and print a hint

If a failed step's output contains `tar: ...: Cannot open: Permission denied`, the reporter attaches a hint showing the host-side toolcache path and the exact command to clear it:

```
Hint: extraction under /opt/hostedtoolcache failed because files from a
previous run are owned by a user this run can't overwrite. Delete the
host-side toolcache and re-run:

    sudo rm -rf '/var/folders/.../agent-ci/<slug>/cache/toolcache'
```

## Test plan

- [x] `pnpm -r test` — 567 CLI tests + 53 DTU tests pass
- [x] `pnpm -r typecheck` passes
- [x] End-to-end against https://github.com/pi0neerpat/agent-ci-simple-spike with cold caches: setup-node now hits the manifest fast path, no "Bad credentials", Node is pulled from `actions/node-versions` releases
- [x] Toolcache hint: covered by new unit tests in `runner-image.test.ts` (match on tar permission signature, no false-positive on generic "Permission denied")

🤖 Generated with [Claude Code](https://claude.com/claude-code)