### PR TITLE
docs: document website release command (CLOUDFLARE_ACCOUNT_ID + CLOUDFLARE_ENV)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -50,3 +50,29 @@ The GitHub repo needs an `NPM_TOKEN` secret with publish access.
 | `pnpm version`   | Apply pending changesets locally (for testing) |
 | `pnpm release`   | Build all packages and publish to npm          |
 | `pnpm -r build`  | Build all packages without publishing          |
+
+## Releasing the Website (agent-ci.dev)
+
+The marketing site at `apps/website/` is deployed to Cloudflare Workers on the
+**RedwoodJS** Cloudflare account. It is not part of the npm release flow above
+— it's deployed manually.
+
+```sh
+cd apps/website
+CLOUDFLARE_ACCOUNT_ID=1634a8e653b2ce7e0f7a23cca8cbd86a CLOUDFLARE_ENV=production pnpm release
+```
+
+Notes:
+
+- `CLOUDFLARE_ACCOUNT_ID` picks the `RedwoodJS` Cloudflare account
+  non-interactively (the OAuth user may have access to multiple accounts).
+- `CLOUDFLARE_ENV=production` selects the production deploy target.
+- `pnpm release` runs: `ensure-deploy-env → clean → build → wrangler deploy`.
+  The `prebuild` hook copies the public CLI docs into `public/docs/` and
+  regenerates `public/.well-known/agent-skills/index.json`, so the site never
+  drifts from `packages/cli/*.md`.
+- After deploying, smoke-test with
+  `curl -I https://agent-ci.dev/robots.txt` and
+  `curl https://agent-ci.dev/sitemap.xml`.
+- You need to be logged in to Wrangler on an account with write access to the
+  RedwoodJS Cloudflare org: `pnpm dlx wrangler login`.


### PR DESCRIPTION
Follow-up from #264. Documents the exact command used to deploy `agent-ci.dev`.

When I went to release the website after merging #264, `wrangler deploy` bailed because:

- The OAuth session has access to multiple Cloudflare accounts and none is pinned in `wrangler.jsonc`.
- The release script runs non-interactively (via `pnpm release`), so there's nothing to prompt against.

Fix is to export two env vars up front:

```sh
cd apps/website
CLOUDFLARE_ACCOUNT_ID=1634a8e653b2ce7e0f7a23cca8cbd86a CLOUDFLARE_ENV=production pnpm release
```

Verified: deployed the site successfully using exactly this command; live site returns the new `robots.txt`, `sitemap.xml`, `.well-known/agent-skills/index.json`, and `Link` headers.

## Alternative considered

Pinning `"account_id": "1634a8e653b2ce7e0f7a23cca8cbd86a"` in `apps/website/wrangler.jsonc` would remove the need for the env var entirely. Didn't do that here because it's a config-level decision (maybe you want to keep the account ID out of the repo for some reason, or the `CLOUDFLARE_ENV` is still needed anyway). Happy to follow up with that change if you'd prefer.

## Changeset

No changeset: docs-only; does not touch anything under `packages/`.
