### PR TITLE
feat(website): serve markdown version of homepage via Accept negotiation

### DIFF
--- a/apps/website/src/app/lib/markdown-negotiation.ts
+++ b/apps/website/src/app/lib/markdown-negotiation.ts
@@ -1,0 +1,72 @@
+import type { RouteMiddleware } from "rwsdk/router";
+
+/**
+ * Parse an Accept header and decide whether the client is asking for
+ * markdown in preference to HTML. Rules:
+ *
+ *   - The client must explicitly list `text/markdown`. A bare `*\/*` is
+ *     treated as "browser default" — HTML wins.
+ *   - If both `text/markdown` and `text/html` are listed, higher q-value
+ *     wins. A tie still returns true (agent opted in explicitly).
+ *   - Malformed q-values fall back to q=1.0 per RFC 9110 §12.5.1.
+ *
+ * This conservative default keeps browsers on HTML (they don't list
+ * text/markdown) and flips to markdown only when an agent sends an
+ * explicit signal, matching Cloudflare's "Markdown for Agents" semantics.
+ */
+export function prefersMarkdown(accept: string | null | undefined): boolean {
+  if (!accept) {
+    return false;
+  }
+  type Entry = { type: string; q: number };
+  const entries: Entry[] = accept.split(",").map((raw) => {
+    const parts = raw.trim().split(";");
+    const type = (parts[0] ?? "").trim().toLowerCase();
+    let q = 1.0;
+    for (const p of parts.slice(1)) {
+      const m = p.trim().match(/^q\s*=\s*([0-9.]+)$/i);
+      if (m) {
+        const parsed = Number.parseFloat(m[1]!);
+        q = Number.isFinite(parsed) ? parsed : 1.0;
+      }
+    }
+    return { type, q };
+  });
+  const md = entries.find((e) => e.type === "text/markdown");
+  if (!md) {
+    return false;
+  }
+  const html = entries.find((e) => e.type === "text/html");
+  if (!html) {
+    return true;
+  }
+  return md.q >= html.q;
+}
+
+/**
+ * Factory that returns a route-level middleware: on matching routes, if
+ * the client prefers markdown, respond with the given markdown body and
+ * short-circuit the downstream component. Otherwise return undefined so
+ * the component renders as normal.
+ *
+ * The middleware sets `Vary: Accept` so caches (including Cloudflare's)
+ * key the response by the Accept header.
+ */
+export function serveMarkdownIfPreferred(body: string): RouteMiddleware {
+  return ({ request, response }) => {
+    if (!prefersMarkdown(request.headers.get("accept"))) {
+      return;
+    }
+    // Tell caches that the body depends on Accept. Append to any existing
+    // Vary the response might already have accumulated.
+    const existingVary = response.headers.get("Vary");
+    const varyValue = existingVary ? `${existingVary}, Accept` : "Accept";
+    return new Response(body, {
+      headers: {
+        "Content-Type": "text/markdown; charset=utf-8",
+        "Cache-Control": "public, max-age=300",
+        Vary: varyValue,
+      },
+    });
+  };
+}

--- a/apps/website/src/app/pages/home.md
+++ b/apps/website/src/app/pages/home.md
@@ -1,0 +1,132 @@
+# Agent CI
+
+**Run GitHub Actions on your machine.** Caching in ~0 ms. Pause on failure. Let your AI agent fix it and retry — without pushing.
+
+- Website: <https://agent-ci.dev>
+- Source: <https://github.com/redwoodjs/agent-ci>
+- Docs: [/docs/README.md](/docs/README.md)
+- Agent skill: [/docs/SKILL.md](/docs/SKILL.md)
+- Compatibility matrix: [/compatibility](/compatibility)
+- Blog: [/blog](/blog)
+
+---
+
+## Principles
+
+### Instant Feedback
+
+**Reality.** Cloud CI takes minutes to spin up, install dependencies, and run tests. The feedback loop is broken.
+
+**Advantage.** By bind-mounting your local `node_modules` and tool caches, Agent CI starts in ~0 ms. Your first run warms the cache; subsequent runs are instant.
+
+### Debug in Place
+
+**Reality.** When a cloud CI job fails, the container is destroyed. You have to guess the fix, push, and wait again.
+
+**Advantage.** Agent CI pauses on failure. The container stays alive with all state intact. Fix the issue on your host, then retry just the failed step.
+
+### True Compatibility
+
+**Reality.** Other local runners use custom re-implementations of the GitHub Actions spec, leading to subtle bugs and drift.
+
+**Advantage.** Agent CI emulates the server-side API surface and feeds jobs to the unmodified, official GitHub Actions runner binary.
+
+---
+
+## Architecture Comparison
+
+| Feature           | GitHub Actions     | Other local runners      | Agent CI                        |
+| ----------------- | ------------------ | ------------------------ | ------------------------------- |
+| Runner binary     | Official           | Custom re-implementation | **Official**                    |
+| API layer         | GitHub.com         | Compatibility shim       | **Full local emulation**        |
+| Cache round-trip  | Network (~seconds) | Varies                   | **~0 ms (bind-mount)**          |
+| On failure        | Start over         | Start over               | **Pause → fix → retry step**    |
+| Container state   | Destroyed          | Destroyed                | **Kept alive**                  |
+
+---
+
+## Quick Start
+
+### 1. Run
+
+```bash
+# Run a specific workflow
+npx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml
+
+# Run all relevant workflows for current branch
+npx @redwoodjs/agent-ci run --all
+```
+
+### 2. Retry
+
+```bash
+npx @redwoodjs/agent-ci retry --name <runner-name>
+```
+
+---
+
+## AI Agent Integration
+
+Install the agent skill — works with Claude Code, Cursor, Codex, and [40+ other agents](https://agentskills.io):
+
+```bash
+npx skills add redwoodjs/agent-ci --skill agent-ci
+```
+
+Then add to your agent instructions (`CLAUDE.md`, `.cursorrules`, `AGENTS.md`):
+
+````markdown
+## CI
+
+Install the agent-ci skill (one-time setup):
+
+```bash
+npx skills add redwoodjs/agent-ci --skill agent-ci
+```
+
+Before completing any work, run the `agent-ci` skill to validate
+your changes locally. If it fails, fix the issue and re-run.
+Do not report work as done until it passes.
+````
+
+**Claude Code.** Agent CI also ships a `/validate` skill. Copy [`.claude/commands/validate.md`](https://github.com/redwoodjs/agent-ci/blob/main/.claude/commands/validate.md) into your project for automatic background execution with monitoring and retry.
+
+---
+
+## In Developers' Own Words
+
+> Waiting for CI could be the subtitle of the book of the last 3 weeks of my life. The Factory Life: Waiting for CI.
+>
+> — Jess Martin ([@jessmartin](https://x.com/jessmartin))
+
+> An alternative to Act for AI? I'll take it!
+>
+> — Eric Clemmons ([@ericclemmons](https://x.com/ericclemmons))
+
+> You can run Github actions workflows fully locally with Agent CI. Such a crazy good unlock for coding agents!
+>
+> — Pekka Enberg ([@penberg](https://x.com/penberg))
+
+> Clever dude!
+>
+> — Cyrus ([@cyrusnewday](https://x.com/cyrusnewday))
+
+> Okay this is awesome.
+>
+> — Chris ([@chriszeuch](https://x.com/chriszeuch))
+
+> I like the look of what you're cooking here.
+>
+> — Andrew Jefferson ([@EastlondonDev](https://x.com/EastlondonDev))
+
+> It's great.
+>
+> — Juho Vepsäläinen ([@bebraw](https://x.com/bebraw))
+
+> Oh noice.
+>
+> — Ahmad Awais ([@MrAhmadAwais](https://x.com/MrAhmadAwais))
+
+---
+
+Built by [RedwoodJS](https://rwsdk.com).

--- a/apps/website/src/worker.tsx
+++ b/apps/website/src/worker.tsx
@@ -7,6 +7,8 @@ import { setCommonHeaders } from "@/app/headers";
 import { Home } from "@/app/pages/home";
 import { Compatibility } from "@/app/pages/compatibility";
 import { sitemap } from "@/app/pages/sitemap";
+import { serveMarkdownIfPreferred } from "@/app/lib/markdown-negotiation";
+import homeMarkdown from "@/app/pages/home.md?raw";
 import { blogRoutes } from "@/blog/routes";
 
 export type AppContext = {};
@@ -19,7 +21,10 @@ export default defineApp([
   // /sitemap.xml returns XML directly — not wrapped in <Document>.
   route("/sitemap.xml", () => sitemap()),
   render(Document, [
-    route("/", Home),
+    // Markdown negotiation: if the request Accept header prefers
+    // `text/markdown`, serve the hand-authored markdown version of the
+    // homepage; otherwise fall through to the React component.
+    route("/", [serveMarkdownIfPreferred(homeMarkdown), Home]),
     route("/compatibility", Compatibility),
     prefix("/blog", blogRoutes),
   ]),

--- a/apps/website/types/vite.d.ts
+++ b/apps/website/types/vite.d.ts
@@ -2,3 +2,8 @@ declare module "*?url" {
   const result: string;
   export default result;
 }
+
+declare module "*?raw" {
+  const result: string;
+  export default result;
+}


### PR DESCRIPTION
Closes the last of the easily-addressable agent-readiness findings: **markdown content negotiation for the homepage**.

## What's in this PR

- `apps/website/src/app/pages/home.md` — hand-authored markdown version of the homepage. Same content as `home.tsx` (hero, principles, architecture comparison, quick start, agent instructions, testimonials) but without React-only decoration (CRT effects, sticky nav, avatars). Lives next to `home.tsx` so they stay in sync during review.
- `apps/website/src/app/lib/markdown-negotiation.ts` — `Accept` parser + route-middleware factory. Returns markdown only when the client explicitly lists `text/markdown` and its q-value beats `text/html` (per RFC 9110 §12.5.1). Sets `Vary: Accept` so caches key by Accept.
- `apps/website/src/worker.tsx` — wires the middleware into `route("/")` using the array form `[serveMarkdownIfPreferred(homeMarkdown), Home]`. Short-circuits to markdown when preferred; otherwise falls through to the React component.
- `apps/website/types/vite.d.ts` — declares `*?raw` so the markdown import type-checks.

## Why hand-authored instead of HTML→MD conversion

Auto-converting the rendered React page would produce noisy output (CRT divs, nav, avatar `<img>` tags, decorative SVGs). A hand-written `home.md` gives agents a clean, semantic, stable document — and it's easier to keep correct under review.

## Verification

Against `npm run preview`:

| `Accept` | Response |
|---|---|
| `text/html, ..., */*;q=0.8` (browser) | `text/html` ✅ |
| `text/markdown` (agent) | `text/markdown; charset=utf-8` ✅ |
| `text/markdown;q=0.9, text/html;q=0.8` | `text/markdown` ✅ |
| `text/html, text/markdown;q=0.5` | `text/html` ✅ |
| `*/*` | `text/html` ✅ |

`Vary: Accept` is set on the markdown response.

## Follow-ups (not in this PR)

- `/compatibility` and `/blog/:slug` also return HTML today. Same middleware pattern works for each; blog posts can serve their raw `.md` from `src/blog/content/` directly (zero content duplication). Worth its own PR.
- Cloudflare's zone-level "Markdown for Agents" toggle would cover the whole site automatically. Orthogonal to this PR; enabling it later would compose fine (CF passes through our `text/markdown` responses untouched).

## Changeset

No changeset: change is entirely under `apps/website/`; doesn't touch `packages/`. Per `.claude/rules/changeset-required.md`: *"If the change is docs-only or CI-only and doesn't affect published packages, you may skip the changeset but must note why in the PR description."*
