### PR TITLE
Fix docker/setup-buildx-action permission denied on native Linux Docker (#257)

### DIFF
--- a/.changeset/docker-socket-sudo-chmod.md
+++ b/.changeset/docker-socket-sudo-chmod.md
@@ -1,0 +1,8 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+fix: docker/setup-buildx-action and other Docker socket users fail with "permission denied" on native Linux Docker (#257)
+
+The runner container's entrypoint chmods the bind-mounted `/var/run/docker.sock` to `0666` so the `runner` user can talk to the Docker daemon. On native Linux Docker the socket is owned `root:docker`, so the chmod needs `sudo` — but it was using plain `chmod` and silently failing. Steps like `docker/setup-buildx-action@v4`, `docker login`, and `docker compose` then failed with `permission denied while trying to connect to the docker API at unix:///var/run/docker.sock`. Now escalated via `MAYBE_SUDO`, matching the other privileged entrypoint operations.

--- a/.github/workflows/smoke-docker-buildx.yml
+++ b/.github/workflows/smoke-docker-buildx.yml
@@ -18,18 +18,15 @@ name: "Smoke: docker/setup-buildx-action fails to run"
 # resolved after the action claims to have completed.
 
 on:
-  pull_request_target:
-    types: [opened, labeled, synchronize]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   docker-buildx:
-    if: '!github.event.pull_request.draft && (contains(fromJSON(''["MEMBER", "OWNER", "COLLABORATOR"]''), github.event.pull_request.author_association) || contains(github.event.pull_request.labels.*.name, ''safe-to-run''))'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/smoke-docker-buildx.yml
+++ b/.github/workflows/smoke-docker-buildx.yml
@@ -1,0 +1,95 @@
+name: "Smoke: docker/setup-buildx-action fails to run"
+
+# Reproduces #257 — docker/setup-buildx-action@v4 fails to run under agent-ci.
+#
+# Reported by @PatrikTheDev. A workflow step as trivial as
+#
+#   - uses: docker/setup-buildx-action@v4
+#
+# never successfully completes inside the runner container. The action needs
+# to shell out to the host's Docker daemon (via the bind-mounted socket) and
+# install/start a buildx builder; something in our runner environment or
+# Docker-in-Docker setup is preventing that from working the way it does on
+# github.com.
+#
+# This smoke test creates a throwaway project with a minimal workflow that
+# runs setup-buildx-action, executes it through agent-ci, and fails if
+# either agent-ci exits non-zero or if `docker buildx version` can't be
+# resolved after the action claims to have completed.
+
+on:
+  pull_request_target:
+    types: [opened, labeled, synchronize]
+
+jobs:
+  docker-buildx:
+    if: '!github.event.pull_request.draft && (contains(fromJSON(''["MEMBER", "OWNER", "COLLABORATOR"]''), github.event.pull_request.author_association) || contains(github.event.pull_request.labels.*.name, ''safe-to-run''))'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - run: pnpm install
+
+      - name: Build agent-ci
+        run: pnpm --filter @redwoodjs/agent-ci... -r build
+
+      - name: Create temp docker-buildx project
+        run: |
+          mkdir -p /tmp/docker-buildx-repro/.github/workflows
+
+          cat > /tmp/docker-buildx-repro/package.json << 'PKG'
+          { "name": "docker-buildx-repro", "private": true }
+          PKG
+
+          # Inner workflow: the one agent-ci will execute inside a container
+          cat > /tmp/docker-buildx-repro/.github/workflows/test.yml << 'WF'
+          name: Test
+          on: push
+          jobs:
+            test:
+              runs-on: ubuntu-latest
+              steps:
+                - uses: docker/setup-buildx-action@v4
+                - name: Verify buildx
+                  run: |
+                    docker buildx version
+                    docker buildx ls
+                    echo "buildx is working"
+          WF
+
+          # agent-ci needs a git repo with a remote to resolve the repo slug
+          cd /tmp/docker-buildx-repro
+          git init
+          git remote add origin https://github.com/test-org/docker-buildx-repro.git
+          git add -A
+          git -c user.name="test" -c user.email="test@test.com" commit -m "init"
+
+      - name: Run agent-ci against docker-buildx project
+        id: run
+        working-directory: /tmp/docker-buildx-repro
+        run: |
+          node "$GITHUB_WORKSPACE/packages/cli/dist/cli.js" \
+            run --workflow .github/workflows/test.yml --quiet 2>&1 | tee /tmp/docker-buildx.out
+
+      - name: Assert setup-buildx-action completed and `docker buildx` is usable
+        run: |
+          if ! grep -q "buildx is working" /tmp/docker-buildx.out; then
+            echo "::error::docker/setup-buildx-action@v4 did not complete — 'Verify buildx' step never ran or failed."
+            grep -n -iE "buildx|error|fail" /tmp/docker-buildx.out || true
+            exit 1
+          fi
+          echo "OK: docker/setup-buildx-action@v4 ran and buildx is usable."

--- a/.github/workflows/smoke-docker-buildx.yml
+++ b/.github/workflows/smoke-docker-buildx.yml
@@ -78,9 +78,38 @@ jobs:
       - name: Run agent-ci against docker-buildx project
         id: run
         working-directory: /tmp/docker-buildx-repro
+        env:
+          DEBUG: "agent-ci:*"
+          AI_AGENT: "1" # same as --quiet: no animated TUI, but still full logs
         run: |
           node "$GITHUB_WORKSPACE/packages/cli/dist/cli.js" \
-            run --workflow .github/workflows/test.yml --quiet 2>&1 | tee /tmp/docker-buildx.out
+            run --workflow .github/workflows/test.yml 2>&1 | tee /tmp/docker-buildx.out
+
+      - name: Dump agent-ci step logs
+        if: always()
+        run: |
+          echo "::group::agent-ci runs dir"
+          ls -la /tmp/agent-ci/ 2>/dev/null || echo "no /tmp/agent-ci"
+          find /tmp/agent-ci -maxdepth 6 -type d 2>/dev/null | head -50
+          echo "::endgroup::"
+          for f in $(find /tmp/agent-ci -path '*/logs/steps/*.log' 2>/dev/null); do
+            echo "::group::$f"
+            cat "$f"
+            echo "::endgroup::"
+          done
+          for f in $(find /tmp/agent-ci -name 'debug.log' 2>/dev/null); do
+            echo "::group::$f"
+            tail -500 "$f"
+            echo "::endgroup::"
+          done
+
+      - name: Upload agent-ci logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-ci-logs
+          path: /tmp/agent-ci/**/logs/**
+          if-no-files-found: warn
 
       - name: Assert setup-buildx-action completed and `docker buildx` is usable
         run: |

--- a/.github/workflows/smoke-docker-buildx.yml
+++ b/.github/workflows/smoke-docker-buildx.yml
@@ -82,6 +82,8 @@ jobs:
           DEBUG: "agent-ci:*"
           AI_AGENT: "1" # same as --quiet: no animated TUI, but still full logs
         run: |
+          # agent-ci exits non-zero if any step fails, so propagate via pipefail
+          set -o pipefail
           node "$GITHUB_WORKSPACE/packages/cli/dist/cli.js" \
             run --workflow .github/workflows/test.yml 2>&1 | tee /tmp/docker-buildx.out
 
@@ -111,11 +113,19 @@ jobs:
           path: /tmp/agent-ci/**/logs/**
           if-no-files-found: warn
 
-      - name: Assert setup-buildx-action completed and `docker buildx` is usable
+      - name: Assert `docker buildx` is usable inside agent-ci
         run: |
-          if ! grep -q "buildx is working" /tmp/docker-buildx.out; then
-            echo "::error::docker/setup-buildx-action@v4 did not complete — 'Verify buildx' step never ran or failed."
-            grep -n -iE "buildx|error|fail" /tmp/docker-buildx.out || true
+          # agent-ci runs in quiet/AI-agent mode and doesn't stream per-step
+          # stdout to its top-level output. The "Verify buildx" step's output
+          # lives in the per-step log file. Check it there.
+          log=$(find /tmp/agent-ci -path '*/logs/steps/Verify-buildx.log' | head -1)
+          if [ -z "$log" ]; then
+            echo "::error::Verify-buildx.log missing — the step never ran."
+            exit 1
+          fi
+          if ! grep -q "buildx is working" "$log"; then
+            echo "::error::'buildx is working' not found in $log"
+            cat "$log"
             exit 1
           fi
           echo "OK: docker/setup-buildx-action@v4 ran and buildx is usable."

--- a/packages/cli/src/docker/container-config.test.ts
+++ b/packages/cli/src/docker/container-config.test.ts
@@ -203,6 +203,24 @@ describe("buildContainerCmd", () => {
 
     expect(cmd[2]).toContain("socat TCP-LISTEN:5432");
   });
+
+  // Regression for #257: on native Linux Docker the bind-mounted
+  // /var/run/docker.sock is root:docker 0660 and the runner user can't
+  // chmod it without sudo. If this line drops MAYBE_SUDO, every step that
+  // talks to the Docker socket (buildx, compose, docker login, ...) fails
+  // with "permission denied".
+  it("chmods the docker socket via MAYBE_SUDO so it works on native Linux Docker (#257)", async () => {
+    const { buildContainerCmd } = await import("./container-config.js");
+    const cmd = buildContainerCmd({
+      svcPortForwardSnippet: "",
+      dtuPort: "3000",
+      dtuHost: "localhost",
+      useDirectContainer: false,
+      containerName: "test-runner",
+    });
+
+    expect(cmd[2]).toContain("MAYBE_SUDO chmod 666 /var/run/docker.sock");
+  });
 });
 
 // ── resolveDockerApiUrl ───────────────────────────────────────────────────────

--- a/packages/cli/src/docker/container-config.ts
+++ b/packages/cli/src/docker/container-config.ts
@@ -155,7 +155,16 @@ export function buildContainerCmd(opts: ContainerCmdOpts): string[] {
     // chmod is done host-side in workspacePrepPromise — skip it here
     `if [ -f /usr/bin/git ]; then MAYBE_SUDO mv /usr/bin/git /usr/bin/git.real 2>/dev/null; MAYBE_SUDO cp -p /tmp/agent-ci-shims/git /usr/bin/git 2>/dev/null; MAYBE_SUDO chmod +x /usr/bin/git 2>/dev/null; fi`,
     T("git-shim"),
-    `${svcPortForwardSnippet}chmod 666 /var/run/docker.sock 2>/dev/null || true`,
+    // The bind-mounted /var/run/docker.sock inherits host ownership (root:docker,
+    // 0660 on native Linux Docker). The runner user inside the container is
+    // not in the host's docker group, so without this chmod, any step that
+    // talks to the Docker socket (docker/setup-buildx-action, docker login,
+    // buildx, compose, ...) fails with "permission denied while trying to
+    // connect to the docker API at unix:///var/run/docker.sock" (#257).
+    // MAYBE_SUDO is required because runner (UID 1001) cannot chmod a
+    // root-owned socket without escalation. macOS/OrbStack/Colima usually
+    // ship the socket as world-accessible so this is a no-op there.
+    `${svcPortForwardSnippet}MAYBE_SUDO chmod 666 /var/run/docker.sock 2>/dev/null || true`,
     T("docker-sock"),
     // The Playwright bind mount creates /home/runner/.cache as root — make it
     // world-writable so tools like Cypress can mkdir inside it (#234).


### PR DESCRIPTION
## Problem

When you ran a GitHub Actions workflow through agent-ci on native Linux Docker, any step that talked to the Docker socket — `docker/setup-buildx-action@v4`, `docker login`, `docker compose` — failed with `permission denied while trying to connect to the docker API at unix:///var/run/docker.sock` (#257).

The runner's entrypoint tries to `chmod 666` the bind-mounted `/var/run/docker.sock` so the non-root `runner` user can reach it. On native Linux the socket is owned `root:docker` with mode `0660`, so a plain `chmod` silently fails — `runner` isn't root and isn't in the host's `docker` group. macOS setups (Docker Desktop, OrbStack, Colima) ship the socket world-writable, so the chmod is a no-op there and nobody on mac hit the bug.

## Solution

The chmod now runs through `MAYBE_SUDO`, matching every other privileged entrypoint step. On native Linux it escalates and the socket becomes reachable; on macOS it stays a no-op. One line in `packages/cli/src/docker/container-config.ts`.

Also added:

- A regression test in `packages/cli/src/docker/container-config.test.ts` so the `MAYBE_SUDO` can't be dropped again without a failing test.
- A smoke workflow (`.github/workflows/smoke-docker-buildx.yml`) that stands up a throwaway project whose inner workflow does `docker/setup-buildx-action@v4` + `docker buildx version`, runs it through agent-ci on the hosted `ubuntu-latest` runner, and asserts `buildx is working` was printed.
- A changeset.

## History note (for future readers)

If you `git log -S "MAYBE_SUDO chmod 666 /var/run/docker.sock"` you'll see this same change was added and then reverted on 2026-04-13 (commits `7389f378` → `23ff3fd9`, 95 seconds apart). That revert was **not** a rejection on the merits — it was untangling unrelated drift that had been dragged into #224 ("fix: support boolean operators in workflow expressions"), whose title has nothing to do with Docker. This PR reintroduces `MAYBE_SUDO` intentionally, with a real reproducer (#257) and a regression test, so please don't re-revert it thinking "we tried this and backed it out."
