### PR TITLE
fix(website): run oxfmt on home.md to unbreak pnpm check on main

### DIFF
--- a/apps/website/src/app/pages/home.md
+++ b/apps/website/src/app/pages/home.md
@@ -35,13 +35,13 @@
 
 ## Architecture Comparison
 
-| Feature           | GitHub Actions     | Other local runners      | Agent CI                        |
-| ----------------- | ------------------ | ------------------------ | ------------------------------- |
-| Runner binary     | Official           | Custom re-implementation | **Official**                    |
-| API layer         | GitHub.com         | Compatibility shim       | **Full local emulation**        |
-| Cache round-trip  | Network (~seconds) | Varies                   | **~0 ms (bind-mount)**          |
-| On failure        | Start over         | Start over               | **Pause → fix → retry step**    |
-| Container state   | Destroyed          | Destroyed                | **Kept alive**                  |
+| Feature          | GitHub Actions     | Other local runners      | Agent CI                     |
+| ---------------- | ------------------ | ------------------------ | ---------------------------- |
+| Runner binary    | Official           | Custom re-implementation | **Official**                 |
+| API layer        | GitHub.com         | Compatibility shim       | **Full local emulation**     |
+| Cache round-trip | Network (~seconds) | Varies                   | **~0 ms (bind-mount)**       |
+| On failure       | Start over         | Start over               | **Pause → fix → retry step** |
+| Container state  | Destroyed          | Destroyed                | **Kept alive**               |
 
 ---
 


### PR DESCRIPTION
#266 merged an edit to `apps/website/src/app/pages/home.md` that doesn't match `oxfmt`'s canonical markdown table column widths. Since then, `pnpm format:check` (and therefore `pnpm check`, and therefore the smoke `Run pnpm check` step) has been red on main.

Fix: run `pnpm exec oxfmt apps/website/src/app/pages/home.md`. Only table whitespace changes.

## Repro (on main before this PR)

```console
$ pnpm exec oxfmt --check apps/website/src/app/pages/home.md
Format issues found in above 1 files.
```

## Changeset

Skipping per `.claude/rules/changeset-required.md`: `apps/website` is `"private": true`, not a published package, and the change is whitespace-only.
