### PR TITLE
fix(smoke-vars-preflight): make generated test.yml retain literal vars refs

### DIFF
--- a/.github/workflows/smoke-vars-preflight.yml
+++ b/.github/workflows/smoke-vars-preflight.yml
@@ -1,6 +1,6 @@
 name: "Smoke: --var pre-flight"
 
-# Proves that `${{ vars.FOO }}` references are caught up-front:
+# Proves that `vars.FOO` references in a workflow are caught up-front:
 #   - Missing vars → agent-ci fails before any container setup, error
 #     message lists every missing var with the --var flag syntax.
 #   - Partial fill → only the still-missing var appears in the error.
@@ -38,23 +38,30 @@ jobs:
 
       - name: Create temp project with a vars-using workflow
         run: |
-          mkdir -p /tmp/vars-repro/.github/workflows
+          # Build the `${X}` GHA-expression opener from parts — the literal
+          # string `${X}` must never appear in this run: script, because the
+          # outer runner's template engine would substitute it before writing
+          # test.yml, stripping the vars.X references the inner agent-ci needs.
+          D='$'
+          OPEN="${D}{{"
+          CLOSE='}}'
 
-          cat > /tmp/vars-repro/.github/workflows/test.yml << 'WF'
+          mkdir -p /tmp/vars-repro/.github/workflows
+          cat > /tmp/vars-repro/.github/workflows/test.yml <<WF
           name: Test
           on: push
           jobs:
             test:
               runs-on: ubuntu-latest
               env:
-                API_URL: ${{ vars.API_URL }}
-                DEPLOY_ENV: ${{ vars.DEPLOY_ENV }}
+                API_URL: ${OPEN} vars.API_URL ${CLOSE}
+                DEPLOY_ENV: ${OPEN} vars.DEPLOY_ENV ${CLOSE}
               steps:
                 - run: |
-                    echo "api=$API_URL"
-                    echo "env=$DEPLOY_ENV"
-                    [ "$API_URL" = "https://api.example.com" ]
-                    [ "$DEPLOY_ENV" = "production" ]
+                    echo "api=\$API_URL"
+                    echo "env=\$DEPLOY_ENV"
+                    [ "\$API_URL" = "https://api.example.com" ]
+                    [ "\$DEPLOY_ENV" = "production" ]
           WF
 
           cd /tmp/vars-repro


### PR DESCRIPTION
`.github/workflows/smoke-vars-preflight.yml` has failed on **every run since it was merged** in #260 — on this PR branch, on main, on `fix/format-home-md`, on earlier PRs. Two independent bugs in the same file:

## Bug 1 — `FOO` falsely required by the outer preflight

The top comment contained `` `${{ vars.FOO }}` `` (inside backticks, for human documentation). `extractVarRefs()` is a text-level regex scan and doesn't understand YAML comments, so the outer preflight always required `--var FOO=...` even though no step uses `vars.FOO`. Rephrase the comment to just `vars.FOO` without the expression syntax.

## Bug 2 — heredoc `${{ }}` gets substituted before the file is written

The setup step wrote the inner test.yml via:
```yaml
cat > /tmp/vars-repro/.github/workflows/test.yml << 'WF'
...
env:
  API_URL: ${{ vars.API_URL }}
  DEPLOY_ENV: ${{ vars.DEPLOY_ENV }}
WF
```
GitHub Actions' template engine processes `${{ ... }}` in every `run:` script **regardless of shell heredoc quoting** — `<< 'WF'` stops bash expansion but the runner has already templated the script text before bash ever sees it. Result: the generated test.yml had **no** `vars.X` references (they'd been substituted at outer-run time), so:

- **Case 1** (no --var flags): inner preflight found nothing to check, workflow proceeded, assertion against `"https://api.example.com"` failed with empty `$API_URL`. Test fails with "missing error header".
- **Case 2** (partial --var): same.
- **Case 3** (all --var): same — but since the outer runner substituted correctly anyway, this one would *look* like it passed if Case 1 hadn't already failed the job.

**Fix:** build `${` + `{{` at shell runtime from non-triggering parts (`D='$'; OPEN="${D}{{"`) so the literal `${{` never appears in the outer `run:` source. Switch the heredoc to unquoted (`<<WF`) so the shell variable expands, and escape `\$API_URL`/`\$DEPLOY_ENV` to keep them literal for the inner shell.

## Validation

```console
$ pnpm agent-ci-dev run --workflow .github/workflows/smoke-vars-preflight.yml -q -p \
    --var API_URL=https://api.example.com --var DEPLOY_ENV=production

━━━ SUMMARY ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Status:    ✓ 1 passed (1 total)
  Duration:  14s
```

All three cases now pass.

## Related

- #256 — the issue this test is supposed to prove is fixed
- #260 — the PR that added the broken test

## Changeset

Skipping per `.claude/rules/changeset-required.md`: workflow-only change, no code in `packages/`.
