### PR TITLE
feat(cli): support env: at workflow and job level

### DIFF
--- a/.changeset/job-and-workflow-level-env.md
+++ b/.changeset/job-and-workflow-level-env.md
@@ -1,0 +1,12 @@
+---
+"@redwoodjs/agent-ci": minor
+"dtu-github-actions": patch
+---
+
+Support `env:` at workflow and job level (not just step level).
+
+Previously the workflow parser only read `env:` declared directly on a step. Workflow-level and job-level `env:` blocks were silently ignored, so any workflow that relied on them — including workflows that referenced `${{ vars.X }}` in a job-level env — saw empty values at runtime.
+
+The parser now merges `env:` from all three levels per the GitHub Actions spec: workflow → job → step, step-most-specific wins. Expressions (including `${{ vars.X }}`, `${{ secrets.X }}`, etc.) are expanded per-level.
+
+This also makes the `smoke-vars-preflight.yml` Case 3 assertion actually verify the feature it documents — previously the assertion depended on env leaking in from the outer runner process.

--- a/packages/cli/src/workflow/workflow-parser.test.ts
+++ b/packages/cli/src/workflow/workflow-parser.test.ts
@@ -1849,3 +1849,122 @@ jobs:
     );
   });
 });
+
+// ─── parseWorkflowSteps env merging (workflow → job → step) ──────────────────────
+describe("parseWorkflowSteps env merging", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  function writeWorkflowTree(content: string): string {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oa-env-merge-"));
+    const workflowDir = path.join(tmpDir, ".github", "workflows");
+    fs.mkdirSync(workflowDir, { recursive: true });
+    const filePath = path.join(workflowDir, "test.yml");
+    fs.writeFileSync(filePath, content);
+    return filePath;
+  }
+
+  it("propagates job-level env to steps", async () => {
+    const filePath = writeWorkflowTree(`
+name: Job Env
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      FROM_JOB: job-value
+    steps:
+      - run: echo hi
+`);
+    const steps = await parseWorkflowSteps(filePath, "test");
+    expect((steps[0] as any).Env).toEqual({ FROM_JOB: "job-value" });
+  });
+
+  it("propagates workflow-level env to steps", async () => {
+    const filePath = writeWorkflowTree(`
+name: Workflow Env
+on: [push]
+env:
+  FROM_WORKFLOW: workflow-value
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`);
+    const steps = await parseWorkflowSteps(filePath, "test");
+    expect((steps[0] as any).Env).toEqual({ FROM_WORKFLOW: "workflow-value" });
+  });
+
+  it("merges workflow + job + step env with step-overrides-job-overrides-workflow precedence", async () => {
+    const filePath = writeWorkflowTree(`
+name: Precedence
+on: [push]
+env:
+  LEVEL: workflow
+  WF_ONLY: workflow
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      LEVEL: job
+      JOB_ONLY: job
+    steps:
+      - env:
+          LEVEL: step
+          STEP_ONLY: step
+        run: echo hi
+`);
+    const steps = await parseWorkflowSteps(filePath, "test");
+    expect((steps[0] as any).Env).toEqual({
+      LEVEL: "step",
+      WF_ONLY: "workflow",
+      JOB_ONLY: "job",
+      STEP_ONLY: "step",
+    });
+  });
+
+  it("expands \\${{ vars.X }} in job-level env", async () => {
+    const filePath = writeWorkflowTree(`
+name: Vars In Job Env
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      API_URL: \${{ vars.API_URL }}
+    steps:
+      - run: echo hi
+`);
+    const vars = { API_URL: "https://api.example.com" };
+    const steps = await parseWorkflowSteps(
+      filePath,
+      "test",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      vars,
+    );
+    expect((steps[0] as any).Env).toEqual({ API_URL: "https://api.example.com" });
+  });
+
+  it("returns undefined Env when no env declared at any level", async () => {
+    const filePath = writeWorkflowTree(`
+name: No Env
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`);
+    const steps = await parseWorkflowSteps(filePath, "test");
+    expect((steps[0] as any).Env).toBeUndefined();
+  });
+});

--- a/packages/cli/src/workflow/workflow-parser.ts
+++ b/packages/cli/src/workflow/workflow-parser.ts
@@ -793,6 +793,57 @@ export async function parseMatrixDef(
   return Object.keys(result).length > 0 ? result : null;
 }
 
+/**
+ * Build a step's effective env by merging workflow-level, job-level, and
+ * step-level `env:` blocks in that order — step overrides job overrides
+ * workflow, per GitHub Actions semantics — then expanding each value's
+ * `${{ }}` expressions.
+ *
+ * Returns undefined when no env is declared at any level, matching the
+ * prior shape so a step with no env produces no `Env` field.
+ */
+function buildStepEnv(
+  rawYaml: unknown,
+  rawJob: unknown,
+  rawStep: unknown,
+  repoPath: string | undefined,
+  secrets: Record<string, string> | undefined,
+  matrixContext: Record<string, string> | undefined,
+  needsContext: Record<string, Record<string, string>> | undefined,
+  inputsContext: Record<string, string> | undefined,
+  vars: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  const pick = (source: unknown): Record<string, unknown> => {
+    if (!source || typeof source !== "object") {
+      return {};
+    }
+    const env = (source as { env?: unknown }).env;
+    return env && typeof env === "object" ? (env as Record<string, unknown>) : {};
+  };
+  const merged: Record<string, unknown> = {
+    ...pick(rawYaml),
+    ...pick(rawJob),
+    ...pick(rawStep),
+  };
+  if (Object.keys(merged).length === 0) {
+    return undefined;
+  }
+  return Object.fromEntries(
+    Object.entries(merged).map(([k, v]) => [
+      k,
+      expandExpressions(
+        String(v),
+        repoPath,
+        secrets,
+        matrixContext,
+        needsContext,
+        inputsContext,
+        vars,
+      ),
+    ]),
+  );
+}
+
 export async function parseWorkflowSteps(
   filePath: string,
   taskName: string,
@@ -889,22 +940,17 @@ export async function parseWorkflowSteps(
             Type: "Script",
           },
           Inputs: inputs,
-          Env: rawStep.env
-            ? Object.fromEntries(
-                Object.entries(rawStep.env).map(([k, v]) => [
-                  k,
-                  expandExpressions(
-                    String(v),
-                    repoPath,
-                    secrets,
-                    undefined,
-                    needsContext,
-                    inputsContext,
-                    vars,
-                  ),
-                ]),
-              )
-            : undefined,
+          Env: buildStepEnv(
+            rawYaml,
+            rawJob,
+            rawStep,
+            repoPath,
+            secrets,
+            undefined,
+            needsContext,
+            inputsContext,
+            vars,
+          ),
         };
       } else if ("uses" in step) {
         // Basic support for 'uses' steps
@@ -998,22 +1044,17 @@ export async function parseWorkflowSteps(
                 }
               : {}), // Prevent actions/checkout from wiping the rsynced workspace
           },
-          Env: rawStep.env
-            ? Object.fromEntries(
-                Object.entries(rawStep.env).map(([k, v]) => [
-                  k,
-                  expandExpressions(
-                    String(v),
-                    repoPath,
-                    secrets,
-                    matrixContext,
-                    needsContext,
-                    inputsContext,
-                    vars,
-                  ),
-                ]),
-              )
-            : undefined,
+          Env: buildStepEnv(
+            rawYaml,
+            rawJob,
+            rawStep,
+            repoPath,
+            secrets,
+            matrixContext,
+            needsContext,
+            inputsContext,
+            vars,
+          ),
         };
       }
       return null;


### PR DESCRIPTION
## Problem

agent-ci's workflow parser only read `env:` declared directly on a step. Workflow-level and job-level `env:` blocks were silently ignored — zero references to either in `packages/cli/src/`:

```yaml
jobs:
  test:
    env:                              # ← job-level: silently ignored
      API_URL: ${{ vars.API_URL }}
    steps:
      - run: echo $API_URL            # ← saw empty string
```

This is a standard GitHub Actions feature and the README claims "If your workflow runs on GitHub, it runs here." The gap was caught when #270 unbroke `smoke-vars-preflight.yml` — Case 3 still failed on CI even with the fixed test, because the test's job-level env was being dropped. (Earlier it had *appeared* to pass locally via env leak from the outer runner process, which my investigation in #270 exposed as a false positive.)

## Fix

The parser now merges `env:` from all three levels per the GHA spec — **workflow → job → step, step-most-specific wins** — and expands expressions (`${{ vars.X }}`, `${{ secrets.X }}`, etc.) per value with the full context.

### Implementation

- New internal `buildStepEnv()` helper in `workflow-parser.ts` that merges the three levels and runs `expandExpressions` on each value.
- Both the `run:` and `uses:` step branches now call it, dropping the duplicated inline env-construction logic.
- **5 new unit tests** in `workflow-parser.test.ts`:
  1. Job-level env propagates to steps
  2. Workflow-level env propagates to steps
  3. Three-level precedence (step > job > workflow)
  4. `${{ vars.X }}` expands in job-level env
  5. Undefined `Env` when no env declared at any level

All 584 package tests still pass.

## End-to-end validation

Ran `pnpm agent-ci-dev run --workflow smoke-vars-preflight.yml` locally against the fixed cli — **all three cases pass** (Case 3 now passes for real, not via env leak):

```console
━━━ SUMMARY ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Status:    ✓ 1 passed (1 total)
  Duration:  14s
```

## Changeset

Included: `minor` for `@redwoodjs/agent-ci` (new capability — previously-declared-but-not-supported env levels now work), `patch` for `dtu-github-actions` (same version bump required since fixed versioning).

## Related

- #256 / #260 — the `vars` feature this unblocks for real-world workflows that use job-level env (most do)
- #270 — the smoke test fix that made this failure visible
