### PR TITLE
Skip jobs with unsupported runs-on OS instead of running them on Linux

### DIFF
--- a/.changeset/skip-unsupported-os-runners.md
+++ b/.changeset/skip-unsupported-os-runners.md
@@ -1,0 +1,13 @@
+---
+"@redwoodjs/agent-ci": minor
+"dtu-github-actions": minor
+---
+
+Skip jobs with `runs-on: macos-*` or `windows-*` instead of silently running them in a Linux container
+
+Previously, jobs targeting macOS or Windows runners were silently routed to the Linux runner container and failed at the first OS-specific step (e.g. `Setup Xcode`), producing a confusing error. They now skip with a visible `[Agent CI]` warning that points at the tracking issues for real support. Linux and `self-hosted`-without-OS-hint jobs are unaffected.
+
+Tracking:
+
+- https://github.com/redwoodjs/agent-ci/issues/254 (this guardrail)
+- https://github.com/redwoodjs/agent-ci/issues/258 (real macOS runner support)

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -35,8 +35,14 @@ import {
   parseJobIf,
   evaluateJobIf,
   parseFailFast,
+  parseJobRunsOn,
   expandExpressions,
 } from "./workflow/workflow-parser.js";
+import {
+  classifyRunsOn,
+  isUnsupportedOS,
+  formatUnsupportedOSWarning,
+} from "./runner/runs-on-compat.js";
 import { resolveJobOutputs } from "./runner/result-builder.js";
 import { Job } from "./types.js";
 import { createConcurrencyLimiter, getDefaultMaxConcurrentJobs } from "./output/concurrency.js";
@@ -925,9 +931,44 @@ async function handleWorkflow(options: {
     }
   }
 
+  // ── Unsupported-OS skip (shared between single- and multi-job paths) ──────
+  // Jobs with `runs-on: macos-*` or `windows-*` can't be executed locally
+  // today — agent-ci only runs jobs in a Linux container. Rather than
+  // silently landing them there and failing at the first OS-specific step,
+  // we skip them with a visible warning. See:
+  //   https://github.com/redwoodjs/agent-ci/issues/254  (this guardrail)
+  //   https://github.com/redwoodjs/agent-ci/issues/258  (real macOS support)
+  const skippedResult = (ej: ExpandedJob): JobResult => ({
+    name: `agent-ci-skipped-${ej.taskName}`,
+    workflow: path.basename(ej.workflowPath),
+    taskId: ej.taskName,
+    succeeded: true,
+    durationMs: 0,
+    debugLogPath: "",
+    steps: [],
+  });
+  const warnedUnsupportedOS = new Set<string>();
+  const maybeSkipUnsupportedOS = (ej: ExpandedJob): JobResult | null => {
+    const actualTaskName = ej.sourceTaskName ?? ej.taskName;
+    const labels = parseJobRunsOn(ej.workflowPath, actualTaskName);
+    const kind = classifyRunsOn(labels);
+    if (!isUnsupportedOS(kind)) {
+      return null;
+    }
+    if (!warnedUnsupportedOS.has(ej.taskName)) {
+      warnedUnsupportedOS.add(ej.taskName);
+      process.stderr.write(formatUnsupportedOSWarning(ej.taskName, labels, kind) + "\n\n");
+    }
+    return skippedResult(ej);
+  };
+
   // For single-job workflows, run directly without extra orchestration
   if (expandedJobs.length === 1) {
     const ej = expandedJobs[0];
+    const osSkip = maybeSkipUnsupportedOS(ej);
+    if (osSkip) {
+      return [osSkip];
+    }
     const actualTaskName = ej.sourceTaskName ?? ej.taskName;
     const requiredRefs = extractSecretRefs(ej.workflowPath, actualTaskName);
     const secrets = loadMachineSecrets(repoRoot, requiredRefs);
@@ -1291,19 +1332,13 @@ async function handleWorkflow(options: {
     return !evaluateJobIf(ifExpr, upstreamResults, needsCtx);
   };
 
-  /** Create a synthetic skipped result for a job that was skipped by if: */
-  const skippedResult = (ej: ExpandedJob): JobResult => ({
-    name: `agent-ci-skipped-${ej.taskName}`,
-    workflow: path.basename(ej.workflowPath),
-    taskId: ej.taskName,
-    succeeded: true,
-    durationMs: 0,
-    debugLogPath: "",
-    steps: [],
-  });
-
-  /** Run a job or skip it based on if: condition */
+  /** Run a job or skip it based on if: condition or unsupported OS */
   const runOrSkipJob = async (ej: ExpandedJob): Promise<JobResult> => {
+    const osSkip = maybeSkipUnsupportedOS(ej);
+    if (osSkip) {
+      jobResultStatus.set(ej.taskName, "skipped");
+      return osSkip;
+    }
     if (shouldSkipJob(ej.taskName, ej)) {
       debugCli(`Skipping ${ej.taskName} (if: condition is false)`);
       const result = skippedResult(ej);

--- a/packages/cli/src/runner/runs-on-compat.test.ts
+++ b/packages/cli/src/runner/runs-on-compat.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { classifyRunsOn, isUnsupportedOS, formatUnsupportedOSWarning } from "./runs-on-compat.js";
+
+describe("classifyRunsOn", () => {
+  it("treats ubuntu-* as linux", () => {
+    expect(classifyRunsOn(["ubuntu-latest"])).toBe("linux");
+    expect(classifyRunsOn(["ubuntu-22.04"])).toBe("linux");
+    expect(classifyRunsOn(["ubuntu"])).toBe("linux");
+    expect(classifyRunsOn(["linux"])).toBe("linux");
+  });
+
+  it("treats macos-* as macos", () => {
+    expect(classifyRunsOn(["macos-latest"])).toBe("macos");
+    expect(classifyRunsOn(["macos-14"])).toBe("macos");
+    expect(classifyRunsOn(["macos-13-large"])).toBe("macos");
+    expect(classifyRunsOn(["macos"])).toBe("macos");
+  });
+
+  it("treats windows-* as windows", () => {
+    expect(classifyRunsOn(["windows-latest"])).toBe("windows");
+    expect(classifyRunsOn(["windows-2022"])).toBe("windows");
+    expect(classifyRunsOn(["windows"])).toBe("windows");
+  });
+
+  it("preserves macOS classification when self-hosted labels are present", () => {
+    // GitHub lets you write `runs-on: [self-hosted, macos, arm64]`. The OS
+    // hint wins over self-hosted — otherwise the job silently lands in the
+    // Linux container (#254).
+    expect(classifyRunsOn(["self-hosted", "macos", "arm64"])).toBe("macos");
+    expect(classifyRunsOn(["self-hosted", "macos-14"])).toBe("macos");
+    expect(classifyRunsOn(["self-hosted", "windows", "x64"])).toBe("windows");
+  });
+
+  it("returns 'other' for empty, pure self-hosted, or unknown labels", () => {
+    expect(classifyRunsOn([])).toBe("other");
+    expect(classifyRunsOn(["self-hosted"])).toBe("other");
+    expect(classifyRunsOn(["self-hosted", "arm64"])).toBe("other");
+    expect(classifyRunsOn(["my-custom-label"])).toBe("other");
+  });
+
+  it("is case-insensitive", () => {
+    expect(classifyRunsOn(["MacOS-Latest"])).toBe("macos");
+    expect(classifyRunsOn(["Ubuntu-Latest"])).toBe("linux");
+    expect(classifyRunsOn(["WINDOWS-2022"])).toBe("windows");
+  });
+
+  it("trims whitespace", () => {
+    expect(classifyRunsOn(["  macos-latest  "])).toBe("macos");
+  });
+});
+
+describe("isUnsupportedOS", () => {
+  it("flags macos and windows as unsupported", () => {
+    expect(isUnsupportedOS("macos")).toBe(true);
+    expect(isUnsupportedOS("windows")).toBe(true);
+  });
+
+  it("allows linux and other", () => {
+    expect(isUnsupportedOS("linux")).toBe(false);
+    expect(isUnsupportedOS("other")).toBe(false);
+  });
+});
+
+describe("formatUnsupportedOSWarning", () => {
+  it("produces a macOS-specific message with the #258 tracker", () => {
+    const msg = formatUnsupportedOSWarning("build-test", ["macos-latest"], "macos");
+    expect(msg).toContain('Skipping job "build-test"');
+    expect(msg).toContain("macOS");
+    expect(msg).toContain("macos-latest");
+    expect(msg).toContain("issues/258");
+  });
+
+  it("produces a Windows-specific message with the #254 tracker", () => {
+    const msg = formatUnsupportedOSWarning("build", ["windows-2022"], "windows");
+    expect(msg).toContain("Windows");
+    expect(msg).toContain("windows-2022");
+    expect(msg).toContain("issues/254");
+  });
+
+  it("lists all labels when multiple were provided", () => {
+    const msg = formatUnsupportedOSWarning("x", ["self-hosted", "macos", "arm64"], "macos");
+    expect(msg).toContain("self-hosted, macos, arm64");
+  });
+});

--- a/packages/cli/src/runner/runs-on-compat.ts
+++ b/packages/cli/src/runner/runs-on-compat.ts
@@ -1,0 +1,74 @@
+/**
+ * Runs-on compatibility classifier.
+ *
+ * agent-ci today runs every job in a Linux Docker container, regardless of
+ * the job's `runs-on:` label. For jobs that explicitly target macOS or
+ * Windows runners, silently landing them in a Linux container produces
+ * confusing failures — typically "command not found" at the first OS-specific
+ * step (see https://github.com/redwoodjs/agent-ci/issues/254).
+ *
+ * This module classifies a job's `runs-on:` labels so the caller can skip
+ * unsupported jobs with a clear warning instead. Real macOS runner support
+ * is tracked separately in https://github.com/redwoodjs/agent-ci/issues/258.
+ */
+
+export type RunnerOSKind = "linux" | "macos" | "windows" | "other";
+
+/**
+ * Classify the OS family implied by a job's `runs-on:` labels.
+ *
+ * Rules (first match wins):
+ *   - Any `macos` or `macos-*` label → "macos"
+ *   - Any `windows` or `windows-*` label → "windows"
+ *   - Any `ubuntu`, `ubuntu-*`, or `linux` label → "linux"
+ *   - Otherwise (empty array, pure `self-hosted`, unknown custom label) → "other"
+ *
+ * "other" is deliberately permissive — a user with a custom self-hosted label
+ * today lands in the Linux container by default, and we don't want to
+ * regress them.
+ */
+export function classifyRunsOn(labels: string[]): RunnerOSKind {
+  for (const raw of labels) {
+    const l = String(raw).toLowerCase().trim();
+    if (l === "macos" || l.startsWith("macos-")) {
+      return "macos";
+    }
+    if (l === "windows" || l.startsWith("windows-")) {
+      return "windows";
+    }
+  }
+  for (const raw of labels) {
+    const l = String(raw).toLowerCase().trim();
+    if (l === "ubuntu" || l.startsWith("ubuntu-") || l === "linux") {
+      return "linux";
+    }
+  }
+  return "other";
+}
+
+/** Is this OS something agent-ci does not yet know how to run? */
+export function isUnsupportedOS(kind: RunnerOSKind): boolean {
+  return kind === "macos" || kind === "windows";
+}
+
+/**
+ * Format a user-facing warning for a job skipped because its `runs-on:`
+ * targets an OS agent-ci can't execute locally. Written for stderr.
+ */
+export function formatUnsupportedOSWarning(
+  taskName: string,
+  labels: string[],
+  kind: RunnerOSKind,
+): string {
+  const labelStr = labels.length > 0 ? labels.join(", ") : "(none)";
+  const osName = kind === "macos" ? "macOS" : kind === "windows" ? "Windows" : kind;
+  const tracker =
+    kind === "macos"
+      ? "https://github.com/redwoodjs/agent-ci/issues/258"
+      : "https://github.com/redwoodjs/agent-ci/issues/254";
+  return [
+    `[Agent CI] Skipping job "${taskName}": runs-on targets ${osName} (${labelStr}).`,
+    `  agent-ci currently only runs jobs in a Linux container, so this job`,
+    `  cannot execute locally. Tracking: ${tracker}`,
+  ].join("\n");
+}

--- a/packages/cli/src/workflow/workflow-parser.test.ts
+++ b/packages/cli/src/workflow/workflow-parser.test.ts
@@ -1968,3 +1968,88 @@ jobs:
     expect((steps[0] as any).Env).toBeUndefined();
   });
 });
+
+import { parseJobRunsOn } from "./workflow-parser.js";
+
+describe("parseJobRunsOn", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  function writeWorkflow(content: string): string {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oa-runson-test-"));
+    const filePath = path.join(tmpDir, "workflow.yml");
+    fs.writeFileSync(filePath, content);
+    return filePath;
+  }
+
+  it("returns a single-element array for a string runs-on", () => {
+    const filePath = writeWorkflow(`
+name: X
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+`);
+    expect(parseJobRunsOn(filePath, "build")).toEqual(["ubuntu-latest"]);
+  });
+
+  it("returns all labels for an array runs-on", () => {
+    const filePath = writeWorkflow(`
+name: X
+on: [push]
+jobs:
+  build:
+    runs-on: [self-hosted, macos, arm64]
+    steps:
+      - run: echo ok
+`);
+    expect(parseJobRunsOn(filePath, "build")).toEqual(["self-hosted", "macos", "arm64"]);
+  });
+
+  it("returns labels from the object form (group + labels)", () => {
+    const filePath = writeWorkflow(`
+name: X
+on: [push]
+jobs:
+  build:
+    runs-on:
+      group: my-group
+      labels: [macos-14, arm64]
+    steps:
+      - run: echo ok
+`);
+    expect(parseJobRunsOn(filePath, "build")).toEqual(["macos-14", "arm64"]);
+  });
+
+  it("returns an empty array when runs-on is missing", () => {
+    const filePath = writeWorkflow(`
+name: X
+on: [push]
+jobs:
+  build:
+    steps:
+      - run: echo ok
+`);
+    expect(parseJobRunsOn(filePath, "build")).toEqual([]);
+  });
+
+  it("returns an empty array when the job does not exist", () => {
+    const filePath = writeWorkflow(`
+name: X
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+`);
+    expect(parseJobRunsOn(filePath, "other")).toEqual([]);
+  });
+});

--- a/packages/cli/src/workflow/workflow-parser.ts
+++ b/packages/cli/src/workflow/workflow-parser.ts
@@ -1571,6 +1571,42 @@ function resolveValue(raw: string, needsCtx?: Record<string, Record<string, stri
  * Parse `strategy.fail-fast` for a job.
  * Returns true/false if explicitly set, undefined if not specified.
  */
+/**
+ * Parse the `runs-on:` field of a workflow job and return the labels as a flat
+ * array of strings. Accepts all three shapes GitHub allows:
+ *
+ *   - String:        `runs-on: ubuntu-latest`
+ *   - Array:         `runs-on: [self-hosted, macos, arm64]`
+ *   - Object form:   `runs-on: { group: foo, labels: [x, y] }`
+ *
+ * Returns an empty array if the job has no `runs-on:` (or the workflow is
+ * unparseable). Callers that need to detect a missing value should treat an
+ * empty array as "unknown".
+ */
+export function parseJobRunsOn(filePath: string, jobId: string): string[] {
+  const yaml = parseYaml(fs.readFileSync(filePath, "utf8"));
+  const raw = yaml?.jobs?.[jobId]?.["runs-on"];
+  if (raw == null) {
+    return [];
+  }
+  if (typeof raw === "string") {
+    return [raw];
+  }
+  if (Array.isArray(raw)) {
+    return raw.map((v) => String(v));
+  }
+  if (typeof raw === "object") {
+    const labels = (raw as Record<string, unknown>).labels;
+    if (Array.isArray(labels)) {
+      return labels.map((v) => String(v));
+    }
+    if (typeof labels === "string") {
+      return [labels];
+    }
+  }
+  return [];
+}
+
 export function parseFailFast(filePath: string, jobId: string): boolean | undefined {
   const yaml = parseYaml(fs.readFileSync(filePath, "utf8"));
   const strategy = yaml?.jobs?.[jobId]?.strategy;


### PR DESCRIPTION
## Problem

If a workflow job said `runs-on: macos-14` or `runs-on: windows-latest`, agent-ci would quietly run it inside the Linux container anyway. The job would then blow up at the first step that actually needed that OS — usually something like `Setup Xcode` failing because `xcodebuild` does not exist on Linux. From the user's point of view the error looked random and unrelated to the real problem (wrong OS).

## Solution

When a job's `runs-on` points at a non-Linux runner, agent-ci now skips the job up front and prints a short warning to stderr explaining why. Linux runners behave exactly as before.

Key pieces:

- `packages/cli/src/workflow/workflow-parser.ts` — `parseJobRunsOn` reads all three shapes of `runs-on` (plain string, array of labels, or `{group, labels}` object) and returns the label list.
- `packages/cli/src/runner/runs-on-compat.ts` — classifies those labels as `linux`, `macos`, `windows`, or `other`, and formats the user-facing warning.
- `packages/cli/src/cli.ts` — hooks the skip into both the single-job and multi-job paths so unsupported jobs surface as cleanly-skipped instead of running and failing mid-step.

Real macOS runner support (via tart) is still coming in #258; this PR just stops the silently-wrong behavior in the meantime.
