### PR TITLE
fix(runner): chmod /home/runner/_diag and _work for Colima/Docker Desktop (#263)

### DIFF
--- a/.changeset/fix-263-diag-work-perms-macos.md
+++ b/.changeset/fix-263-diag-work-perms-macos.md
@@ -1,0 +1,8 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Fix `UnauthorizedAccessException` on `/home/runner/_diag` and workspace write failures when running on macOS with Colima or Docker Desktop (#263).
+
+On those Docker backends the bind-mounted `_diag` and `_work` directories surface as `root:root 0755` inside the container because host permissions don't translate through the VM mount layer. The runner user (uid 1001) then can't write its diag logs or scratch files and the job crashes on startup. We now `MAYBE_SUDO chmod 1777` both mount points during container boot, mirroring the existing fix for `/home/runner/.cache` (#234). OrbStack and native Linux Docker are unaffected — the chmod is a no-op there.

--- a/.changeset/fix-263-diag-work-perms-macos.md
+++ b/.changeset/fix-263-diag-work-perms-macos.md
@@ -6,3 +6,5 @@
 Fix `UnauthorizedAccessException` on `/home/runner/_diag` and workspace write failures when running on macOS with Colima or Docker Desktop (#263).
 
 On those Docker backends the bind-mounted `_diag` and `_work` directories surface as `root:root 0755` inside the container because host permissions don't translate through the VM mount layer. The runner user (uid 1001) then can't write its diag logs or scratch files and the job crashes on startup. We now `MAYBE_SUDO chmod 1777` both mount points during container boot, mirroring the existing fix for `/home/runner/.cache` (#234). OrbStack and native Linux Docker are unaffected — the chmod is a no-op there.
+
+Also hardens Docker socket detection: agent-ci now requires a working socket at `/var/run/docker.sock` (unless `DOCKER_HOST` is set explicitly) and fails fast with a link to a new per-provider setup guide (`packages/cli/docs/docker-socket.md`) instead of silently picking a provider-specific path that the mount layer later rejects. This eliminates a class of confusing "operation not supported" errors when switching Docker backends (e.g. leftover OrbStack symlinks on a Colima host).

--- a/packages/cli/docs/docker-socket.md
+++ b/packages/cli/docs/docker-socket.md
@@ -1,0 +1,64 @@
+# Docker socket setup
+
+agent-ci launches GitHub Actions runners in Docker containers and bind-mounts the host's Docker socket into each runner so `docker build` / `docker run` steps work. For that bind-mount to survive Docker's mount layer (especially on macOS, where Docker runs inside a VM), agent-ci needs **a working Docker socket at `/var/run/docker.sock`**.
+
+If you see an error like `agent-ci couldn't use a Docker socket at /var/run/docker.sock`, use the recipe below that matches your Docker provider.
+
+## Why `/var/run/docker.sock` specifically?
+
+Docker's mount subsystem (both on native Linux and through Docker's macOS VM) treats `/var/run/docker.sock` as a canonical path. Provider-specific paths like `~/.orbstack/run/docker.sock` or `~/.colima/<profile>/docker.sock`:
+
+- may be forwarded sockets that don't exist _inside_ the provider's VM (so Docker can't bind-mount them),
+- disappear the moment you stop that provider,
+- may get shadowed when you switch providers (e.g. OrbStack creates `/var/run/docker.sock` as a symlink that dangles if you later swap to Colima).
+
+Relying on `/var/run/docker.sock` as the single source of truth avoids all of that.
+
+## Recipes
+
+### Docker Desktop (macOS / Windows / Linux)
+
+Docker Desktop creates `/var/run/docker.sock` automatically on startup. If it's missing, just start Docker Desktop (or restart it if it was running during an upgrade).
+
+### OrbStack (macOS)
+
+OrbStack creates `/var/run/docker.sock` as a symlink to `~/.orbstack/run/docker.sock` on first startup. Start OrbStack and the link is created.
+
+If you previously used OrbStack and have since switched providers, the symlink may be left dangling. Remove it and set up the new provider's link (see below).
+
+### Colima (macOS)
+
+Colima does **not** create `/var/run/docker.sock` by default. Create the symlink yourself:
+
+```sh
+colima start                                                 # if not already running
+sudo ln -sf "$HOME/.colima/docker.sock" /var/run/docker.sock
+```
+
+Why the top-level `~/.colima/docker.sock` and not `~/.colima/<profile>/docker.sock`? The profile-internal path is the socket Colima advertises via `docker context inspect`, but Docker's mount layer can't bind-mount it through Colima's VM ([operation not supported]). The top-level alias `~/.colima/docker.sock` is the stable, mountable entry point.
+
+### Native Linux (dockerd)
+
+`/var/run/docker.sock` should already exist — that's where dockerd creates it. If it's missing, check that the Docker daemon is running (`systemctl status docker`). If it exists but you can't R/W it, add yourself to the `docker` group (`sudo usermod -aG docker $USER` and re-login) — agent-ci handles the "exists but not readable by our UID" case by reading the socket path from `docker context inspect` and still using `/var/run/docker.sock` as the bind-mount source.
+
+### Rootless Docker / custom locations
+
+If your daemon's socket lives somewhere else (e.g. `/run/user/1000/docker.sock` for rootless), set `DOCKER_HOST` explicitly:
+
+```sh
+export DOCKER_HOST=unix:///run/user/1000/docker.sock
+```
+
+agent-ci honours `DOCKER_HOST` ahead of `/var/run/docker.sock` and uses your explicit path for both the API client and the container bind-mount.
+
+## Diagnosing "but it's right there"
+
+If `/var/run/docker.sock` seems to exist but agent-ci still errors:
+
+```sh
+ls -la /var/run/docker.sock        # is it a regular socket, or a dangling symlink?
+readlink /var/run/docker.sock      # where does the symlink point?
+ls -la "$(readlink /var/run/docker.sock)"   # does the target exist?
+```
+
+A common failure mode after switching Docker providers: the old provider left a symlink pointing at its now-missing socket. Delete the symlink and start the new provider (or create a fresh symlink as shown above).

--- a/packages/cli/src/docker/container-config.test.ts
+++ b/packages/cli/src/docker/container-config.test.ts
@@ -221,6 +221,24 @@ describe("buildContainerCmd", () => {
 
     expect(cmd[2]).toContain("MAYBE_SUDO chmod 666 /var/run/docker.sock");
   });
+
+  // Regression for #263: on macOS with Colima / Docker Desktop the
+  // bind-mounted /home/runner/_diag and /home/runner/_work appear as
+  // root:root 0755 inside the container (host perms don't translate
+  // through the VM mount layer), so the runner user (uid 1001) hits
+  // UnauthorizedAccessException when writing its diag logs and workspace.
+  it("chmods /home/runner/_diag and /home/runner/_work via MAYBE_SUDO (#263)", async () => {
+    const { buildContainerCmd } = await import("./container-config.js");
+    const cmd = buildContainerCmd({
+      svcPortForwardSnippet: "",
+      dtuPort: "3000",
+      dtuHost: "localhost",
+      useDirectContainer: false,
+      containerName: "test-runner",
+    });
+    expect(cmd[2]).toContain("MAYBE_SUDO chmod 1777 /home/runner/_diag");
+    expect(cmd[2]).toContain("MAYBE_SUDO chmod 1777 /home/runner/_work");
+  });
 });
 
 // ── resolveDockerApiUrl ───────────────────────────────────────────────────────

--- a/packages/cli/src/docker/container-config.ts
+++ b/packages/cli/src/docker/container-config.ts
@@ -169,6 +169,13 @@ export function buildContainerCmd(opts: ContainerCmdOpts): string[] {
     // The Playwright bind mount creates /home/runner/.cache as root — make it
     // world-writable so tools like Cypress can mkdir inside it (#234).
     `MAYBE_SUDO chmod 1777 /home/runner/.cache 2>/dev/null || true`,
+    // On Colima / Docker Desktop the bind-mounted _diag and _work dirs
+    // surface as root:root inside the container (host perms don't translate
+    // through the VM mount layer), so the runner user (uid 1001) can't
+    // write diag logs or workspace scratch files (#263). OrbStack maps
+    // UIDs automatically, so this is effectively a no-op there.
+    `MAYBE_SUDO chmod 1777 /home/runner/_diag 2>/dev/null || true`,
+    `MAYBE_SUDO chmod 1777 /home/runner/_work 2>/dev/null || true`,
     `cd /home/runner`,
     `${credentialSnippet}true`,
     T("credentials"),

--- a/packages/cli/src/docker/docker-socket.test.ts
+++ b/packages/cli/src/docker/docker-socket.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import fs from "node:fs";
-import os from "node:os";
 import { execSync } from "node:child_process";
 
 vi.mock("node:child_process", () => ({
@@ -14,7 +13,6 @@ afterEach(() => {
   delete process.env.DOCKER_HOST;
 });
 
-// Helper to dynamically import (fresh module each test via vi.resetModules)
 async function importFresh() {
   vi.resetModules();
   return import("./docker-socket.js");
@@ -59,10 +57,23 @@ describe("resolveDockerSocket", () => {
     expect(result.bindMountPath).toBe("");
   });
 
+  it("throws with doc link when DOCKER_HOST points to non-existent socket", async () => {
+    process.env.DOCKER_HOST = "unix:///nonexistent/docker.sock";
+    vi.spyOn(fs, "realpathSync").mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    const { resolveDockerSocket } = await importFresh();
+
+    expect(() => resolveDockerSocket()).toThrow("DOCKER_HOST=unix:///nonexistent/docker.sock");
+    expect(() => resolveDockerSocket()).toThrow("docs/docker-socket.md");
+  });
+
   // ── Default socket path ────────────────────────────────────────────────
 
   it("resolves /var/run/docker.sock symlink", async () => {
     delete process.env.DOCKER_HOST;
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
     vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
       if (String(p) === "/var/run/docker.sock") {
         return "/Users/test/.orbstack/run/docker.sock";
@@ -84,6 +95,7 @@ describe("resolveDockerSocket", () => {
 
   it("uses /var/run/docker.sock as bindMountPath when it resolves to Docker Desktop path (regression #197)", async () => {
     delete process.env.DOCKER_HOST;
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
     vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
       if (String(p) === "/var/run/docker.sock") {
         return "/Users/username/.docker/run/docker.sock";
@@ -95,9 +107,7 @@ describe("resolveDockerSocket", () => {
     const { resolveDockerSocket } = await importFresh();
     const result = resolveDockerSocket();
 
-    // Docker API client uses resolved path
     expect(result.socketPath).toBe("/Users/username/.docker/run/docker.sock");
-    // Bind mount uses the stable symlink — NOT the resolved path that caused the regression
     expect(result.bindMountPath).toBe("/var/run/docker.sock");
   });
 
@@ -140,90 +150,51 @@ describe("resolveDockerSocket", () => {
     expect(result.bindMountPath).toBe("/var/run/docker.sock");
   });
 
-  // ── Docker context fallback ─────────────────────────────────────────────
+  // ── Missing / dangling /var/run/docker.sock ─────────────────────────────
 
-  it("falls back to docker context inspect when default socket missing", async () => {
+  it("throws with doc link when /var/run/docker.sock is missing", async () => {
     delete process.env.DOCKER_HOST;
-    vi.spyOn(fs, "realpathSync").mockImplementation(() => {
-      throw new Error("ENOENT");
-    });
-    vi.spyOn(fs, "existsSync").mockImplementation((p) => {
-      return String(p) === "/Users/test/.docker/run/docker.sock";
-    });
-    mockedExecSync.mockReturnValue(
-      JSON.stringify([
-        {
-          Endpoints: {
-            docker: { Host: "unix:///Users/test/.docker/run/docker.sock" },
-          },
-        },
-      ]),
-    );
-
-    const { resolveDockerSocket } = await importFresh();
-    const result = resolveDockerSocket();
-
-    expect(result.socketPath).toBe("/Users/test/.docker/run/docker.sock");
-    expect(result.bindMountPath).toBe("/Users/test/.docker/run/docker.sock");
-  });
-
-  // ── macOS provider fallback ──────────────────────────────────────────────
-
-  it("checks well-known macOS provider sockets when context fails", async () => {
-    delete process.env.DOCKER_HOST;
-    vi.spyOn(fs, "realpathSync").mockImplementation(() => {
-      throw new Error("ENOENT");
-    });
-    mockedExecSync.mockImplementation(() => {
-      throw new Error("docker not found");
-    });
-    const home = os.homedir();
-    vi.spyOn(fs, "existsSync").mockImplementation((p) => {
-      return String(p) === `${home}/.docker/run/docker.sock`;
-    });
-    // Ensure we're on darwin for this path
-    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
-
-    const { resolveDockerSocket } = await importFresh();
-    const result = resolveDockerSocket();
-
-    expect(result.socketPath).toBe(`${home}/.docker/run/docker.sock`);
-    expect(result.bindMountPath).toBe(`${home}/.docker/run/docker.sock`);
-  });
-
-  // ── Reproduction: symlink missing → clear error ─────────────────────────
-
-  it("throws with actionable error when no socket is found", async () => {
-    delete process.env.DOCKER_HOST;
-    vi.spyOn(fs, "realpathSync").mockImplementation(() => {
-      throw new Error("ENOENT");
-    });
     vi.spyOn(fs, "existsSync").mockReturnValue(false);
-    mockedExecSync.mockImplementation(() => {
-      throw new Error("docker not found");
-    });
-    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
-
-    const { resolveDockerSocket } = await importFresh();
-
-    expect(() => resolveDockerSocket()).toThrow("Could not find a Docker socket");
-    expect(() => resolveDockerSocket()).toThrow("DOCKER_HOST");
-    expect(() => resolveDockerSocket()).toThrow("ln -s");
-  });
-
-  it("falls through when DOCKER_HOST points to non-existent socket", async () => {
-    process.env.DOCKER_HOST = "unix:///nonexistent/docker.sock";
     vi.spyOn(fs, "realpathSync").mockImplementation(() => {
       throw new Error("ENOENT");
     });
-    vi.spyOn(fs, "existsSync").mockReturnValue(false);
-    mockedExecSync.mockImplementation(() => {
-      throw new Error("docker not found");
-    });
-    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
 
     const { resolveDockerSocket } = await importFresh();
 
-    expect(() => resolveDockerSocket()).toThrow("Could not find a Docker socket");
+    expect(() => resolveDockerSocket()).toThrow("/var/run/docker.sock");
+    expect(() => resolveDockerSocket()).toThrow("missing or a dangling symlink");
+    expect(() => resolveDockerSocket()).toThrow("docs/docker-socket.md");
+  });
+
+  it("throws with doc link when /var/run/docker.sock is a dangling symlink (stale OrbStack / Colima switch)", async () => {
+    // Regression for #263 debugging session: /var/run/docker.sock → ~/.orbstack/...
+    // but OrbStack is stopped, so the link dangles. fs.existsSync returns false for
+    // dangling symlinks, which is the signal we want.
+    delete process.env.DOCKER_HOST;
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    vi.spyOn(fs, "realpathSync").mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    const { resolveDockerSocket } = await importFresh();
+
+    expect(() => resolveDockerSocket()).toThrow("dangling symlink");
+  });
+
+  it("throws with doc link when /var/run/docker.sock exists but EACCES and no readable context", async () => {
+    delete process.env.DOCKER_HOST;
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    vi.spyOn(fs, "realpathSync").mockReturnValue("/var/run/docker.sock");
+    vi.spyOn(fs, "accessSync").mockImplementation(() => {
+      throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+    });
+    mockedExecSync.mockImplementation(() => {
+      throw new Error("docker not found");
+    });
+
+    const { resolveDockerSocket } = await importFresh();
+
+    expect(() => resolveDockerSocket()).toThrow("not readable");
+    expect(() => resolveDockerSocket()).toThrow("docs/docker-socket.md");
   });
 });

--- a/packages/cli/src/docker/docker-socket.ts
+++ b/packages/cli/src/docker/docker-socket.ts
@@ -1,26 +1,11 @@
 import fs from "fs";
-import os from "os";
-import path from "path";
 import { execSync } from "child_process";
 import { debugRunner } from "../output/debug.js";
 
 const DEFAULT_SOCKET = "/var/run/docker.sock";
+const DOCS_URL =
+  "https://github.com/redwoodjs/agent-ci/blob/main/packages/cli/docs/docker-socket.md";
 
-/**
- * Well-known Docker socket paths on macOS, checked in order.
- * Linux distros almost always have /var/run/docker.sock directly.
- */
-const MACOS_PROVIDER_SOCKETS = [
-  path.join(os.homedir(), ".orbstack/run/docker.sock"),
-  path.join(os.homedir(), ".docker/run/docker.sock"),
-  path.join(os.homedir(), ".colima/default/docker.sock"),
-  path.join(os.homedir(), ".lima/docker/sock/docker.sock"),
-];
-
-/**
- * Try to extract the socket path from the active Docker context.
- * Returns undefined if the command fails or the context uses a non-unix endpoint.
- */
 function socketFromDockerContext(): string | undefined {
   try {
     const json = execSync("docker context inspect", {
@@ -64,51 +49,50 @@ export interface DockerSocket {
  *   - `socketPath` — what our Node process opens for the Docker API client.
  *     Needs R/W access from our UID.
  *   - `bindMountPath` — what we pass as the bind-mount *source* when mounting
- *     the Docker socket into a runner container. Docker's VM (on macOS + Linux
- *     Docker Desktop) validates this path against its shared-mount list. Our
- *     process's permissions are irrelevant here — only path recognition matters.
+ *     the Docker socket into a runner container. Docker's mount subsystem
+ *     (on macOS through the VM, on Linux directly) validates this path against
+ *     its shared-mount list. Our process's permissions are irrelevant here —
+ *     only path recognition matters.
  *
- * Invariant: whenever `/var/run/docker.sock` exists on the host, use it as
- * `bindMountPath` regardless of R/W access. Every Docker provider we've seen
- * (Docker Desktop mac + Linux, OrbStack, Colima, native dockerd) either creates
- * it directly or symlinks to it, and Docker Desktop's mount proxy accepts it.
- * This collapses the macOS Desktop symlink case (#197) and the Linux Desktop +
- * non-docker-group case (#209) into one rule.
+ * The bind-mount invariant: unless the user has set DOCKER_HOST explicitly,
+ * `/var/run/docker.sock` must exist and be the bind-mount source. Every Docker
+ * provider either creates it directly (Docker Desktop, native dockerd) or can
+ * be pointed at it via a symlink (OrbStack does this automatically; Colima is
+ * a manual `ln -sf`). We refuse to guess provider-specific paths — those tend
+ * to fail later at bind-mount time with confusing errors (#197, #209, #263).
  *
- * Resolution order for `socketPath`:
- *  1. `DOCKER_HOST` env var (returned as-is for non-unix schemes)
- *  2. Default socket `/var/run/docker.sock` (resolves symlinks, requires R/W)
- *  3. Active Docker context (`docker context inspect`)
- *  4. Well-known macOS provider sockets
- *
- * Throws with actionable guidance when no socket can be found.
+ * Resolution order:
+ *  1. `DOCKER_HOST` env var wins outright (local paths validated; non-unix
+ *     schemes returned as-is).
+ *  2. `/var/run/docker.sock` must exist. If we can R/W it, its resolved path
+ *     is the API `socketPath`; otherwise we look up the active docker context
+ *     to find a readable path (#209), but `bindMountPath` stays as
+ *     `/var/run/docker.sock`.
+ *  3. Neither → throw with a doc link.
  */
 export function resolveDockerSocket(): DockerSocket {
-  // `/var/run/docker.sock` existence check is independent of R/W access —
-  // `existsSync` only needs search permission on `/var/run`, which is always granted.
-  const mountableDefault = fs.existsSync(DEFAULT_SOCKET) ? DEFAULT_SOCKET : undefined;
-
-  // 1. Explicit DOCKER_HOST — user's explicit choice wins for bindMountPath too.
+  // 1. Explicit DOCKER_HOST wins.
   const envHost = process.env.DOCKER_HOST?.trim();
   if (envHost) {
-    if (envHost.startsWith("unix://")) {
-      const socketPath = envHost.replace("unix://", "");
-      const resolved = resolveIfExists(socketPath);
-      if (resolved) {
-        // Use the original DOCKER_HOST path for bind mounts, not the resolved one.
-        // On macOS, Docker's VM may not be able to access the resolved path directly.
-        return { socketPath: resolved, uri: `unix://${resolved}`, bindMountPath: socketPath };
-      }
-      // The env var points to a non-existent socket — fall through to auto-detect
-      debugRunner(`DOCKER_HOST=${envHost} does not exist, trying auto-detection`);
-    } else {
-      // Non-unix scheme (ssh://, tcp://, etc.) — cannot resolve a local path
-      // Return a sentinel; callers handle non-unix hosts separately.
+    if (!envHost.startsWith("unix://")) {
+      // Non-unix scheme (ssh://, tcp://) — container bind-mount is out of scope.
       return { socketPath: "", uri: envHost, bindMountPath: "" };
     }
+    const socketPath = envHost.replace("unix://", "");
+    const resolved = resolveIfExists(socketPath);
+    if (resolved) {
+      return { socketPath: resolved, uri: `unix://${resolved}`, bindMountPath: socketPath };
+    }
+    throw unusableSocketError(`DOCKER_HOST=${envHost} does not resolve to a working socket.`);
   }
 
-  // 2. Default socket path (often a symlink on macOS)
+  // 2. /var/run/docker.sock must exist. existsSync returns false for dangling
+  //    symlinks, which is exactly the case we want to reject (stale provider state).
+  if (!fs.existsSync(DEFAULT_SOCKET)) {
+    throw unusableSocketError(`${DEFAULT_SOCKET} is missing or a dangling symlink.`);
+  }
+
+  // Happy path: we can R/W the socket directly.
   const defaultResolved = resolveIfExists(DEFAULT_SOCKET);
   if (defaultResolved) {
     return {
@@ -118,44 +102,34 @@ export function resolveDockerSocket(): DockerSocket {
     };
   }
 
-  // 3. Docker context
+  // The socket exists but we can't R/W it. Linux + Docker Desktop with user
+  // outside the `docker` group is the canonical case (#209) — the active
+  // docker context tells us a path we *can* read, but we still bind-mount
+  // /var/run/docker.sock because that's what the mount layer accepts.
   const contextSocket = socketFromDockerContext();
   if (contextSocket) {
     return {
       socketPath: contextSocket,
       uri: `unix://${contextSocket}`,
-      bindMountPath: mountableDefault ?? contextSocket,
+      bindMountPath: DEFAULT_SOCKET,
     };
   }
 
-  // 4. Well-known macOS provider paths
-  if (process.platform === "darwin") {
-    for (const candidate of MACOS_PROVIDER_SOCKETS) {
-      if (fs.existsSync(candidate)) {
-        return {
-          socketPath: candidate,
-          uri: `unix://${candidate}`,
-          bindMountPath: mountableDefault ?? candidate,
-        };
-      }
-    }
-  }
+  throw unusableSocketError(
+    `${DEFAULT_SOCKET} exists but is not readable, and no active docker context provides an alternative.`,
+  );
+}
 
-  // Nothing found — give the user actionable guidance
-  const searched = [
-    DEFAULT_SOCKET,
-    ...(process.platform === "darwin" ? MACOS_PROVIDER_SOCKETS : []),
-  ];
-  const lines = [
-    "Could not find a Docker socket. Searched:",
-    ...searched.map((p) => `  - ${p}`),
-    "",
-    "To fix this, either:",
-    "  • Set the DOCKER_HOST environment variable (e.g. DOCKER_HOST=unix:///path/to/docker.sock)",
-    `  • Create a symlink:  ln -s /path/to/docker.sock ${DEFAULT_SOCKET}`,
-    "  • Start your Docker provider (Docker Desktop, OrbStack, Colima, etc.)",
-  ];
-  throw new Error(lines.join("\n"));
+function unusableSocketError(detail: string): Error {
+  return new Error(
+    [
+      `agent-ci couldn't use a Docker socket at /var/run/docker.sock.`,
+      detail,
+      ``,
+      `A working Docker socket is required there (or set DOCKER_HOST explicitly).`,
+      `See: ${DOCS_URL}`,
+    ].join("\n"),
+  );
 }
 
 /**
@@ -164,10 +138,7 @@ export function resolveDockerSocket(): DockerSocket {
  */
 function resolveIfExists(socketPath: string): string | undefined {
   try {
-    // fs.realpathSync follows symlinks and throws if the target doesn't exist
     const resolved = fs.realpathSync(socketPath);
-    // Verify we can actually connect — the socket may exist but be owned by
-    // root:docker with 660 perms (common on Linux with Docker Desktop).
     fs.accessSync(resolved, fs.constants.R_OK | fs.constants.W_OK);
     return resolved;
   } catch {

--- a/packages/cli/src/docker/repro-197.test.ts
+++ b/packages/cli/src/docker/repro-197.test.ts
@@ -36,6 +36,7 @@ describe("issue-197 reproduction: Docker Desktop bind mount path", () => {
   it("resolves to the real path for API client but keeps the symlink path for bind mounts", async () => {
     delete process.env.DOCKER_HOST;
     // Simulate Docker Desktop: /var/run/docker.sock → ~/.docker/run/docker.sock
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
     vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
       if (String(p) === "/var/run/docker.sock") {
         return "/Users/test/.docker/run/docker.sock";
@@ -57,6 +58,7 @@ describe("issue-197 reproduction: Docker Desktop bind mount path", () => {
 
   it("container bind string uses /var/run/docker.sock, not the resolved path (the failing case)", async () => {
     delete process.env.DOCKER_HOST;
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
     vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
       if (String(p) === "/var/run/docker.sock") {
         return "/Users/test/.docker/run/docker.sock";


### PR DESCRIPTION
## Problem

Two closely-related macOS issues that block agent-ci on Colima (and some Docker Desktop configurations), surfaced while reproducing #263.

### 1. Runner crash on `_diag` — #263

On macOS with Colima / Docker Desktop, the runner container crashes on boot with:

```
Unhandled exception. System.UnauthorizedAccessException:
Access to the path '/home/runner/_diag/Runner_<date>.log' is denied.
```

Bind-mounted host dirs (`_diag`, `_work`) surface inside the container as `root:root 0755` because host permissions don't translate through the VM mount layer. The runner user (uid 1001) can't write its diag logs or scratch files. OrbStack and native Linux Docker aren't affected.

This is the same root cause as #234 (which fixed `/home/runner/.cache`) — we just missed `_diag` and `_work`.

### 2. Confusing "operation not supported" from the socket resolver

Under pre-existing `resolveDockerSocket` logic, when `/var/run/docker.sock` wasn't usable we fell through to `docker context inspect` and then to a list of well-known provider paths (`~/.orbstack/…`, `~/.colima/<profile>/…`). On Colima the profile-internal socket is **not bind-mountable** through the VM, so agent-ci would crash later at container launch with:

```
error while creating mount source path '/Users/…/.colima/default/docker.sock':
mkdir …: operation not supported
```

That failure signature is miles from the real cause (your `/var/run/docker.sock` is missing or dangling) and easy to hit when switching Docker backends, since OrbStack leaves a symlink behind that dangles when you move to Colima.

## Solution

### 1. Runner `_diag` / `_work` permissions

The container entrypoint now runs two more `chmod 1777` lines alongside the existing `.cache` one, so the runner user can write to `_diag` and `_work` regardless of how the mount surfaces them:

```sh
MAYBE_SUDO chmod 1777 /home/runner/_diag 2>/dev/null || true
MAYBE_SUDO chmod 1777 /home/runner/_work 2>/dev/null || true
```

`MAYBE_SUDO` is the existing helper that uses `sudo` where available; `|| true` keeps the entrypoint green on backends where the chmod is unnecessary (OrbStack, native Linux).

### 2. Harden socket detection + doc it

`resolveDockerSocket` now requires a working socket at `/var/run/docker.sock` when `DOCKER_HOST` is unset, and fails fast with a short error that links to a new per-provider setup guide:

```
agent-ci couldn't use a Docker socket at /var/run/docker.sock.
/var/run/docker.sock is missing or a dangling symlink.

A working Docker socket is required there (or set DOCKER_HOST explicitly).
See: https://github.com/redwoodjs/agent-ci/blob/main/packages/cli/docs/docker-socket.md
```

The new doc (`packages/cli/docs/docker-socket.md`) walks through the recipe for each backend (Docker Desktop / OrbStack / Colima / native Linux / rootless). Rather than encoding each provider's socket-layout quirks in agent-ci, we lean on the invariant that every Docker provider either creates `/var/run/docker.sock` or can be pointed at it with a one-line `ln -sf`.

Regression coverage:
- `docker-socket.test.ts` — 10 cases incl. dangling-symlink + EACCES fallthrough (#209) + DOCKER_HOST wins.
- `repro-197.test.ts` — existing #197 cases kept passing under the new stricter rule.
- `container-config.test.ts` — asserts both new `chmod 1777` lines are present.

## Proof

Reproduced end-to-end on macOS + Colima. Same workflow, same host:

| Commit | Result |
|---|---|
| pre-fix (`HEAD^`) | `UnauthorizedAccessException: /home/runner/_diag/Runner_*.log` → crash (exit 134), matches #263 stack verbatim |
| HEAD (this PR) | `✓ 1 passed (1 total)` |

Files touched:
- `packages/cli/src/docker/container-config.ts` (+ test)
- `packages/cli/src/docker/docker-socket.ts` (+ tests)
- `packages/cli/src/docker/repro-197.test.ts` (mock adjustments)
- `packages/cli/docs/docker-socket.md` (new)
- `.changeset/fix-263-diag-work-perms-macos.md`

Fixes #263.
