### PR TITLE
Close referenced issues on release, not on version-PR merge

### DIFF
--- a/.changeset/release-closes-issues.md
+++ b/.changeset/release-closes-issues.md
@@ -1,0 +1,8 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Release workflow now closes referenced issues on publish instead of on version-PR merge.
+
+`pnpm run version` captures `Closes|Fixes|Resolves #N` references from pending changesets into `.release-closes.json`, pairs each with the PR that introduced the changeset, and rewrites the keywords to `Refs #N` in the changeset bodies so the "chore: version packages" PR does not close them on merge. After `changesets/action` publishes, a new step reads `.release-closes.json` and closes each issue with a `Closes Issue #N via PR #M.` comment.

--- a/.claude/rules/changeset-required.md
+++ b/.claude/rules/changeset-required.md
@@ -20,4 +20,6 @@ Short description of the change.
 
 3. Both packages are versioned together (fixed versioning), so include both in the changeset header.
 
+4. **Linking issues.** If the change resolves a reported issue, write `Closes #N` (or `Fixes #N` / `Resolves #N`) in the changeset body; use `Refs #N` / `(#N)` for a mention you don't want to close. See [RELEASING.md → Linking issues](../../RELEASING.md#linking-issues) for how the release workflow defers the close until publish.
+
 **Do not create a PR without a changeset.** If the change is docs-only or CI-only and doesn't affect published packages, you may skip the changeset but must note why in the PR description.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
       - run: pnpm check
       - run: pnpm --include-workspace-root=false -r test
       - name: Create Release PR or Publish
+        id: changesets
         uses: changesets/action@v1
         with:
           publish: pnpm release
@@ -46,3 +47,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+      - name: Close resolved issues
+        if: steps.changesets.outputs.published == 'true'
+        run: node scripts/release-closes.mjs apply
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,6 +20,16 @@ This opens an interactive prompt where you:
 
 This creates a markdown file in `.changeset/` — commit it with your PR.
 
+#### Linking issues
+
+If the change resolves a reported issue, write `Closes #N` (or `Fixes #N` / `Resolves #N`) in the changeset body. During `pnpm run version`, the release workflow:
+
+1. Captures each closing reference into `.release-closes.json`, pairing it with the PR that introduced the changeset.
+2. Rewrites the keywords to `Refs #N` in the changeset body so the generated CHANGELOG and the "Version Packages" PR carry only references, not closers. GitHub therefore does **not** close the issue when the Version PR merges.
+3. After the packages are published, the workflow runs `gh issue close` on each captured issue with the comment `Closes Issue #N via PR #M.`
+
+If you only want to _reference_ an issue without closing it on release, use `Refs #N` or `(#N)` — those pass through untouched.
+
 ### 2. Merge to `main`
 
 When your PR is merged, the [release workflow](.github/workflows/release.yml) runs automatically and creates a **"Version Packages"** PR that:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "./scripts/run.sh",
     "prepare": "husky || true",
     "changeset": "changeset",
-    "version": "changeset version && oxfmt",
+    "version": "node scripts/release-closes.mjs capture && changeset version && oxfmt",
     "release": "pnpm -r build && changeset publish"
   },
   "devDependencies": {

--- a/scripts/release-closes.mjs
+++ b/scripts/release-closes.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Capture issue-closing references from pending changesets into
+// .release-closes.json, and rewrite keywords to "Refs #N" so the
+// "chore: version packages" PR doesn't close them on merge. After
+// publish, `apply` closes the captured issues with a comment that
+// points at the PR that introduced the fix.
+
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const CHANGESET_DIR = join(ROOT, ".changeset");
+const CLOSES_FILE = join(ROOT, ".release-closes.json");
+const KEYWORD_RE = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+const REPO = process.env.GITHUB_REPOSITORY || "redwoodjs/agent-ci";
+
+function sh(cmd) {
+  return execSync(cmd, { cwd: ROOT, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+function findPRForChangeset(relPath) {
+  const sha = sh(`git log -1 --format=%H -- ${JSON.stringify(relPath)}`);
+  if (!sha) {
+    return null;
+  }
+  try {
+    const out = sh(`gh api repos/${REPO}/commits/${sha}/pulls --jq '.[0].number'`);
+    return out ? Number.parseInt(out, 10) : null;
+  } catch {
+    return null;
+  }
+}
+
+function capture() {
+  const entries = [];
+  const files = readdirSync(CHANGESET_DIR).filter((f) => f.endsWith(".md") && f !== "README.md");
+  for (const file of files) {
+    const relPath = `.changeset/${file}`;
+    const fullPath = join(CHANGESET_DIR, file);
+    const text = readFileSync(fullPath, "utf8");
+    const issues = [...text.matchAll(KEYWORD_RE)].map((m) => Number.parseInt(m[1], 10));
+    if (issues.length === 0) {
+      continue;
+    }
+    const pr = findPRForChangeset(relPath);
+    for (const issue of issues) {
+      entries.push({ issue, pr, changeset: file });
+    }
+    writeFileSync(
+      fullPath,
+      text.replace(KEYWORD_RE, (_, n) => `Refs #${n}`),
+    );
+  }
+  writeFileSync(CLOSES_FILE, `${JSON.stringify(entries, null, 2)}\n`);
+  console.log(`Captured ${entries.length} close reference(s) -> .release-closes.json`);
+}
+
+function apply() {
+  if (!existsSync(CLOSES_FILE)) {
+    console.log("No .release-closes.json found; nothing to close.");
+    return;
+  }
+  const entries = JSON.parse(readFileSync(CLOSES_FILE, "utf8"));
+  if (entries.length === 0) {
+    console.log(".release-closes.json is empty; nothing to close.");
+    return;
+  }
+  for (const { issue, pr } of entries) {
+    const msg = pr ? `Closes Issue #${issue} via PR #${pr}.` : `Closes Issue #${issue}.`;
+    try {
+      sh(`gh issue close ${issue} --repo ${REPO} --comment ${JSON.stringify(msg)}`);
+      console.log(`Closed #${issue}${pr ? ` (PR #${pr})` : ""}`);
+    } catch (err) {
+      console.log(`Could not close #${issue}: ${err.message?.split("\n")[0] ?? err}`);
+    }
+  }
+}
+
+const cmd = process.argv[2];
+if (cmd === "capture") {
+  capture();
+} else if (cmd === "apply") {
+  apply();
+} else {
+  console.error("Usage: release-closes.mjs <capture|apply>");
+  process.exit(1);
+}


### PR DESCRIPTION
## Problem

Today, if a changeset author writes "Closes #123" in the changeset body, GitHub closes issue #123 the moment the "Version Packages" PR is merged — even though the fix hasn't actually been published to npm yet. So issues are reported as resolved before users can install the release that contains the fix. Conversely, if authors write only bare references like `(#123)` to avoid this, the issue never closes automatically and someone has to close it by hand after publish.

## Solution

The release workflow now defers issue-closing to the publish step.

- A new script, `scripts/release-closes.mjs`, runs inside `pnpm run version` before `changeset version`. It scans pending changesets for `Closes #N` / `Fixes #N` / `Resolves #N`, records each one in `.release-closes.json` (paired with the PR that introduced the changeset), and rewrites the keywords to `Refs #N` in the changeset body. The generated CHANGELOG and the "Version Packages" PR therefore only carry references — GitHub no longer auto-closes when the Version PR merges.
- `.github/workflows/release.yml` has a new "Close resolved issues" step that runs after `changesets/action` publishes. It reads `.release-closes.json` and runs `gh issue close` on each issue with the comment `Closes Issue #N via PR #M.`
- `RELEASING.md` documents the convention so it lives outside of any specific agent-tool folder.
- `.claude/rules/changeset-required.md` keeps a one-line pointer to `RELEASING.md → Linking issues`.

Authors who only want to mention an issue (not close it on release) keep using `Refs #N` or `(#N)` — those pass through untouched.

### Files touched

- `scripts/release-closes.mjs` — new capture/apply script.
- `package.json` — `version` script runs `capture` before `changeset version`.
- `.github/workflows/release.yml` — gives the changesets step an `id` and adds the `apply` step gated on `published == 'true'`.
- `RELEASING.md` — new "Linking issues" section.
- `.claude/rules/changeset-required.md` — one-line link to the new section.

### Validation note

Local checks (`pnpm check`, typecheck, lint, format) pass. Full workflow validation via `pnpm agent-ci-dev run --all` could not be completed in this environment (Docker not running locally), but none of these changes affect the per-PR agent-ci runtime — only the release pipeline and its docs.
