### PR TITLE
fix(runner): unique sibling container names when nested

### DIFF
--- a/.changeset/nested-sibling-name-collision.md
+++ b/.changeset/nested-sibling-name-collision.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+fix(runner): nested agent-ci sibling containers collide on `agent-ci-1` when multiple outer runs execute in parallel. Each nested run has its own filesystem so it always allocated `agent-ci-1`, and the pre-spawn `docker rm -f` then killed a sibling belonging to a concurrent nested run. Include the outer container's hostname in the prefix when `/.dockerenv` is present so sibling names stay unique across nested runs. Fixes `smoke-bun-setup.yml` + `smoke-docker-buildx.yml` failing when run together via `agent-ci-dev run --all`.

--- a/.github/workflows/smoke-docker-buildx.yml
+++ b/.github/workflows/smoke-docker-buildx.yml
@@ -90,16 +90,25 @@ jobs:
       - name: Dump agent-ci step logs
         if: always()
         run: |
+          # agent-ci stores logs under /tmp/agent-ci on GitHub runners, but
+          # under <project>/.agent-ci when running inside a container (nested
+          # agent-ci-dev), because /tmp isn't host-shared there.
+          roots=()
+          [ -d /tmp/agent-ci ] && roots+=(/tmp/agent-ci)
+          [ -d "$GITHUB_WORKSPACE/packages/cli/.agent-ci" ] && roots+=("$GITHUB_WORKSPACE/packages/cli/.agent-ci")
           echo "::group::agent-ci runs dir"
-          ls -la /tmp/agent-ci/ 2>/dev/null || echo "no /tmp/agent-ci"
-          find /tmp/agent-ci -maxdepth 6 -type d 2>/dev/null | head -50
+          if [ "${#roots[@]}" -eq 0 ]; then echo "no agent-ci log roots found"; fi
+          for r in "${roots[@]}"; do
+            ls -la "$r/" 2>/dev/null || true
+            find "$r" -maxdepth 6 -type d 2>/dev/null | head -50
+          done
           echo "::endgroup::"
-          for f in $(find /tmp/agent-ci -path '*/logs/steps/*.log' 2>/dev/null); do
+          for f in $(find "${roots[@]}" -path '*/logs/steps/*.log' 2>/dev/null); do
             echo "::group::$f"
             cat "$f"
             echo "::endgroup::"
           done
-          for f in $(find /tmp/agent-ci -name 'debug.log' 2>/dev/null); do
+          for f in $(find "${roots[@]}" -name 'debug.log' 2>/dev/null); do
             echo "::group::$f"
             tail -500 "$f"
             echo "::endgroup::"
@@ -110,7 +119,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: agent-ci-logs
-          path: /tmp/agent-ci/**/logs/**
+          path: |
+            /tmp/agent-ci/**/logs/**
+            ${{ github.workspace }}/packages/cli/.agent-ci/**/logs/**
           if-no-files-found: warn
 
       - name: Assert `docker buildx` is usable inside agent-ci
@@ -118,7 +129,14 @@ jobs:
           # agent-ci runs in quiet/AI-agent mode and doesn't stream per-step
           # stdout to its top-level output. The "Verify buildx" step's output
           # lives in the per-step log file. Check it there.
-          log=$(find /tmp/agent-ci -path '*/logs/steps/Verify-buildx.log' | head -1)
+          roots=()
+          [ -d /tmp/agent-ci ] && roots+=(/tmp/agent-ci)
+          [ -d "$GITHUB_WORKSPACE/packages/cli/.agent-ci" ] && roots+=("$GITHUB_WORKSPACE/packages/cli/.agent-ci")
+          if [ "${#roots[@]}" -eq 0 ]; then
+            echo "::error::no agent-ci log roots found — the nested run never produced logs."
+            exit 1
+          fi
+          log=$(find "${roots[@]}" -path '*/logs/steps/Verify-buildx.log' | head -1)
           if [ -z "$log" ]; then
             echo "::error::Verify-buildx.log missing — the step never ran."
             exit 1

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -147,12 +147,17 @@ export async function executeLocalJob(
   }
 
   // ── Prepare directories ───────────────────────────────────────────────────
+  // When running nested (another agent-ci is our parent), include a short
+  // hostname suffix in the prefix so sibling container names don't collide
+  // with a concurrent nested run inside a different parent container.
+  const nestedHost = fs.existsSync("/.dockerenv") ? process.env.HOSTNAME?.slice(0, 12) : "";
+  const prefix = nestedHost ? `agent-ci-${nestedHost}` : "agent-ci";
   const {
     name: containerName,
     runDir,
     logDir,
     debugLogPath,
-  } = createLogContext("agent-ci", job.runnerName);
+  } = createLogContext(prefix, job.runnerName);
 
   // Register the job in the store so the render loop can show the boot spinner
   store?.addJob(


### PR DESCRIPTION
## Problem

When `agent-ci-dev run --all` runs two workflows in parallel, and each one invokes `agent-ci` again from inside its runner container (like `smoke-bun-setup.yml` and `smoke-docker-buildx.yml` do), both nested processes pick the same sibling container name: `agent-ci-1`. Each nested run lives in its own isolated filesystem, so the log-dir counter starts at 1 for both.

The second nested run's pre-spawn cleanup runs `docker rm -f agent-ci-1` — which kills the **other** run's sibling mid-step. The victim reports a fast `✗ 1 failed` with no useful error, because its runner container just disappeared.

`smoke-docker-buildx.yml` also hard-coded `/tmp/agent-ci` when looking for nested logs, but under `agent-ci-dev` the inner run writes to `<project>/.agent-ci` (because `/tmp` isn't shared with the host).

## Solution

- When `/.dockerenv` is present, include the outer container's hostname in the run-dir prefix (e.g. `agent-ci-96f265a4832d-1`). Each concurrent nested run has a different hostname, so sibling names no longer collide.
- Update the smoke-docker-buildx assert/dump/upload steps to search both `/tmp/agent-ci` and `$GITHUB_WORKSPACE/packages/cli/.agent-ci`.

Verified with `pnpm agent-ci-dev run --all`: `✓ 28 passed` in ~5 min.

## Test plan

- [x] `pnpm -r test` — 646 tests pass
- [x] `pnpm agent-ci-dev run --all -q -p` — 28/28 pass, including both smoke tests concurrently
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)