### PR TITLE
fix(docs+cli): point Docker Desktop users at the default-socket toggle

### DIFF
--- a/.changeset/fix-253-docker-desktop-default-socket-doc.md
+++ b/.changeset/fix-253-docker-desktop-default-socket-doc.md
@@ -1,0 +1,8 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Document and surface Docker Desktop's default-socket toggle. Docker Desktop 4.x ships with `/var/run/docker.sock` disabled, so a fresh install will hit `agent-ci couldn't use a Docker socket at /var/run/docker.sock` even when Docker Desktop is running. The `docker-socket.md` recipe now walks through the Settings → Advanced toggle, and the resolver error appends a one-shot hint pointing at it whenever it detects Docker Desktop's user-side socket (`~/.docker/run/docker.sock`).
+
+Closes #253.

--- a/packages/cli/docs/docker-socket.md
+++ b/packages/cli/docs/docker-socket.md
@@ -18,7 +18,15 @@ Relying on `/var/run/docker.sock` as the single source of truth avoids all of th
 
 ### Docker Desktop (macOS / Windows / Linux)
 
-Docker Desktop creates `/var/run/docker.sock` automatically on startup. If it's missing, just start Docker Desktop (or restart it if it was running during an upgrade).
+Docker Desktop 4.x ships with the default Docker socket disabled. Even with Docker Desktop running, `/var/run/docker.sock` will not exist until you opt in:
+
+1. Open Docker Desktop → ⚙ Settings → **Advanced**.
+2. Tick **"Allow the default Docker socket to be used (requires password)"**.
+3. Click **Apply & Restart** — Docker Desktop will prompt for your admin password to install the privileged helper that creates the symlink.
+
+After the restart, `/var/run/docker.sock` is a symlink to `~/.docker/run/docker.sock` and agent-ci can use it.
+
+If you previously had this toggle on but `/var/run/docker.sock` is missing again after a Docker Desktop upgrade, toggle it off and back on to re-install the helper.
 
 ### OrbStack (macOS)
 

--- a/packages/cli/src/docker/docker-socket.test.ts
+++ b/packages/cli/src/docker/docker-socket.test.ts
@@ -166,6 +166,30 @@ describe("resolveDockerSocket", () => {
     expect(() => resolveDockerSocket()).toThrow("docs/docker-socket.md");
   });
 
+  it("appends Docker Desktop toggle hint when ~/.docker/run/docker.sock exists but /var/run/docker.sock is missing", async () => {
+    delete process.env.DOCKER_HOST;
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+      const s = String(p);
+      if (s === "/var/run/docker.sock") {
+        return false;
+      }
+      if (s.endsWith("/.docker/run/docker.sock")) {
+        return true;
+      }
+      return false;
+    });
+    vi.spyOn(fs, "realpathSync").mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    const { resolveDockerSocket } = await importFresh();
+
+    expect(() => resolveDockerSocket()).toThrow(
+      "Docker Desktop is running but the default socket is disabled",
+    );
+    expect(() => resolveDockerSocket()).toThrow("Settings → Advanced");
+  });
+
   it("throws with doc link when /var/run/docker.sock is a dangling symlink (stale OrbStack / Colima switch)", async () => {
     // Regression for #263 debugging session: /var/run/docker.sock → ~/.orbstack/...
     // but OrbStack is stopped, so the link dangles. fs.existsSync returns false for

--- a/packages/cli/src/docker/docker-socket.ts
+++ b/packages/cli/src/docker/docker-socket.ts
@@ -1,10 +1,23 @@
 import fs from "fs";
+import os from "os";
+import path from "path";
 import { execSync } from "child_process";
 import { debugRunner } from "../output/debug.js";
 
 const DEFAULT_SOCKET = "/var/run/docker.sock";
 const DOCS_URL =
   "https://github.com/redwoodjs/agent-ci/blob/main/packages/cli/docs/docker-socket.md";
+
+// Docker Desktop's user-side socket path (same on macOS/Linux/Windows-WSL).
+// Its presence means Docker Desktop is running but the "Allow the default
+// Docker socket to be used" toggle in Settings → Advanced is off.
+function dockerDesktopRunningWithoutDefaultSocket(): boolean {
+  const home = os.homedir();
+  if (!home) {
+    return false;
+  }
+  return fs.existsSync(path.join(home, ".docker", "run", "docker.sock"));
+}
 
 function socketFromDockerContext(): string | undefined {
   try {
@@ -121,15 +134,22 @@ export function resolveDockerSocket(): DockerSocket {
 }
 
 function unusableSocketError(detail: string): Error {
-  return new Error(
-    [
-      `agent-ci couldn't use a Docker socket at /var/run/docker.sock.`,
-      detail,
+  const lines = [
+    `agent-ci couldn't use a Docker socket at /var/run/docker.sock.`,
+    detail,
+    ``,
+    `A working Docker socket is required there (or set DOCKER_HOST explicitly).`,
+  ];
+  if (dockerDesktopRunningWithoutDefaultSocket()) {
+    lines.push(
       ``,
-      `A working Docker socket is required there (or set DOCKER_HOST explicitly).`,
-      `See: ${DOCS_URL}`,
-    ].join("\n"),
-  );
+      `Docker Desktop is running but the default socket is disabled.`,
+      `Enable it: Docker Desktop → Settings → Advanced →`,
+      `  "Allow the default Docker socket to be used (requires password)" → Apply & Restart.`,
+    );
+  }
+  lines.push(``, `See: ${DOCS_URL}`);
+  return new Error(lines.join("\n"));
 }
 
 /**


### PR DESCRIPTION
## Problem

If you install Docker Desktop today and try `agent-ci`, you get this error even though Docker Desktop is open and running:

```
agent-ci couldn't use a Docker socket at /var/run/docker.sock.
/var/run/docker.sock is missing or a dangling symlink.
```

The reason: new versions of Docker Desktop ship with a setting turned **off** by default. Until you turn it on, Docker Desktop won't put its socket file at the standard `/var/run/docker.sock` path that agent-ci expects. The setting is buried in Settings → Advanced and needs an admin password to change.

Our docs used to say "Docker Desktop creates the file automatically" — that was true in older versions, but not anymore. So people hit the error, opened the doc link, were told to "just start Docker Desktop" (which they already did), and got stuck.

## Solution

Two small changes, no behaviour change at runtime:

- **Docs:** the Docker Desktop section of `packages/cli/docs/docker-socket.md` now walks through the actual setting you need to turn on, with the exact menu path and a note that Docker Desktop will ask for your password.
- **Error message:** when agent-ci can't find the socket, it now checks if Docker Desktop's own socket file (in your home folder) exists. If it does, agent-ci appends a short hint pointing at the toggle, so you don't have to read the whole doc to find the one paragraph that matters.

## Why this is the only thing left to do for #253

The original report in #253 suggested telling Mac users to switch a different Docker Desktop setting (file sharing) to work around a permission error. That permission error was already fixed properly in #274, so the workaround is no longer needed. I confirmed this by installing Docker Desktop fresh, leaving every setting at its default, and running every workflow agent-ci has — all 28 passed.

That leaves only the missing default socket as a leftover problem, and that's what this PR fixes.

## Test plan

- [x] Reproduced the original error on a fresh Docker Desktop install with the default setting off.
- [x] After turning the setting on, ran `pnpm agent-ci-dev run --all -q -p` — **28/28 workflows pass** (9m 43s).
- [x] New unit test covers the new hint in the error message.
- [x] `pnpm lint`, `pnpm format:check`, and `pnpm -r typecheck` all clean.

Closes #253.
