### PR TITLE
experiments: repro for smolvm TSI idle-keep-alive drop

### DIFF
--- a/experiments/smolvm-tsi-idle-repro.sh
+++ b/experiments/smolvm-tsi-idle-repro.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Repro for smolvm/libkrun TSI: idle keep-alive HTTP connections from guest to
+# host are silently killed after a few minutes, deadlocking the next reuse.
+#
+# Setup: starts a host HTTP server, boots an alpine smolvm with --net, opens
+# a Python HTTP keep-alive connection from the guest, sends 5 requests
+# (instant), idles 6 minutes, then tries to reuse the connection.
+#
+# Expected: all 10 requests succeed.
+# Actual (smolvm 0.5.19): #5..9 fail with TimeoutError / CannotSendRequest.
+#
+# Usage: ./smolvm-tsi-idle-repro.sh
+# Tested: smolvm 0.5.19, macOS 14 (darwin-arm64).
+set -euo pipefail
+
+PORT=7779
+VM=tsi-idle-repro
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"; smolvm machine stop --name "$VM" 2>/dev/null || true; smolvm machine delete -f "$VM" 2>/dev/null || true; [[ -n "${SRV_PID:-}" ]] && kill "$SRV_PID" 2>/dev/null || true' EXIT
+
+cat > "$TMPDIR/server.mjs" <<EOF
+import http from 'node:http';
+const s = http.createServer((_, r) => r.end('ok\n'));
+s.listen($PORT, '0.0.0.0', () => console.log('[host] listening on $PORT'));
+EOF
+
+cat > "$TMPDIR/reuse.py" <<EOF
+import http.client, time
+c = http.client.HTTPConnection('127.0.0.1', $PORT, timeout=30)
+def req(label):
+    t = time.time()
+    try:
+        c.request('GET', '/x'); r = c.getresponse(); body = r.read()
+        print(f"{label}: status={r.status} t={time.time()-t:.3f}s", flush=True)
+    except Exception as e:
+        print(f"{label}: FAIL {type(e).__name__}: {e} t={time.time()-t:.3f}s", flush=True)
+for i in range(5):    req(f"req#{i}")
+print("idle 360s on the same connection...", flush=True)
+time.sleep(360)
+for i in range(5,10): req(f"req#{i}-after-idle")
+EOF
+
+echo "[repro] starting host server..."
+node "$TMPDIR/server.mjs" &
+SRV_PID=$!
+sleep 1
+curl -fsS "http://127.0.0.1:$PORT/sanity" >/dev/null
+
+echo "[repro] booting smolvm..."
+smolvm machine create -I alpine --net -v "$TMPDIR:/host:ro" "$VM" >/dev/null
+smolvm machine start --name "$VM" >/dev/null
+sleep 5
+smolvm machine exec --name "$VM" -- sh -c "apk add --no-cache python3 >/dev/null 2>&1 && echo python3 ready"
+
+echo "[repro] running reuse test (will take ~6 minutes)..."
+smolvm machine exec --name "$VM" -- python3 /host/reuse.py


### PR DESCRIPTION
## Problem

smolvm 0.5.19 (libkrun TSI) silently drops idle TCP keep-alive connections from guest → host after a few minutes. The next write on the dead socket hangs until the client timeout, then the connection is permanently in a broken `Request-sent` state.

This is the root cause of the `Runner connect error: Invalid argument` deadlock in GitHub Actions workflows that use `actions/setup-node@v4` (or anything that idles the runner's pooled listener-connection for ~6 min while a worker downloads a payload on a separate connection). Full diagnostic write-up: #284 (2026-04-19 comment).

Effect on agent-ci's smolvm backend:
- Pure shell / checkout workflows: ✅
- Anything using `actions/setup-*` (idle > ~5 min): ❌ deadlock

## Solution

This PR adds a 30-line, self-contained reproducer that anyone can run independently — no agent-ci, no DTU, no runner — so the bug can be verified against a plain Python `HTTPConnection`.

`experiments/smolvm-tsi-idle-repro.sh`:
1. Starts a host HTTP server on `0.0.0.0:7779`.
2. Boots an alpine smolvm with `--net`, mounts a tmp dir read-only.
3. From inside the guest, opens a Python `http.client.HTTPConnection` to `127.0.0.1:7779` (libkrun TSI proxies guest loopback → host loopback).
4. Sends 5 requests on the same connection — all succeed in <1ms.
5. `time.sleep(360)` on that connection.
6. Sends 5 more requests on the **same** connection.

Expected: all 10 succeed.
Actual (smolvm 0.5.19 / darwin-arm64): req #5 hangs 30s with `TimeoutError`, #6–9 fail instantly with `CannotSendRequest`.

## Steps to reproduce

```bash
bash experiments/smolvm-tsi-idle-repro.sh
```

Requires `smolvm` on `PATH` and Node on the host. Takes ~7 minutes (boot + 6 min idle + 30 s timeout + teardown). Output on a reproducing host:

```
req#0: status=200 t=0.002s
req#1..4: status=200 t=0.000s
idle 360s on the same connection...
req#5-after-idle: FAIL TimeoutError: timed out t=30.035s
req#6..9-after-idle: FAIL CannotSendRequest: Request-sent t=0.000s
```

## Upstream

Filed against smolvm: smol-machines/smolvm#177.

## Notes

- Experiments-only; no `packages/` changes, so no changeset per `.claude/rules/changeset-required.md`.
- Tested on: smolvm 0.5.19, macOS 14 (darwin-arm64).