### PR TITLE
feat(runner): smolvm backend foundation (WIP, blocked on smolvm#177)

### DIFF
--- a/.changeset/smolvm-backend-foundation.md
+++ b/.changeset/smolvm-backend-foundation.md
@@ -1,0 +1,10 @@
+---
+"@redwoodjs/agent-ci": minor
+"dtu-github-actions": patch
+---
+
+Add opt-in smolvm backend for per-job VM isolation on Linux jobs. Set
+`AGENT_CI_BACKEND=smolvm` to route Linux jobs through [smolvm](https://github.com/smol-machines/smolvm)
+micro-VMs (Hypervisor.framework on macOS, KVM on Linux) instead of the
+shared-kernel Docker daemon. Falls back to Docker if smolvm is missing or the
+host is unsupported. Refs #284.

--- a/.github/workflows/smoke-smolvm-checkout.yml
+++ b/.github/workflows/smoke-smolvm-checkout.yml
@@ -1,0 +1,13 @@
+name: "Smoke: smolvm checkout"
+
+on: [workflow_dispatch]
+
+jobs:
+  checkout-only:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Show files
+        run: ls -la
+      - name: Show package.json head
+        run: head -20 package.json

--- a/.github/workflows/smoke-smolvm-setup-node.yml
+++ b/.github/workflows/smoke-smolvm-setup-node.yml
@@ -1,0 +1,14 @@
+name: "Smoke: smolvm setup-node"
+
+on: [workflow_dispatch]
+
+jobs:
+  setup-node-only:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Show node version
+        run: node --version

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,6 +15,8 @@ import type Docker from "dockerode";
 import { executeLocalJob, getDocker } from "./runner/local-job.js";
 import { executeMacosVmJob } from "./runner/macos-vm/macos-vm-job.js";
 import { checkMacosVmHost } from "./runner/macos-vm/host-capability.js";
+import { executeSmolvmJob } from "./runner/smolvm/smolvm-job.js";
+import { checkSmolvmHost } from "./runner/smolvm/host-capability.js";
 import {
   discoverRunnerImage,
   ensureRunnerImage,
@@ -975,11 +977,23 @@ async function handleWorkflow(options: {
   });
   const warnedUnsupportedOS = new Set<string>();
   const macosVmHost = checkMacosVmHost();
+  const smolvmBackendRequested = (process.env.AGENT_CI_BACKEND || "").toLowerCase() === "smolvm";
+  const smolvmHost = smolvmBackendRequested
+    ? checkSmolvmHost()
+    : { supported: false as const, reason: "" };
+  if (smolvmBackendRequested && !smolvmHost.supported) {
+    process.stderr.write(
+      `\nwarning: AGENT_CI_BACKEND=smolvm requested but host is unsupported: ${smolvmHost.reason}\n` +
+        `         Falling back to Docker for Linux jobs.\n\n`,
+    );
+  }
   const classifyJob = (ej: ExpandedJob) => {
     const labels = parseJobRunsOn(ej.workflowPath, ej.sourceTaskName ?? ej.taskName);
     return { labels, kind: classifyRunsOn(labels) };
   };
   const canRunMacosHere = (kind: RunnerOSKind) => kind === "macos" && macosVmHost.supported;
+  const canRunSmolvmHere = (kind: RunnerOSKind) =>
+    smolvmBackendRequested && smolvmHost.supported && (kind === "linux" || kind === "other");
   const maybeSkipUnsupportedOS = (ej: ExpandedJob): JobResult | null => {
     const { labels, kind } = classifyJob(ej);
     if (!isUnsupportedOS(kind) || canRunMacosHere(kind)) {
@@ -997,8 +1011,12 @@ async function handleWorkflow(options: {
   // Returns the executor for a job. Callers have already filtered out
   // OS-skipped jobs via maybeSkipUnsupportedOS.
   const runJobExecutor = (ej: ExpandedJob, job: Job): Promise<JobResult> => {
-    if (canRunMacosHere(classifyJob(ej).kind)) {
+    const kind = classifyJob(ej).kind;
+    if (canRunMacosHere(kind)) {
       return executeMacosVmJob(job);
+    }
+    if (canRunSmolvmHere(kind)) {
+      return executeSmolvmJob(job);
     }
     return executeLocalJob(job, { pauseOnFailure, store });
   };

--- a/packages/cli/src/runner/smolvm/host-capability.test.ts
+++ b/packages/cli/src/runner/smolvm/host-capability.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { checkSmolvmHost } from "./host-capability.js";
+
+const macOk = {
+  platform: "darwin" as NodeJS.Platform,
+  arch: "arm64",
+  whichSmolvm: () => true,
+  hasKvm: () => false, // ignored on darwin
+};
+const linuxOk = {
+  platform: "linux" as NodeJS.Platform,
+  arch: "x64",
+  whichSmolvm: () => true,
+  hasKvm: () => true,
+};
+
+describe("checkSmolvmHost", () => {
+  it("supports darwin + arm64 + smolvm installed", () => {
+    expect(checkSmolvmHost(macOk)).toEqual({ supported: true });
+  });
+
+  it("supports linux + smolvm + /dev/kvm", () => {
+    expect(checkSmolvmHost(linuxOk)).toEqual({ supported: true });
+  });
+
+  it("rejects windows hosts", () => {
+    const r = checkSmolvmHost({ ...macOk, platform: "win32" });
+    expect(r.supported).toBe(false);
+    expect(r.supported === false && r.reason).toMatch(/macOS or Linux/);
+  });
+
+  it("rejects Intel macs", () => {
+    const r = checkSmolvmHost({ ...macOk, arch: "x64" });
+    expect(r.supported).toBe(false);
+    expect(r.supported === false && r.reason).toMatch(/Apple Silicon/);
+    expect(r.supported === false && r.hint).toMatch(/untested/);
+  });
+
+  it("rejects linux without /dev/kvm", () => {
+    const r = checkSmolvmHost({ ...linuxOk, hasKvm: () => false });
+    expect(r.supported).toBe(false);
+    expect(r.supported === false && r.reason).toMatch(/\/dev\/kvm/);
+    expect(r.supported === false && r.hint).toMatch(/KVM/);
+  });
+
+  it("rejects hosts without smolvm installed", () => {
+    const r = checkSmolvmHost({ ...macOk, whichSmolvm: () => false });
+    expect(r.supported).toBe(false);
+    expect(r.supported === false && r.reason).toMatch(/smolvm/);
+    expect(r.supported === false && r.hint).toMatch(/install\.sh/);
+  });
+});

--- a/packages/cli/src/runner/smolvm/host-capability.ts
+++ b/packages/cli/src/runner/smolvm/host-capability.ts
@@ -1,0 +1,70 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+
+export type HostCapability =
+  | { supported: true }
+  | { supported: false; reason: string; hint?: string };
+
+export interface HostCapabilityEnv {
+  platform?: NodeJS.Platform;
+  arch?: string;
+  whichSmolvm?: () => boolean;
+  hasKvm?: () => boolean;
+}
+
+function which(cmd: string): boolean {
+  try {
+    execSync(`command -v ${cmd}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function defaultHasKvm(): boolean {
+  try {
+    return fs.existsSync("/dev/kvm");
+  } catch {
+    return false;
+  }
+}
+
+// Can the host run smolvm? smolvm uses Hypervisor.framework on macOS (Apple
+// Silicon supported; Intel listed as untested) and KVM on Linux. We're strict
+// on macOS arch — Intel macOS is documented as untested upstream — and require
+// /dev/kvm on Linux because libkrun fails opaquely without it.
+export function checkSmolvmHost(env: HostCapabilityEnv = {}): HostCapability {
+  const platform = env.platform ?? process.platform;
+  const arch = env.arch ?? process.arch;
+  const whichSmolvm = env.whichSmolvm ?? (() => which("smolvm"));
+  const hasKvm = env.hasKvm ?? defaultHasKvm;
+
+  if (platform !== "darwin" && platform !== "linux") {
+    return {
+      supported: false,
+      reason: `smolvm runner requires macOS or Linux (got ${platform}).`,
+    };
+  }
+  if (platform === "darwin" && arch !== "arm64") {
+    return {
+      supported: false,
+      reason: `smolvm runner on macOS requires Apple Silicon (got ${arch}).`,
+      hint: "Intel macOS is listed as untested upstream — run on arm64 or use a Linux host.",
+    };
+  }
+  if (platform === "linux" && !hasKvm()) {
+    return {
+      supported: false,
+      reason: "smolvm runner on Linux requires /dev/kvm.",
+      hint: "Enable KVM (kernel module + group membership) before retrying.",
+    };
+  }
+  if (!whichSmolvm()) {
+    return {
+      supported: false,
+      reason: "smolvm runner requires the `smolvm` binary on PATH.",
+      hint: "Install: curl -sSL https://smolmachines.com/install.sh | bash",
+    };
+  }
+  return { supported: true };
+}

--- a/packages/cli/src/runner/smolvm/image-mapping.test.ts
+++ b/packages/cli/src/runner/smolvm/image-mapping.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { resolveSmolvmImage, DEFAULT_SMOLVM_IMAGE } from "./image-mapping.js";
+
+describe("resolveSmolvmImage", () => {
+  const originalOverride = process.env.AGENT_CI_SMOLVM_IMAGE;
+  beforeEach(() => {
+    delete process.env.AGENT_CI_SMOLVM_IMAGE;
+  });
+  afterEach(() => {
+    if (originalOverride === undefined) {
+      delete process.env.AGENT_CI_SMOLVM_IMAGE;
+    } else {
+      process.env.AGENT_CI_SMOLVM_IMAGE = originalOverride;
+    }
+  });
+
+  it("AGENT_CI_SMOLVM_IMAGE wins over labels", () => {
+    process.env.AGENT_CI_SMOLVM_IMAGE = "myorg/custom:1.0";
+    const r = resolveSmolvmImage(["ubuntu-22.04"]);
+    expect(r.image).toBe("myorg/custom:1.0");
+    expect(r.exact).toBe(true);
+    expect(r.matchedLabel).toBeNull();
+  });
+
+  it("ignores empty AGENT_CI_SMOLVM_IMAGE", () => {
+    process.env.AGENT_CI_SMOLVM_IMAGE = "   ";
+    const r = resolveSmolvmImage(["ubuntu-22.04"]);
+    expect(r.image).toBe(DEFAULT_SMOLVM_IMAGE);
+    expect(r.exact).toBe(true);
+    expect(r.matchedLabel).toBe("ubuntu-22.04");
+  });
+
+  it("matches ubuntu-* labels exactly", () => {
+    for (const label of ["ubuntu-22.04", "ubuntu-24.04", "ubuntu-latest", "ubuntu", "linux"]) {
+      const r = resolveSmolvmImage([label]);
+      expect(r.image).toBe(DEFAULT_SMOLVM_IMAGE);
+      expect(r.exact).toBe(true);
+      expect(r.matchedLabel).toBe(label);
+    }
+  });
+
+  it("is case-insensitive on labels", () => {
+    const r = resolveSmolvmImage(["Ubuntu-Latest"]);
+    expect(r.exact).toBe(true);
+    expect(r.matchedLabel).toBe("Ubuntu-Latest");
+  });
+
+  it("falls back when no label matches", () => {
+    const r = resolveSmolvmImage(["self-hosted", "custom-pool"]);
+    expect(r.image).toBe(DEFAULT_SMOLVM_IMAGE);
+    expect(r.exact).toBe(false);
+    expect(r.matchedLabel).toBe("self-hosted");
+  });
+
+  it("prefers a linux-like label as the fallback hint", () => {
+    const r = resolveSmolvmImage(["self-hosted", "ubuntu-foo"]);
+    expect(r.exact).toBe(false);
+    expect(r.matchedLabel).toBe("ubuntu-foo");
+  });
+
+  it("handles empty label list", () => {
+    const r = resolveSmolvmImage([]);
+    expect(r.exact).toBe(false);
+    expect(r.matchedLabel).toBeNull();
+  });
+});

--- a/packages/cli/src/runner/smolvm/image-mapping.ts
+++ b/packages/cli/src/runner/smolvm/image-mapping.ts
@@ -1,0 +1,42 @@
+// Map a Linux job's `runs-on:` labels to an OCI container image that smolvm
+// will boot as a micro-VM. We default to the same actions-runner image the
+// Docker backend uses so behavior matches between the two paths; users can
+// override with AGENT_CI_SMOLVM_IMAGE for a custom base.
+
+export const DEFAULT_SMOLVM_IMAGE = "ghcr.io/actions/actions-runner:latest";
+
+const LABEL_TO_IMAGE: Record<string, string> = {
+  // GitHub-hosted ubuntu-* labels all collapse to the same actions-runner
+  // image — smolvm doesn't need a per-version image tag the way macOS does
+  // because the Linux runner binary is version-agnostic. We keep the map
+  // explicit so future divergence (e.g. ubuntu-24.04 → noble-pinned image)
+  // is a one-line change.
+  "ubuntu-22.04": DEFAULT_SMOLVM_IMAGE,
+  "ubuntu-24.04": DEFAULT_SMOLVM_IMAGE,
+  "ubuntu-latest": DEFAULT_SMOLVM_IMAGE,
+  ubuntu: DEFAULT_SMOLVM_IMAGE,
+  linux: DEFAULT_SMOLVM_IMAGE,
+};
+
+export interface ImageResolution {
+  image: string;
+  /** True when we recognized a specific label; false when we fell back. */
+  exact: boolean;
+  /** The label we matched on (or the first one we considered when falling back). */
+  matchedLabel: string | null;
+}
+
+export function resolveSmolvmImage(labels: string[]): ImageResolution {
+  const override = process.env.AGENT_CI_SMOLVM_IMAGE?.trim();
+  if (override) {
+    return { image: override, exact: true, matchedLabel: null };
+  }
+  for (const label of labels) {
+    const mapped = LABEL_TO_IMAGE[label.toLowerCase()];
+    if (mapped) {
+      return { image: mapped, exact: true, matchedLabel: label };
+    }
+  }
+  const firstLinuxLike = labels.find((l) => /^(ubuntu|linux)/i.test(l)) ?? labels[0] ?? null;
+  return { image: DEFAULT_SMOLVM_IMAGE, exact: false, matchedLabel: firstLinuxLike };
+}

--- a/packages/cli/src/runner/smolvm/smolvm-job.ts
+++ b/packages/cli/src/runner/smolvm/smolvm-job.ts
@@ -1,0 +1,473 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { startEphemeralDtu } from "dtu-github-actions/ephemeral";
+
+import { Job } from "../../types.js";
+import { getWorkingDirectory } from "../../output/working-directory.js";
+import { createLogContext } from "../../output/logger.js";
+import { debugRunner, debugBoot } from "../../output/debug.js";
+import { type JobResult } from "../../output/reporter.js";
+import { buildJobResult, isJobSuccessful } from "../result-builder.js";
+import { writeJobMetadata } from "../metadata.js";
+import { appendOutputCaptureStep } from "../step-wrapper.js";
+import { writeRunnerCredentials } from "../runner-credentials.js";
+import { classifyRunsOn } from "../runs-on-compat.js";
+import { parseJobRunsOn } from "../../workflow/workflow-parser.js";
+import { createRunDirectories } from "../directory-setup.js";
+import { prepareWorkspace } from "../workspace.js";
+import { writeGitShim } from "../git-shim.js";
+
+import { checkSmolvmHost } from "./host-capability.js";
+import { resolveSmolvmImage } from "./image-mapping.js";
+import {
+  createAndStart,
+  execScript,
+  exec as smolvmExec,
+  stop as smolvmStop,
+  destroy as smolvmDestroy,
+  packImageIfMissing,
+} from "./smolvm.js";
+
+// ─── Tunables (env-overridable) ───────────────────────────────────────────────
+
+// smolvm 0.5.19's state DB is a single-writer SQLite; concurrent
+// create/start/stop/delete calls fail with "Database already open. Cannot
+// acquire lock." Default to 1 so the orchestrator serializes lifecycle ops;
+// once smolvm fixes its locking the env var lets users opt back into parallel.
+const SMOLVM_CONCURRENCY = parseInt(process.env.AGENT_CI_SMOLVM_CONCURRENCY || "1", 10);
+
+// smolvm uses libkrun's TSI: the guest has no virtual NIC, but outbound
+// connections are proxied through the host's network stack. A connection to
+// 127.0.0.1 from inside the guest lands on the host's 127.0.0.1 — so the DTU
+// (which binds 0.0.0.0) is reachable at "127.0.0.1" from the guest's POV.
+// (10.0.2.2 — the libkrun-user-mode-net default — does NOT work under TSI;
+// it times out. Verified against smolvm 0.5.19.)
+const VM_HOST_IP = process.env.AGENT_CI_SMOLVM_HOST_IP || "127.0.0.1";
+
+// Where the actions-runner image expects its workspace. The upstream image
+// (ghcr.io/actions/actions-runner) installs run.sh at /home/runner.
+const VM_RUNNER_DIR = process.env.AGENT_CI_SMOLVM_RUNNER_DIR || "/home/runner";
+const VM_RUNNER_WORK_DIR = `${VM_RUNNER_DIR}/_work`;
+
+// ─── Tiny semaphore (kept inline to avoid pulling the macos-vm one) ───────────
+
+interface Semaphore {
+  acquire(): Promise<() => void>;
+}
+
+function createSemaphore(limit: number): Semaphore {
+  const safe = Number.isInteger(limit) && limit >= 1 ? limit : 1;
+  let active = 0;
+  const waiters: Array<() => void> = [];
+  const release = () => {
+    active--;
+    const next = waiters.shift();
+    if (next) {
+      active++;
+      next();
+    }
+  };
+  return {
+    acquire(): Promise<() => void> {
+      if (active < safe) {
+        active++;
+        return Promise.resolve(release);
+      }
+      return new Promise<() => void>((resolve) => {
+        waiters.push(() => resolve(release));
+      });
+    },
+  };
+}
+
+const semaphore = createSemaphore(SMOLVM_CONCURRENCY);
+
+// ─── Entrypoint ───────────────────────────────────────────────────────────────
+
+export async function executeSmolvmJob(job: Job): Promise<JobResult> {
+  const host = checkSmolvmHost();
+  if (!host.supported) {
+    throw new Error(
+      `smolvm runner unavailable: ${host.reason}${host.hint ? `\n  ${host.hint}` : ""}`,
+    );
+  }
+
+  const release = await semaphore.acquire();
+  const startTime = Date.now();
+
+  const { name, runDir, logDir, debugLogPath } = createLogContext(
+    "agent-ci-smolvm",
+    job.runnerName,
+  );
+  job.runnerName = name;
+  writeJobMetadata({ logDir, containerName: name, job });
+  const debugStream = fs.createWriteStream(debugLogPath);
+  const debug = (line: string) => {
+    debugRunner(line);
+    debugStream.write(line + "\n");
+  };
+
+  const bootStart = Date.now();
+  const bt = (label: string, since: number) => {
+    debugBoot(`${name} ${label}: ${Date.now() - since}ms`);
+    return Date.now();
+  };
+
+  // ── Resolve image up front so we fail fast on unknown labels ──────────────
+  const labels = job.workflowPath ? parseJobRunsOn(job.workflowPath, job.taskId ?? "") : [];
+  const kind = classifyRunsOn(labels);
+  if (kind !== "linux" && kind !== "other") {
+    throw new Error(
+      `executeSmolvmJob called for a ${kind} job (labels: ${JSON.stringify(labels)}). ` +
+        "This is a routing bug — only Linux/other jobs should reach this path.",
+    );
+  }
+  const { image, exact } = resolveSmolvmImage(labels);
+  if (!exact) {
+    process.stderr.write(
+      `\nwarning: could not map runs-on ${JSON.stringify(labels)} to a known smolvm image.\n` +
+        `         Falling back to ${image}. Override with AGENT_CI_SMOLVM_IMAGE if needed.\n\n`,
+    );
+  }
+
+  // ── Start the ephemeral DTU on the host ───────────────────────────────────
+  let t0 = Date.now();
+  const dtuCacheDir = path.resolve(getWorkingDirectory(), "cache", "dtu");
+  const dtu = await startEphemeralDtu(dtuCacheDir);
+  const dtuHostUrl = dtu.url;
+  const dtuVmUrl = `http://${VM_HOST_IP}:${dtu.port}`;
+  t0 = bt("dtu-start", t0);
+
+  let vmName: string | null = null;
+  const tmpRunnerCredsDir = await fsp.mkdtemp(path.join(os.tmpdir(), "agent-ci-smolvm-creds-"));
+
+  const signalCleanup = () => {
+    if (vmName) {
+      smolvmStop(vmName).catch(() => {});
+      smolvmDestroy(vmName).catch(() => {});
+    }
+  };
+  process.on("SIGINT", signalCleanup);
+  process.on("SIGTERM", signalCleanup);
+  process.on("SIGHUP", signalCleanup);
+
+  try {
+    // ── Seed the job to the DTU ─────────────────────────────────────────────
+    await fetch(`${dtuHostUrl}/_dtu/start-runner`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        runnerName: name,
+        logDir,
+        timelineDir: logDir,
+        virtualCachePatterns: [],
+      }),
+    }).catch(() => {
+      /* non-fatal */
+    });
+
+    const [githubOwner, githubRepoName] = (job.githubRepo || "").split("/");
+    const overriddenRepository = job.githubRepo
+      ? {
+          full_name: job.githubRepo,
+          name: githubRepoName,
+          owner: { login: githubOwner },
+          default_branch: job.repository?.default_branch || "main",
+        }
+      : job.repository;
+    const seededSteps = appendOutputCaptureStep(job.steps ?? []);
+
+    const seedResponse = await fetch(`${dtuHostUrl}/_dtu/seed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: job.githubJobId || "1",
+        name: "job",
+        status: "queued",
+        ...job,
+        steps: seededSteps,
+        repository: overriddenRepository,
+        runnerOs: "Linux",
+        runnerArch: process.arch === "arm64" ? "ARM64" : "X64",
+        runnerWorkDir: VM_RUNNER_WORK_DIR,
+      }),
+    });
+    if (!seedResponse.ok) {
+      throw new Error(`Failed to seed DTU: ${seedResponse.status} ${seedResponse.statusText}`);
+    }
+    t0 = bt("dtu-seed", t0);
+
+    // ── Build the same per-run dirs the Docker path uses so workflows that
+    //    use actions/checkout, setup-node, setup-pnpm, etc. find the workspace,
+    //    git shim, tool cache, and PM caches at the paths they expect. ─────
+    const dirs = createRunDirectories({
+      runDir,
+      githubRepo: job.githubRepo!,
+      workflowPath: job.workflowPath,
+    });
+
+    // Write the git shim and prepare the workspace BEFORE mounting — virtiofs
+    // sees current host contents at mount time, and the runner will reach for
+    // /tmp/agent-ci-shims/git on first checkout.
+    writeGitShim(dirs.shimsDir, job.realHeadSha ?? job.headSha ?? "0000000");
+    await prepareWorkspace({
+      workflowPath: job.workflowPath,
+      headSha: job.headSha,
+      githubRepo: job.githubRepo,
+      workspaceDir: dirs.workspaceDir,
+    }).catch((err) => debug(`prepareWorkspace failed (non-fatal): ${err}`));
+    t0 = bt("workspace-ready", t0);
+
+    // ── Write runner credentials BEFORE mounting (virtiofs sees current
+    //    contents at mount time; we want them present from the first exec). ─
+    const repoUrl = `${dtuVmUrl}/${job.githubRepo}`;
+    writeRunnerCredentials(tmpRunnerCredsDir, name, repoUrl);
+
+    // ── Pre-pack the image (idempotent) so each VM creates from a local
+    //    .smolmachine artifact instead of pulling from the registry. Avoids a
+    //    per-VM ~4GB pull and dodges a smolvm 0.5.19 issue where repeated
+    //    registry pulls cause TSI DNS to go unreachable across the host. ──
+    const packDir = path.resolve(getWorkingDirectory(), "cache", "smolvm-packs");
+    const packBase = path.join(packDir, imageToPackBasename(image));
+    const packPath = await packImageIfMissing(image, packBase);
+    t0 = bt("smolvm-pack-ready", t0);
+
+    // ── Mount set mirrors `buildContainerBinds` from the Docker path, minus
+    //    Docker-specific bits (no /var/run/docker.sock — DinD inside smolvm
+    //    is out of scope). virtiofs only mounts directories. ────────────────
+    const repoName = job.githubRepo!.split("/").pop() || "repo";
+    const volumes: string[] = [
+      `${tmpRunnerCredsDir}:/runner-credentials:ro`,
+      // logDir mounted at the same path so the in-VM tee target
+      // (${logDir}/run.log) writes to a host-readable file.
+      `${logDir}:${logDir}`,
+      `${dirs.containerWorkDir}:${VM_RUNNER_WORK_DIR}`,
+      `${dirs.shimsDir}:/tmp/agent-ci-shims`,
+      `${dirs.diagDir}:${VM_RUNNER_DIR}/_diag`,
+      // toolcache deliberately NOT mounted: setup-node writes ~30k small
+      // files into /opt/hostedtoolcache, and virtiofs over libkrun hangs on
+      // sustained small-file writes (smolvm 0.5.19). Letting the cache live
+      // on the in-VM overlay disk avoids the hang at the cost of re-extracting
+      // node per VM. Toggle back on via AGENT_CI_SMOLVM_MOUNT_TOOLCACHE=1.
+      ...(process.env.AGENT_CI_SMOLVM_MOUNT_TOOLCACHE === "1"
+        ? [`${dirs.toolCacheDir}:/opt/hostedtoolcache`]
+        : []),
+      `${dirs.playwrightCacheDir}:${VM_RUNNER_DIR}/.cache/ms-playwright`,
+      `${dirs.warmModulesDir}:${VM_RUNNER_WORK_DIR}/${repoName}/${repoName}/node_modules`,
+    ];
+    if (dirs.pnpmStoreDir) {
+      volumes.push(`${dirs.pnpmStoreDir}:${VM_RUNNER_WORK_DIR}/.pnpm-store`);
+    }
+    if (dirs.npmCacheDir) {
+      volumes.push(`${dirs.npmCacheDir}:${VM_RUNNER_DIR}/.npm`);
+    }
+    if (dirs.bunCacheDir) {
+      volumes.push(`${dirs.bunCacheDir}:${VM_RUNNER_DIR}/.bun`);
+    }
+
+    // ── Boot the VM from the pack with all bind mounts ──────────────────────
+    vmName = `agent-ci-smolvm-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    await createAndStart(
+      vmName,
+      { fromPack: packPath },
+      {
+        network: true,
+        volumes,
+      },
+    );
+    t0 = bt("smolvm-create-start", t0);
+
+    // Wait for the VM to be exec-ready by retrying a no-op a few times.
+    await waitForExec(vmName, debug);
+    t0 = bt("smolvm-exec-ready", t0);
+
+    // ── Install creds + git shim + perms inside the VM ──────────────────────
+    // - cp -a uses `.` source so dotfiles (.runner / .credentials / ...) come
+    //   along; bare `*` glob would skip them.
+    // - Swap /usr/bin/git ↔ /usr/bin/git.real and drop the shim in place so
+    //   actions/checkout sees the pre-populated workspace instead of cloning.
+    // - chown _work + _diag because the runner runs as the unprivileged
+    //   `runner` user and virtiofs mounts come up root-owned.
+    await execScript(
+      vmName,
+      `set -e
+mkdir -p ${VM_RUNNER_DIR} ${VM_RUNNER_WORK_DIR} ${VM_RUNNER_DIR}/_diag
+cp -a /runner-credentials/. ${VM_RUNNER_DIR}/
+if [ -f /usr/bin/git ] && [ ! -f /usr/bin/git.real ]; then
+  mv /usr/bin/git /usr/bin/git.real
+  cp -p /tmp/agent-ci-shims/git /usr/bin/git
+  chmod +x /usr/bin/git
+fi
+chown -R runner:runner ${VM_RUNNER_DIR} ${VM_RUNNER_WORK_DIR} ${VM_RUNNER_DIR}/_diag
+chmod -R u+rwX ${VM_RUNNER_WORK_DIR}`,
+      { timeoutMs: 60_000 },
+    );
+    t0 = bt("creds-shim-installed", t0);
+
+    // ── Kick off ./run.sh ────────────────────────────────────────────────────
+    // Redirect stdout/stderr to a virtiofs-mounted log file *inside* the VM
+    // instead of letting it stream back over smolvm's vsock exec channel.
+    // The .NET runner prints heavily during setup-* steps and Console.WriteLine
+    // blocks when its 64K pipe buffer fills; if smolvm's vsock host-side reader
+    // can't drain fast enough the runner deadlocks. Writing to a file
+    // sidesteps the entire backpressure path. We tail the file from the host
+    // for live debug log streaming.
+    const inVmRunLog = `${logDir}/run.log`;
+    const inVmDiagLog = `${logDir}/in-vm-diag.log`;
+    const runScript = `set -e
+cd ${VM_RUNNER_DIR}
+chmod +x run.sh
+# Side watcher: dump process / network / runner-status snapshot every 5s to
+# a host-readable file so we can see what's happening during a hang.
+(
+  while true; do
+    {
+      echo "=== $(date -u +%H:%M:%S) ==="
+      echo "--- ps (runner-related) ---"
+      ps -eo pid,ppid,stat,etime,cmd | grep -E 'Runner|run.sh|node|npm|yarn|dotnet' | grep -v grep | head -30 || true
+      echo "--- ss (tcp) ---"
+      ss -tnp 2>/dev/null | head -20 || netstat -tnp 2>/dev/null | head -20 || true
+      echo "--- meminfo ---"
+      grep -E 'MemAvailable|MemFree|Active' /proc/meminfo 2>/dev/null | head -5 || true
+    } >>${inVmDiagLog} 2>&1
+    sleep 5
+  done
+) &
+WATCHER_PID=$!
+trap "kill $WATCHER_PID 2>/dev/null" EXIT
+exec runuser -u runner -- ./run.sh --once >${inVmRunLog} 2>&1
+`;
+    debug(`Starting ./run.sh inside smolvm ${vmName}`);
+    bt("total-boot", bootStart);
+
+    // Tail the in-VM log file (virtiofs-backed, host-readable) so live debug
+    // output keeps flowing while the runner runs.
+    const tailAbort = new AbortController();
+    const tailPromise = tailFileToStream(inVmRunLog, debugStream, tailAbort.signal);
+
+    const runResult = await execScript(vmName, runScript, {
+      timeoutMs: 3_600_000, // 1h hard cap
+    });
+    tailAbort.abort();
+    await tailPromise.catch(() => {});
+
+    await new Promise<void>((resolve) => debugStream.end(resolve));
+
+    // ── Assemble the JobResult from timeline + outputs ──────────────────────
+    const timelinePath = path.join(logDir, "timeline.json");
+    const outputsFile = path.join(logDir, "outputs.json");
+    let stepOutputs: Record<string, string> = {};
+    if (fs.existsSync(outputsFile)) {
+      try {
+        stepOutputs = JSON.parse(fs.readFileSync(outputsFile, "utf-8"));
+      } catch {
+        /* best-effort */
+      }
+    }
+
+    const lastFailedStep = readLastFailedStep(timelinePath);
+    const isBooting = !fs.existsSync(timelinePath);
+    const jobSucceeded = isJobSuccessful({
+      lastFailedStep,
+      containerExitCode: runResult.code,
+      isBooting,
+    });
+
+    return buildJobResult({
+      containerName: name,
+      job,
+      startTime,
+      jobSucceeded,
+      lastFailedStep,
+      containerExitCode: runResult.code,
+      timelinePath,
+      logDir,
+      debugLogPath,
+      stepOutputs,
+    });
+  } finally {
+    process.removeListener("SIGINT", signalCleanup);
+    process.removeListener("SIGTERM", signalCleanup);
+    process.removeListener("SIGHUP", signalCleanup);
+
+    if (vmName) {
+      await smolvmStop(vmName).catch(() => {});
+      await smolvmDestroy(vmName).catch(() => {});
+    }
+
+    await dtu.close().catch(() => {});
+    await fsp.rm(tmpRunnerCredsDir, { recursive: true, force: true }).catch(() => {});
+    release();
+  }
+}
+
+// Poll a host-readable file (the VM writes here via virtiofs) and forward any
+// newly-appended bytes to `out`. Stops when `signal` aborts.
+async function tailFileToStream(
+  filePath: string,
+  out: NodeJS.WritableStream,
+  signal: AbortSignal,
+): Promise<void> {
+  let pos = 0;
+  while (!signal.aborted) {
+    try {
+      const stat = await fsp.stat(filePath).catch(() => null);
+      if (stat && stat.size > pos) {
+        const fh = await fsp.open(filePath, "r");
+        try {
+          const buf = Buffer.alloc(stat.size - pos);
+          await fh.read(buf, 0, buf.length, pos);
+          out.write(buf);
+          pos = stat.size;
+        } finally {
+          await fh.close();
+        }
+      }
+    } catch {
+      // best-effort
+    }
+    await new Promise((res) => setTimeout(res, 500));
+  }
+}
+
+async function waitForExec(name: string, debug: (line: string) => void): Promise<void> {
+  const deadline = Date.now() + 60_000;
+  let lastErr = "";
+  while (Date.now() < deadline) {
+    const r = await smolvmExec(name, ["true"], { timeoutMs: 5000 }).catch((e) => ({
+      code: -1,
+      stdout: "",
+      stderr: String(e),
+    }));
+    if (r.code === 0) {
+      return;
+    }
+    lastErr = (r.stderr || "").trim();
+    await new Promise((res) => setTimeout(res, 1000));
+  }
+  debug(`waitForExec last error: ${lastErr}`);
+  throw new Error(`Timed out waiting for smolvm VM ${name} to become exec-ready`);
+}
+
+// Filesystem-safe basename for the pack file. We just need a stable, unique-
+// per-image string; replace registry punctuation that breaks file paths.
+function imageToPackBasename(image: string): string {
+  return image.replace(/[^a-zA-Z0-9._-]+/g, "_");
+}
+
+function readLastFailedStep(timelinePath: string): string | null {
+  if (!fs.existsSync(timelinePath)) {
+    return null;
+  }
+  try {
+    const records = JSON.parse(fs.readFileSync(timelinePath, "utf-8")) as any[];
+    const failed = records
+      .filter((r) => r.type === "Task" && (r.result || "").toLowerCase() === "failed")
+      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+    return failed.length > 0 ? failed[failed.length - 1].name : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/cli/src/runner/smolvm/smolvm.test.ts
+++ b/packages/cli/src/runner/smolvm/smolvm.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import {
+  createMachineArgs,
+  startArgs,
+  runEphemeralArgs,
+  execArgs,
+  stopArgs,
+  deleteArgs,
+  listArgs,
+  statusArgs,
+  packCreateArgs,
+} from "./smolvm.js";
+
+describe("smolvm argv builders", () => {
+  describe("createMachineArgs", () => {
+    it("appends NAME positionally with -I image", () => {
+      const [cmd, args] = createMachineArgs("vm1", { image: "ubuntu:22.04" });
+      expect(cmd).toBe("smolvm");
+      expect(args[0]).toBe("machine");
+      expect(args[1]).toBe("create");
+      const iIdx = args.indexOf("-I");
+      expect(iIdx).toBeGreaterThan(-1);
+      expect(args[iIdx + 1]).toBe("ubuntu:22.04");
+      expect(args[args.length - 1]).toBe("vm1");
+    });
+
+    it("supports a bare VM (no image) — name still positional last", () => {
+      const [, args] = createMachineArgs("vm1");
+      expect(args).not.toContain("-I");
+      expect(args[args.length - 1]).toBe("vm1");
+    });
+
+    it("threads cpus / memMib / storageGib / network", () => {
+      const [, args] = createMachineArgs("vm1", {
+        image: "img",
+        cpus: 8,
+        memMib: 4096,
+        storageGib: 32,
+        network: true,
+      });
+      expect(args[args.indexOf("--cpus") + 1]).toBe("8");
+      expect(args[args.indexOf("--mem") + 1]).toBe("4096");
+      expect(args[args.indexOf("--storage") + 1]).toBe("32");
+      expect(args).toContain("--net");
+    });
+
+    it("appends each volume / env / allow-* before the positional name", () => {
+      const [, args] = createMachineArgs("vm1", {
+        image: "img",
+        volumes: ["/src:/app", "/cache:/cache:ro"],
+        env: { FOO: "bar" },
+        allowCidr: ["10.0.0.0/8"],
+        allowHost: ["github.com"],
+      });
+      const vIdxs = args.reduce<number[]>((a, v, i) => (v === "-v" ? [...a, i] : a), []);
+      expect(vIdxs.map((i) => args[i + 1])).toEqual(["/src:/app", "/cache:/cache:ro"]);
+      expect(args[args.indexOf("-e") + 1]).toBe("FOO=bar");
+      expect(args[args.indexOf("--allow-cidr") + 1]).toBe("10.0.0.0/8");
+      expect(args[args.indexOf("--allow-host") + 1]).toBe("github.com");
+      expect(args[args.length - 1]).toBe("vm1");
+    });
+  });
+
+  describe("startArgs", () => {
+    it("uses --name", () => {
+      expect(startArgs("vm1")).toEqual(["smolvm", ["machine", "start", "--name", "vm1"]]);
+    });
+  });
+
+  describe("runEphemeralArgs", () => {
+    it("does NOT include --name (run is ephemeral) and uses -- before command", () => {
+      const [cmd, args] = runEphemeralArgs("alpine", ["echo", "hi"]);
+      expect(cmd).toBe("smolvm");
+      expect(args[0]).toBe("machine");
+      expect(args[1]).toBe("run");
+      expect(args).not.toContain("--name");
+      const sepIdx = args.indexOf("--");
+      expect(sepIdx).toBeGreaterThan(-1);
+      expect(args.slice(sepIdx + 1)).toEqual(["echo", "hi"]);
+      expect(args[args.indexOf("-I") + 1]).toBe("alpine");
+    });
+
+    it("omits the -- separator when no command is given", () => {
+      const [, args] = runEphemeralArgs("alpine");
+      expect(args).not.toContain("--");
+    });
+
+    it("threads -d / --net / --timeout / mem", () => {
+      const [, args] = runEphemeralArgs("alpine", ["sh"], {
+        detach: true,
+        network: true,
+        timeout: "30s",
+        memMib: 2048,
+      });
+      expect(args).toContain("-d");
+      expect(args).toContain("--net");
+      expect(args[args.indexOf("--timeout") + 1]).toBe("30s");
+      expect(args[args.indexOf("--mem") + 1]).toBe("2048");
+    });
+  });
+
+  describe("execArgs", () => {
+    it("builds machine exec --name <name> -- <cmd>", () => {
+      const [cmd, args] = execArgs("vm1", ["echo", "hello"]);
+      expect(cmd).toBe("smolvm");
+      expect(args.slice(0, 4)).toEqual(["machine", "exec", "--name", "vm1"]);
+      const sepIdx = args.indexOf("--");
+      expect(args.slice(sepIdx + 1)).toEqual(["echo", "hello"]);
+    });
+
+    it("adds -i / -t flags when requested", () => {
+      const [, args] = execArgs("vm1", ["bash"], { interactive: true, tty: true });
+      expect(args).toContain("-i");
+      expect(args).toContain("-t");
+    });
+
+    it("threads workdir and env vars before --", () => {
+      const [, args] = execArgs("vm1", ["pwd"], {
+        workdir: "/work",
+        env: { FOO: "bar", BAZ: "qux" },
+      });
+      const sepIdx = args.indexOf("--");
+      const wIdx = args.indexOf("-w");
+      expect(wIdx).toBeGreaterThan(-1);
+      expect(wIdx).toBeLessThan(sepIdx);
+      expect(args[wIdx + 1]).toBe("/work");
+      const envFlags = args.map((v, i) => (v === "-e" ? args[i + 1] : null)).filter(Boolean);
+      expect(envFlags).toEqual(["FOO=bar", "BAZ=qux"]);
+    });
+  });
+
+  it("stopArgs uses --name", () => {
+    expect(stopArgs("vm1")).toEqual(["smolvm", ["machine", "stop", "--name", "vm1"]]);
+  });
+
+  it("deleteArgs uses positional NAME with -f to skip the prompt", () => {
+    expect(deleteArgs("vm1")).toEqual(["smolvm", ["machine", "delete", "-f", "vm1"]]);
+  });
+
+  it("listArgs / statusArgs", () => {
+    expect(listArgs()).toEqual(["smolvm", ["machine", "ls", "--json"]]);
+    expect(statusArgs("vm1")).toEqual(["smolvm", ["machine", "status", "--name", "vm1"]]);
+  });
+
+  describe("createMachineArgs --from", () => {
+    it("uses --from when fromPack is given", () => {
+      const [, args] = createMachineArgs("vm1", { fromPack: "/cache/runner.smolmachine" });
+      expect(args).toContain("--from");
+      expect(args[args.indexOf("--from") + 1]).toBe("/cache/runner.smolmachine");
+      expect(args).not.toContain("-I");
+    });
+
+    it("rejects passing both image and fromPack", () => {
+      expect(() =>
+        createMachineArgs("vm1", { image: "alpine", fromPack: "/x.smolmachine" }),
+      ).toThrow(/either `image` or `fromPack`/);
+    });
+  });
+
+  it("packCreateArgs builds `pack create -I <image> -o <output>`", () => {
+    expect(
+      packCreateArgs("ghcr.io/actions/actions-runner:latest", "/cache/runner.smolmachine"),
+    ).toEqual([
+      "smolvm",
+      [
+        "pack",
+        "create",
+        "-I",
+        "ghcr.io/actions/actions-runner:latest",
+        "-o",
+        "/cache/runner.smolmachine",
+      ],
+    ]);
+  });
+});

--- a/packages/cli/src/runner/smolvm/smolvm.ts
+++ b/packages/cli/src/runner/smolvm/smolvm.ts
@@ -1,0 +1,380 @@
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
+
+// ─── Pure argv builders (unit-testable) ───────────────────────────────────────
+//
+// smolvm splits ephemeral and persistent VMs across two top-level subcommands:
+//   - `machine run`    — ephemeral; no `--name`. Pass image + command, VM is
+//                        torn down when the command exits (unless --detach).
+//   - `machine create` — persistent named config; no boot.
+//   - `machine start`  — boot a previously-created named VM.
+// We need persistent VMs so we can exec into them across the job lifecycle,
+// so the high-level `runMachine` below composes create + start.
+//
+// CLI surface verified against smolvm 0.5.19. See:
+//   https://github.com/smol-machines/smolvm
+
+export interface CreateMachineOptions {
+  /** Container image (e.g. "ubuntu:22.04"). Optional for bare-VM mode. */
+  image?: string;
+  /**
+   * Path to a packed .smolmachine artifact. Mutually exclusive with `image` —
+   * --from skips the OCI registry pull entirely, reusing pre-extracted layers
+   * from a prior `smolvm pack create`. Use this to amortize the pull across
+   * many VMs (one pack, N creates).
+   */
+  fromPack?: string;
+  /** virtiofs bind mounts: HOST:GUEST or HOST:GUEST:ro. */
+  volumes?: string[];
+  /** vCPU count. Defaults to smolvm's own default (4) when omitted. */
+  cpus?: number;
+  /** Memory in MiB. smolvm expects a number, not "8G"-style strings. */
+  memMib?: number;
+  /** Storage disk size in GiB (for OCI layers + container data). */
+  storageGib?: number;
+  /** Enable network egress. smolvm requires explicit opt-in. */
+  network?: boolean;
+  allowCidr?: string[];
+  allowHost?: string[];
+  /** Per-VM env vars (set on create, persist across exec sessions). */
+  env?: Record<string, string>;
+  /** Working directory inside the guest. */
+  workdir?: string;
+}
+
+export function createMachineArgs(
+  name: string,
+  opts: CreateMachineOptions = {},
+): [string, string[]] {
+  const args: string[] = ["machine", "create"];
+  if (opts.fromPack !== undefined && opts.image !== undefined) {
+    throw new Error("createMachineArgs: pass either `image` or `fromPack`, not both");
+  }
+  if (opts.fromPack !== undefined) {
+    args.push("--from", opts.fromPack);
+  } else if (opts.image !== undefined) {
+    args.push("-I", opts.image);
+  }
+  if (opts.cpus !== undefined) {
+    args.push("--cpus", String(opts.cpus));
+  }
+  if (opts.memMib !== undefined) {
+    args.push("--mem", String(opts.memMib));
+  }
+  if (opts.storageGib !== undefined) {
+    args.push("--storage", String(opts.storageGib));
+  }
+  if (opts.network) {
+    args.push("--net");
+  }
+  for (const cidr of opts.allowCidr ?? []) {
+    args.push("--allow-cidr", cidr);
+  }
+  for (const host of opts.allowHost ?? []) {
+    args.push("--allow-host", host);
+  }
+  for (const v of opts.volumes ?? []) {
+    args.push("-v", v);
+  }
+  for (const [k, v] of Object.entries(opts.env ?? {})) {
+    args.push("-e", `${k}=${v}`);
+  }
+  if (opts.workdir) {
+    args.push("-w", opts.workdir);
+  }
+  args.push(name);
+  return ["smolvm", args];
+}
+
+export function startArgs(name: string): [string, string[]] {
+  return ["smolvm", ["machine", "start", "--name", name]];
+}
+
+export interface RunEphemeralOptions extends CreateMachineOptions {
+  /** Detach (background) the VM and keep it alive after the command exits. */
+  detach?: boolean;
+  interactive?: boolean;
+  tty?: boolean;
+  timeout?: string;
+}
+
+// `machine run` for ephemeral, fire-and-forget VMs. No --name. Useful for
+// smoke tests / one-shots; the persistent path uses create + start.
+export function runEphemeralArgs(
+  image: string,
+  command: string[] = [],
+  opts: RunEphemeralOptions = {},
+): [string, string[]] {
+  const args: string[] = ["machine", "run"];
+  if (opts.detach) {
+    args.push("-d");
+  }
+  if (opts.interactive) {
+    args.push("-i");
+  }
+  if (opts.tty) {
+    args.push("-t");
+  }
+  if (opts.timeout) {
+    args.push("--timeout", opts.timeout);
+  }
+  if (opts.cpus !== undefined) {
+    args.push("--cpus", String(opts.cpus));
+  }
+  if (opts.memMib !== undefined) {
+    args.push("--mem", String(opts.memMib));
+  }
+  if (opts.network) {
+    args.push("--net");
+  }
+  for (const cidr of opts.allowCidr ?? []) {
+    args.push("--allow-cidr", cidr);
+  }
+  for (const host of opts.allowHost ?? []) {
+    args.push("--allow-host", host);
+  }
+  for (const v of opts.volumes ?? []) {
+    args.push("-v", v);
+  }
+  for (const [k, v] of Object.entries(opts.env ?? {})) {
+    args.push("-e", `${k}=${v}`);
+  }
+  if (opts.workdir) {
+    args.push("-w", opts.workdir);
+  }
+  args.push("-I", image);
+  if (command.length > 0) {
+    args.push("--", ...command);
+  }
+  return ["smolvm", args];
+}
+
+export interface ExecOptions {
+  tty?: boolean;
+  interactive?: boolean;
+  env?: Record<string, string>;
+  workdir?: string;
+}
+
+export function execArgs(name: string, cmd: string[], opts: ExecOptions = {}): [string, string[]] {
+  const args: string[] = ["machine", "exec", "--name", name];
+  if (opts.interactive) {
+    args.push("-i");
+  }
+  if (opts.tty) {
+    args.push("-t");
+  }
+  if (opts.workdir) {
+    args.push("-w", opts.workdir);
+  }
+  for (const [k, v] of Object.entries(opts.env ?? {})) {
+    args.push("-e", `${k}=${v}`);
+  }
+  args.push("--", ...cmd);
+  return ["smolvm", args];
+}
+
+export function stopArgs(name: string): [string, string[]] {
+  return ["smolvm", ["machine", "stop", "--name", name]];
+}
+
+// `machine delete` takes the name positionally. -f skips the confirmation
+// prompt; without it the command would block on stdin in our non-interactive
+// teardown path.
+export function deleteArgs(name: string): [string, string[]] {
+  return ["smolvm", ["machine", "delete", "-f", name]];
+}
+
+export function listArgs(): [string, string[]] {
+  return ["smolvm", ["machine", "ls", "--json"]];
+}
+
+export function statusArgs(name: string): [string, string[]] {
+  return ["smolvm", ["machine", "status", "--name", name]];
+}
+
+// `smolvm pack create -I <image> -o <output>` bundles an OCI image into a
+// self-contained .smolmachine file we can later instantiate with
+// `machine create --from <path>` — skipping the per-VM registry pull.
+export function packCreateArgs(image: string, outputPath: string): [string, string[]] {
+  return ["smolvm", ["pack", "create", "-I", image, "-o", outputPath]];
+}
+
+// ─── I/O wrappers ─────────────────────────────────────────────────────────────
+
+export interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface RunOptions {
+  input?: string;
+  timeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+  onStdout?: (chunk: string) => void;
+  onStderr?: (chunk: string) => void;
+}
+
+export function runCommand(cmd: string, args: string[], opts: RunOptions = {}): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const spawnOpts: SpawnOptions = {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: opts.env ?? process.env,
+      cwd: opts.cwd,
+    };
+    const child = spawn(cmd, args, spawnOpts);
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timer = opts.timeoutMs
+      ? setTimeout(() => {
+          timedOut = true;
+          child.kill("SIGTERM");
+          setTimeout(() => child.kill("SIGKILL"), 2000).unref();
+        }, opts.timeoutMs)
+      : null;
+
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+      opts.onStdout?.(chunk);
+    });
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+      opts.onStderr?.(chunk);
+    });
+
+    child.on("error", (err) => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      reject(err);
+    });
+    child.on("close", (code) => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      if (timedOut) {
+        return reject(new Error(`${cmd} ${args.join(" ")} timed out after ${opts.timeoutMs}ms`));
+      }
+      resolve({ code: code ?? -1, stdout, stderr });
+    });
+
+    if (opts.input !== undefined) {
+      child.stdin?.write(opts.input);
+      child.stdin?.end();
+    }
+  });
+}
+
+function expectSuccess(label: string, result: RunResult): RunResult {
+  if (result.code !== 0) {
+    const detail = (result.stderr || result.stdout).trim();
+    throw new Error(`${label} failed (exit ${result.code}): ${detail}`);
+  }
+  return result;
+}
+
+// ─── High-level smolvm lifecycle ──────────────────────────────────────────────
+
+// Create a named VM and start it. We need the named/persistent path because
+// the job orchestration execs into the VM multiple times across boot.
+// Pass `image` to pull from a registry, or `fromPack` to instantiate from a
+// pre-built .smolmachine artifact (faster + dodges per-VM network pulls).
+export async function createAndStart(
+  name: string,
+  source: { image: string } | { fromPack: string },
+  opts: Omit<CreateMachineOptions, "image" | "fromPack"> = {},
+): Promise<void> {
+  const [cCmd, cArgs] = createMachineArgs(name, { ...opts, ...source });
+  expectSuccess(`smolvm machine create ${name}`, await runCommand(cCmd, cArgs));
+  const [sCmd, sArgs] = startArgs(name);
+  expectSuccess(`smolvm machine start ${name}`, await runCommand(sCmd, sArgs));
+}
+
+// Pack an OCI image into a .smolmachine if not already cached. `basePath` is
+// the prefix (without extension); smolvm produces TWO files:
+//   - <basePath>             — self-contained launcher executable (~30MB)
+//   - <basePath>.smolmachine — the artifact `machine create --from` wants
+// We always return the .smolmachine sidecar path and treat its presence as
+// the cache hit. Idempotent. Caller is responsible for cache eviction.
+export async function packImageIfMissing(image: string, basePath: string): Promise<string> {
+  const fs = await import("node:fs");
+  const sidecar = `${basePath}.smolmachine`;
+  if (fs.existsSync(sidecar)) {
+    return sidecar;
+  }
+  const fsp = await import("node:fs/promises");
+  const path = await import("node:path");
+  await fsp.mkdir(path.dirname(basePath), { recursive: true });
+  const [cmd, args] = packCreateArgs(image, basePath);
+  expectSuccess(`smolvm pack create ${image}`, await runCommand(cmd, args, { timeoutMs: 600_000 }));
+  return sidecar;
+}
+
+export async function exec(
+  name: string,
+  cmd: string[],
+  opts: ExecOptions & { timeoutMs?: number; input?: string } = {},
+): Promise<RunResult> {
+  const [bin, args] = execArgs(name, cmd, opts);
+  return runCommand(bin, args, { input: opts.input, timeoutMs: opts.timeoutMs });
+}
+
+// Run a shell script via `exec -i -- bash -s` with the script piped to stdin.
+// Same quoting-safe pattern as the tart adapter — heredoc-via-stdin avoids
+// argv-joining traps.
+export async function execScript(
+  name: string,
+  script: string,
+  opts: { timeoutMs?: number; onStdout?: (c: string) => void; onStderr?: (c: string) => void } = {},
+): Promise<RunResult> {
+  const [bin, args] = execArgs(name, ["bash", "-s"], { interactive: true });
+  return runCommand(bin, args, {
+    input: script,
+    timeoutMs: opts.timeoutMs,
+    onStdout: opts.onStdout,
+    onStderr: opts.onStderr,
+  });
+}
+
+export async function stop(name: string): Promise<void> {
+  const [cmd, args] = stopArgs(name);
+  await runCommand(cmd, args, { timeoutMs: 30_000 });
+}
+
+export async function destroy(name: string): Promise<void> {
+  const [cmd, args] = deleteArgs(name);
+  await runCommand(cmd, args, { timeoutMs: 10_000 });
+}
+
+export async function listMachines(): Promise<string[]> {
+  const [cmd, args] = listArgs();
+  const r = await runCommand(cmd, args);
+  if (r.code !== 0) {
+    return [];
+  }
+  try {
+    const rows = JSON.parse(r.stdout) as Array<{ name?: string; Name?: string }>;
+    return rows.map((row) => row.name ?? row.Name ?? "").filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+// Spawn an attached `machine run` (ephemeral). Useful for smoke tests where
+// the caller wants to stream output of a one-shot command.
+export function runEphemeralAttached(
+  image: string,
+  command: string[] = [],
+  opts: RunEphemeralOptions = {},
+): ChildProcess {
+  const [cmd, args] = runEphemeralArgs(image, command, opts);
+  return spawn(cmd, args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: process.env,
+    detached: false,
+  });
+}

--- a/packages/cli/src/runner/smolvm/smolvm.ts
+++ b/packages/cli/src/runner/smolvm/smolvm.ts
@@ -10,7 +10,7 @@ import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process"
 // We need persistent VMs so we can exec into them across the job lifecycle,
 // so the high-level `runMachine` below composes create + start.
 //
-// CLI surface verified against smolvm 0.5.19. See:
+// CLI surface verified against smolvm 0.5.20. See:
 //   https://github.com/smol-machines/smolvm
 
 export interface CreateMachineOptions {


### PR DESCRIPTION
## Problem

Docker's shared-kernel model limits the isolation we can offer for Linux jobs, and a real-VM per-job path (Hypervisor.framework on macOS, KVM on Linux) would close that gap. smolvm is a lightweight micro-VM runtime that fits the shape of agent-ci's job dispatcher.

## Solution

Adds an opt-in `AGENT_CI_BACKEND=smolvm` backend:

- `packages/cli/src/runner/smolvm/smolvm.ts` — CLI wrapper (create / start / stop / exec / delete / image pull / pack).
- `host-capability.ts` — detects whether the host can actually run smolvm (binary + platform gate), falls back to Docker otherwise.
- `image-mapping.ts` — maps the existing agent-ci image identifiers to smolvm's pack/image semantics.
- `smolvm-job.ts` — the per-job orchestrator: boot VM, seed DTU credentials, mount workspace + git shim, start `./run.sh --once` as `runner`, stream the in-VM log, tear down.
- `.github/workflows/smoke-smolvm-checkout.yml` and `smoke-smolvm-setup-node.yml` — manual smoke workflows.
- Dispatch flag wired up in `packages/cli/src/cli.ts`.
- Changeset: `minor` for `@redwoodjs/agent-ci`, `patch` for `dtu-github-actions`.

## Status — DRAFT, not ready to merge

Blocked upstream on **smol-machines/smolvm#177** (TSI silently drops idle keep-alive connections from guest to host after ~6 min). Reproduction and downstream report in redwoodjs/agent-ci#286 and issue #284.

What works today through this backend:

| | |
|---|---|
| Pure shell workflows | ✅ end-to-end |
| `actions/checkout@v4` (workspace mount + git shim) | ✅ |
| Multi-job dispatch (concurrency=1 due to smolvm SQLite single-writer) | ✅ |
| Pack-cache (1× pull, N× create) | ✅ ~18 s/job warm |
| Anything using `actions/setup-*` | ❌ deadlocks on TSI bug |

Parking this as a draft so the foundation isn't lost — it's ~10 lines of rewiring to land once the upstream networking story exists (either a TSI keep-alive fix on smolvm, a libkrun host-gateway flag, or in-VM DTU).

## Test plan

- [x] `pnpm agent-ci-dev run --all` green
- [x] `AGENT_CI_BACKEND=smolvm pnpm agent-ci-dev run --workflow .github/workflows/smoke-smolvm-hello.yml -p` passes
- [x] smoke-smolvm-checkout.yml passes end-to-end
- [x] smoke-smolvm-setup-node.yml — currently expected to fail; unblock once smolvm#177 lands
- [x] Host without smolvm installed: silent fall-back to Docker (host-capability probe)

Refs #284.