### PR TITLE
feat(cli): persist latest run result per worktree as JSON (#288)

### DIFF
--- a/.changeset/tmux-pane-run-state.md
+++ b/.changeset/tmux-pane-run-state.md
@@ -1,0 +1,10 @@
+---
+"@redwoodjs/agent-ci": minor
+"dtu-github-actions": patch
+---
+
+Persist the latest run result per worktree to `$AGENT_CI_STATE_DIR` (or OS-default state dir) as JSON, so external consumers (tmux panes, status bars, editor integrations) can read the current branch's CI status without re-running the tool or scraping human output.
+
+The file is written atomically after every `agent-ci run` / `agent-ci run --all` and keyed by `<branch>.<worktree-hash>.json` under `<org>/<repo>/`, so two worktrees on the same branch don't stomp each other. Includes `headSha` so consumers can detect stale results themselves.
+
+Closes #288

--- a/.changeset/tmux-pane-run-state.md
+++ b/.changeset/tmux-pane-run-state.md
@@ -5,6 +5,6 @@
 
 Persist the latest run result per worktree to `$AGENT_CI_STATE_DIR` (or OS-default state dir) as JSON, so external consumers (tmux panes, status bars, editor integrations) can read the current branch's CI status without re-running the tool or scraping human output.
 
-The file is written atomically after every `agent-ci run` / `agent-ci run --all` and keyed by `<branch>.<worktree-hash>.json` under `<org>/<repo>/`, so two worktrees on the same branch don't stomp each other. Each job entry carries the full step list with per-step `logPath`, plus `debugLogPath` for the whole job and `failingStepLogPath` when a step fails. Paths are only included when the file still exists at write time. Includes `headSha` so consumers can detect stale results themselves.
+The file is written atomically after every `agent-ci run` / `agent-ci run --all` and keyed by `<branch>.<worktree-hash>.json` under `<org>/<repo>/`, so two worktrees on the same branch don't stomp each other. Each job entry carries the full step list with per-step `logPath`, plus `debugLogPath` for the whole job. Paths are only included when the file still exists at write time. Includes `headSha` so consumers can detect stale results themselves.
 
 Closes #288

--- a/.changeset/tmux-pane-run-state.md
+++ b/.changeset/tmux-pane-run-state.md
@@ -5,6 +5,6 @@
 
 Persist the latest run result per worktree to `$AGENT_CI_STATE_DIR` (or OS-default state dir) as JSON, so external consumers (tmux panes, status bars, editor integrations) can read the current branch's CI status without re-running the tool or scraping human output.
 
-The file is written atomically after every `agent-ci run` / `agent-ci run --all` and keyed by `<branch>.<worktree-hash>.json` under `<org>/<repo>/`, so two worktrees on the same branch don't stomp each other. Includes `headSha` so consumers can detect stale results themselves.
+The file is written atomically after every `agent-ci run` / `agent-ci run --all` and keyed by `<branch>.<worktree-hash>.json` under `<org>/<repo>/`, so two worktrees on the same branch don't stomp each other. Each job entry carries the full step list with per-step `logPath`, plus `debugLogPath` for the whole job and `failingStepLogPath` when a step fails. Paths are only included when the file still exists at write time. Includes `headSha` so consumers can detect stale results themselves.
 
 Closes #288

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -68,6 +68,7 @@ import { isAgentMode, setQuietMode } from "./output/agent-mode.js";
 import { createDiffRenderer } from "./output/diff-renderer.js";
 import { createFailedJobResult, wrapJobError, isJobError } from "./runner/job-result.js";
 import { postCommitStatus } from "./commit-status.js";
+import { writeRunResult } from "./run-result-writer.js";
 
 function findSignalsDir(runnerName: string): string | null {
   const workDir = getWorkingDirectory();
@@ -226,6 +227,7 @@ async function run() {
         process.exit(0);
       }
 
+      const startedAt = new Date();
       const results = await runWorkflows({
         workflowPaths: relevant,
         sha,
@@ -241,6 +243,7 @@ async function run() {
       if (commitStatus) {
         postCommitStatus(results, sha, githubToken);
       }
+      persistRunResult({ results, repoRoot, startedAt, sha, branch });
       const anyFailed = results.length === 0 || results.some((r) => !r.succeeded);
       process.exit(anyFailed ? 1 : 0);
     }
@@ -254,11 +257,11 @@ async function run() {
 
     // Resolve workflow path before calling runWorkflows
     let workflowPath: string;
+    const repoRootFallback = resolveRepoRoot();
     if (path.isAbsolute(workflow)) {
       workflowPath = workflow;
     } else {
       const cwd = process.cwd();
-      const repoRootFallback = resolveRepoRoot();
       const workflowsDir = path.resolve(repoRootFallback, ".github", "workflows");
       const pathsToTry = [
         path.resolve(cwd, workflow),
@@ -268,6 +271,7 @@ async function run() {
       workflowPath = pathsToTry.find((p) => fs.existsSync(p)) || pathsToTry[1];
     }
 
+    const startedAt = new Date();
     const results = await runWorkflows({
       workflowPaths: [workflowPath],
       sha,
@@ -283,6 +287,7 @@ async function run() {
     if (commitStatus) {
       postCommitStatus(results, sha, githubToken);
     }
+    persistRunResult({ results, repoRoot: repoRootFallback, startedAt, sha });
     if (results.length === 0 || results.some((r) => !r.succeeded)) {
       process.exit(1);
     }
@@ -1537,6 +1542,35 @@ function resolveHeadSha(repoRoot: string, sha: string) {
     };
   } catch {
     throw new Error(`Failed to resolve ref: ${sha}`);
+  }
+}
+
+function persistRunResult(opts: {
+  results: JobResult[];
+  repoRoot: string;
+  startedAt: Date;
+  sha?: string;
+  branch?: string;
+}): void {
+  try {
+    const repo = config.GITHUB_REPO ?? resolveRepoSlug(opts.repoRoot);
+    const branch =
+      opts.branch ??
+      execSync("git rev-parse --abbrev-ref HEAD", { cwd: opts.repoRoot }).toString().trim();
+    const headSha = (
+      opts.sha ?? execSync("git rev-parse HEAD", { cwd: opts.repoRoot }).toString()
+    ).trim();
+    writeRunResult({
+      repo,
+      branch,
+      worktreePath: opts.repoRoot,
+      headSha,
+      startedAt: opts.startedAt,
+      finishedAt: new Date(),
+      results: opts.results,
+    });
+  } catch {
+    // Best-effort: never let result persistence fail the run.
   }
 }
 

--- a/packages/cli/src/output/reporter.ts
+++ b/packages/cli/src/output/reporter.ts
@@ -5,6 +5,8 @@ import fs from "fs";
 export interface StepResult {
   name: string;
   status: "passed" | "failed" | "skipped";
+  /** Absolute path to `<logDir>/steps/<id>.log`. File is deleted after passing runs. */
+  logPath?: string;
 }
 
 export interface JobResult {

--- a/packages/cli/src/run-result-writer.test.ts
+++ b/packages/cli/src/run-result-writer.test.ts
@@ -1,0 +1,213 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { JobResult } from "./output/reporter.js";
+import {
+  buildRunResultJson,
+  resolveRunResultPath,
+  resolveStateDir,
+  RUN_RESULT_SCHEMA_VERSION,
+  worktreePathHash,
+  writeRunResult,
+} from "./run-result-writer.js";
+
+function job(overrides: Partial<JobResult> = {}): JobResult {
+  return {
+    name: "job",
+    workflow: "test.yml",
+    taskId: "task",
+    succeeded: true,
+    durationMs: 1000,
+    debugLogPath: "/dev/null",
+    ...overrides,
+  };
+}
+
+describe("resolveStateDir", () => {
+  it("honors AGENT_CI_STATE_DIR verbatim", () => {
+    expect(resolveStateDir({ AGENT_CI_STATE_DIR: "/custom/path" }, "linux")).toBe("/custom/path");
+    expect(resolveStateDir({ AGENT_CI_STATE_DIR: "/custom/path" }, "darwin")).toBe("/custom/path");
+  });
+
+  it("uses Library/Application Support on macOS", () => {
+    expect(resolveStateDir({ HOME: "/Users/alice" }, "darwin")).toBe(
+      "/Users/alice/Library/Application Support/agent-ci",
+    );
+  });
+
+  it("uses $XDG_STATE_HOME/agent-ci on Linux when set", () => {
+    expect(resolveStateDir({ HOME: "/home/alice", XDG_STATE_HOME: "/state" }, "linux")).toBe(
+      "/state/agent-ci",
+    );
+  });
+
+  it("falls back to ~/.local/state/agent-ci on Linux", () => {
+    expect(resolveStateDir({ HOME: "/home/alice" }, "linux")).toBe(
+      "/home/alice/.local/state/agent-ci",
+    );
+  });
+});
+
+describe("worktreePathHash", () => {
+  it("is deterministic for the same path", () => {
+    expect(worktreePathHash("/a/b")).toBe(worktreePathHash("/a/b"));
+  });
+
+  it("differs across paths", () => {
+    expect(worktreePathHash("/a/b")).not.toBe(worktreePathHash("/a/c"));
+  });
+
+  it("is 8 hex chars", () => {
+    expect(worktreePathHash("/a/b")).toMatch(/^[0-9a-f]{8}$/);
+  });
+});
+
+describe("resolveRunResultPath", () => {
+  it("disambiguates two worktrees on the same branch", () => {
+    const a = resolveRunResultPath("/state", "org/repo", "main", "/wt/a");
+    const b = resolveRunResultPath("/state", "org/repo", "main", "/wt/b");
+    expect(a).not.toBe(b);
+    expect(path.dirname(a)).toBe("/state/org/repo");
+  });
+
+  it("sanitizes slashes in branch names into dashes", () => {
+    const p = resolveRunResultPath("/state", "org/repo", "feat/foo", "/wt");
+    expect(path.basename(p)).toMatch(/^feat-foo\.[0-9a-f]{8}\.json$/);
+  });
+});
+
+describe("buildRunResultJson", () => {
+  const base = {
+    repo: "org/repo",
+    branch: "main",
+    worktreePath: "/wt",
+    headSha: "abc123",
+    startedAt: new Date("2026-04-20T10:15:00Z"),
+    finishedAt: new Date("2026-04-20T10:17:42Z"),
+  };
+
+  it("marks run passed only when every job passed", () => {
+    const r1 = buildRunResultJson({ ...base, results: [job(), job()] });
+    expect(r1.status).toBe("passed");
+    const r2 = buildRunResultJson({ ...base, results: [job(), job({ succeeded: false })] });
+    expect(r2.status).toBe("failed");
+  });
+
+  it("emits the documented schema shape", () => {
+    const out = buildRunResultJson({
+      ...base,
+      results: [
+        job({ name: "lint", succeeded: true, durationMs: 4123 }),
+        job({ name: "test", succeeded: false, durationMs: 18210, failedStep: "run tests" }),
+      ],
+    });
+    expect(out).toEqual({
+      schemaVersion: RUN_RESULT_SCHEMA_VERSION,
+      repo: "org/repo",
+      branch: "main",
+      worktreePath: "/wt",
+      headSha: "abc123",
+      startedAt: "2026-04-20T10:15:00.000Z",
+      finishedAt: "2026-04-20T10:17:42.000Z",
+      status: "failed",
+      jobs: [
+        { name: "lint", workflow: "test.yml", status: "passed", durationMs: 4123 },
+        {
+          name: "test",
+          workflow: "test.yml",
+          status: "failed",
+          durationMs: 18210,
+          failingStep: "run tests",
+        },
+      ],
+    });
+  });
+
+  it("omits failingStep when none is set", () => {
+    const out = buildRunResultJson({ ...base, results: [job({ succeeded: false })] });
+    expect(out.jobs[0]).not.toHaveProperty("failingStep");
+  });
+});
+
+describe("writeRunResult", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-ci-state-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("writes parseable JSON at the expected path", () => {
+    const out = writeRunResult(
+      {
+        repo: "org/repo",
+        branch: "main",
+        worktreePath: "/wt",
+        headSha: "abc",
+        startedAt: new Date(0),
+        finishedAt: new Date(1000),
+        results: [job()],
+      },
+      { stateDir },
+    );
+    expect(out).not.toBeNull();
+    const parsed = JSON.parse(fs.readFileSync(out!, "utf-8"));
+    expect(parsed.schemaVersion).toBe(RUN_RESULT_SCHEMA_VERSION);
+    expect(parsed.repo).toBe("org/repo");
+    expect(parsed.status).toBe("passed");
+  });
+
+  it("overwrites the previous run result for the same worktree", () => {
+    const common = {
+      repo: "org/repo",
+      branch: "main",
+      worktreePath: "/wt",
+      headSha: "abc",
+      startedAt: new Date(0),
+      finishedAt: new Date(1000),
+    };
+    const first = writeRunResult({ ...common, results: [job({ succeeded: false })] }, { stateDir });
+    const second = writeRunResult({ ...common, results: [job()] }, { stateDir });
+    expect(first).toBe(second);
+    const parsed = JSON.parse(fs.readFileSync(second!, "utf-8"));
+    expect(parsed.status).toBe("passed");
+  });
+
+  it("leaves no tmp file behind on success", () => {
+    const out = writeRunResult(
+      {
+        repo: "org/repo",
+        branch: "main",
+        worktreePath: "/wt",
+        headSha: "abc",
+        startedAt: new Date(0),
+        finishedAt: new Date(1000),
+        results: [job()],
+      },
+      { stateDir },
+    );
+    const dir = path.dirname(out!);
+    const leftover = fs.readdirSync(dir).filter((f) => f.endsWith(".tmp"));
+    expect(leftover).toEqual([]);
+  });
+
+  it("returns null on write failure without throwing", () => {
+    const out = writeRunResult(
+      {
+        repo: "org/repo",
+        branch: "main",
+        worktreePath: "/wt",
+        headSha: "abc",
+        startedAt: new Date(0),
+        finishedAt: new Date(1000),
+        results: [job()],
+      },
+      { stateDir: "/nonexistent/\0/invalid" },
+    );
+    expect(out).toBeNull();
+  });
+});

--- a/packages/cli/src/run-result-writer.test.ts
+++ b/packages/cli/src/run-result-writer.test.ts
@@ -174,14 +174,11 @@ describe("buildRunResultJson", () => {
     expect(out.jobs[0].steps).toEqual([{ name: "Setup", status: "passed" }]);
   });
 
-  it("includes debugLogPath and failingStepLogPath when files exist", () => {
+  it("includes debugLogPath when the file exists", () => {
     const logDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-ci-logs-"));
     try {
       const debugLog = path.join(logDir, "debug.log");
-      const failingLog = path.join(logDir, "steps", "Build.log");
-      fs.mkdirSync(path.dirname(failingLog), { recursive: true });
       fs.writeFileSync(debugLog, "");
-      fs.writeFileSync(failingLog, "");
 
       const out = buildRunResultJson({
         ...base,
@@ -190,19 +187,17 @@ describe("buildRunResultJson", () => {
             succeeded: false,
             debugLogPath: debugLog,
             failedStep: "Build",
-            failedStepLogPath: failingLog,
           }),
         ],
       });
 
       expect(out.jobs[0].debugLogPath).toBe(debugLog);
-      expect(out.jobs[0].failingStepLogPath).toBe(failingLog);
     } finally {
       fs.rmSync(logDir, { recursive: true, force: true });
     }
   });
 
-  it("omits debugLogPath and failingStepLogPath when files are gone", () => {
+  it("omits debugLogPath when the file is gone", () => {
     const out = buildRunResultJson({
       ...base,
       results: [
@@ -215,7 +210,6 @@ describe("buildRunResultJson", () => {
       ],
     });
     expect(out.jobs[0]).not.toHaveProperty("debugLogPath");
-    expect(out.jobs[0]).not.toHaveProperty("failingStepLogPath");
     expect(out.jobs[0].failingStep).toBe("Build");
   });
 

--- a/packages/cli/src/run-result-writer.test.ts
+++ b/packages/cli/src/run-result-writer.test.ts
@@ -19,7 +19,7 @@ function job(overrides: Partial<JobResult> = {}): JobResult {
     taskId: "task",
     succeeded: true,
     durationMs: 1000,
-    debugLogPath: "/dev/null",
+    debugLogPath: "/tmp/agent-ci-missing-debug.log",
     ...overrides,
   };
 }
@@ -127,6 +127,101 @@ describe("buildRunResultJson", () => {
   it("omits failingStep when none is set", () => {
     const out = buildRunResultJson({ ...base, results: [job({ succeeded: false })] });
     expect(out.jobs[0]).not.toHaveProperty("failingStep");
+  });
+
+  it("emits steps[] with per-step logPath when the file exists", () => {
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-ci-logs-"));
+    try {
+      const stepsDir = path.join(logDir, "steps");
+      fs.mkdirSync(stepsDir, { recursive: true });
+      const setupLog = path.join(stepsDir, "Setup.log");
+      const buildLog = path.join(stepsDir, "Build.log");
+      fs.writeFileSync(setupLog, "ok\n");
+      fs.writeFileSync(buildLog, "boom\n");
+
+      const out = buildRunResultJson({
+        ...base,
+        results: [
+          job({
+            steps: [
+              { name: "Setup", status: "passed", logPath: setupLog },
+              { name: "Build", status: "failed", logPath: buildLog },
+              { name: "Deploy", status: "skipped" },
+            ],
+          }),
+        ],
+      });
+
+      expect(out.jobs[0].steps).toEqual([
+        { name: "Setup", status: "passed", logPath: setupLog },
+        { name: "Build", status: "failed", logPath: buildLog },
+        { name: "Deploy", status: "skipped" },
+      ]);
+    } finally {
+      fs.rmSync(logDir, { recursive: true, force: true });
+    }
+  });
+
+  it("drops step logPath when the file has been cleaned up", () => {
+    const out = buildRunResultJson({
+      ...base,
+      results: [
+        job({
+          steps: [{ name: "Setup", status: "passed", logPath: "/tmp/definitely-missing.log" }],
+        }),
+      ],
+    });
+    expect(out.jobs[0].steps).toEqual([{ name: "Setup", status: "passed" }]);
+  });
+
+  it("includes debugLogPath and failingStepLogPath when files exist", () => {
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-ci-logs-"));
+    try {
+      const debugLog = path.join(logDir, "debug.log");
+      const failingLog = path.join(logDir, "steps", "Build.log");
+      fs.mkdirSync(path.dirname(failingLog), { recursive: true });
+      fs.writeFileSync(debugLog, "");
+      fs.writeFileSync(failingLog, "");
+
+      const out = buildRunResultJson({
+        ...base,
+        results: [
+          job({
+            succeeded: false,
+            debugLogPath: debugLog,
+            failedStep: "Build",
+            failedStepLogPath: failingLog,
+          }),
+        ],
+      });
+
+      expect(out.jobs[0].debugLogPath).toBe(debugLog);
+      expect(out.jobs[0].failingStepLogPath).toBe(failingLog);
+    } finally {
+      fs.rmSync(logDir, { recursive: true, force: true });
+    }
+  });
+
+  it("omits debugLogPath and failingStepLogPath when files are gone", () => {
+    const out = buildRunResultJson({
+      ...base,
+      results: [
+        job({
+          succeeded: false,
+          debugLogPath: "/tmp/gone/debug.log",
+          failedStep: "Build",
+          failedStepLogPath: "/tmp/gone/steps/Build.log",
+        }),
+      ],
+    });
+    expect(out.jobs[0]).not.toHaveProperty("debugLogPath");
+    expect(out.jobs[0]).not.toHaveProperty("failingStepLogPath");
+    expect(out.jobs[0].failingStep).toBe("Build");
+  });
+
+  it("omits steps when the job has none", () => {
+    const out = buildRunResultJson({ ...base, results: [job()] });
+    expect(out.jobs[0]).not.toHaveProperty("steps");
   });
 });
 

--- a/packages/cli/src/run-result-writer.ts
+++ b/packages/cli/src/run-result-writer.ts
@@ -6,12 +6,24 @@ import type { JobResult } from "./output/reporter.js";
 
 export const RUN_RESULT_SCHEMA_VERSION = 1;
 
+export interface RunResultStepEntry {
+  name: string;
+  status: "passed" | "failed" | "skipped";
+  /** Only present when the per-step log file still exists at write time. */
+  logPath?: string;
+}
+
 export interface RunResultJobEntry {
   name: string;
   workflow: string;
   status: "passed" | "failed";
   durationMs: number;
   failingStep?: string;
+  /** Only present when the on-disk file still exists at write time. */
+  failingStepLogPath?: string;
+  /** Only present when the on-disk file still exists at write time. */
+  debugLogPath?: string;
+  steps?: RunResultStepEntry[];
 }
 
 export interface RunResultFile {
@@ -89,14 +101,49 @@ export function resolveRunResultPath(
   );
 }
 
+/** Include a file path only when the file is still on disk — passing-job logs get cleaned up. */
+function pathIfExists(p: string | undefined): string | undefined {
+  if (!p) {
+    return undefined;
+  }
+  try {
+    return fs.existsSync(p) ? p : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function buildRunResultJson(input: RunResultInput): RunResultFile {
-  const jobs: RunResultJobEntry[] = input.results.map((r) => ({
-    name: r.name,
-    workflow: r.workflow,
-    status: r.succeeded ? "passed" : "failed",
-    durationMs: r.durationMs,
-    ...(r.failedStep ? { failingStep: r.failedStep } : {}),
-  }));
+  const jobs: RunResultJobEntry[] = input.results.map((r) => {
+    const entry: RunResultJobEntry = {
+      name: r.name,
+      workflow: r.workflow,
+      status: r.succeeded ? "passed" : "failed",
+      durationMs: r.durationMs,
+    };
+    const debugLogPath = pathIfExists(r.debugLogPath);
+    if (debugLogPath) {
+      entry.debugLogPath = debugLogPath;
+    }
+    if (r.failedStep) {
+      entry.failingStep = r.failedStep;
+    }
+    const failingStepLogPath = pathIfExists(r.failedStepLogPath);
+    if (failingStepLogPath) {
+      entry.failingStepLogPath = failingStepLogPath;
+    }
+    if (r.steps && r.steps.length > 0) {
+      entry.steps = r.steps.map((s) => {
+        const step: RunResultStepEntry = { name: s.name, status: s.status };
+        const logPath = pathIfExists(s.logPath);
+        if (logPath) {
+          step.logPath = logPath;
+        }
+        return step;
+      });
+    }
+    return entry;
+  });
   const status: "passed" | "failed" = input.results.every((r) => r.succeeded) ? "passed" : "failed";
   return {
     schemaVersion: RUN_RESULT_SCHEMA_VERSION,

--- a/packages/cli/src/run-result-writer.ts
+++ b/packages/cli/src/run-result-writer.ts
@@ -20,8 +20,6 @@ export interface RunResultJobEntry {
   durationMs: number;
   failingStep?: string;
   /** Only present when the on-disk file still exists at write time. */
-  failingStepLogPath?: string;
-  /** Only present when the on-disk file still exists at write time. */
   debugLogPath?: string;
   steps?: RunResultStepEntry[];
 }
@@ -127,10 +125,6 @@ export function buildRunResultJson(input: RunResultInput): RunResultFile {
     }
     if (r.failedStep) {
       entry.failingStep = r.failedStep;
-    }
-    const failingStepLogPath = pathIfExists(r.failedStepLogPath);
-    if (failingStepLogPath) {
-      entry.failingStepLogPath = failingStepLogPath;
     }
     if (r.steps && r.steps.length > 0) {
       entry.steps = r.steps.map((s) => {

--- a/packages/cli/src/run-result-writer.ts
+++ b/packages/cli/src/run-result-writer.ts
@@ -1,0 +1,133 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { JobResult } from "./output/reporter.js";
+
+export const RUN_RESULT_SCHEMA_VERSION = 1;
+
+export interface RunResultJobEntry {
+  name: string;
+  workflow: string;
+  status: "passed" | "failed";
+  durationMs: number;
+  failingStep?: string;
+}
+
+export interface RunResultFile {
+  schemaVersion: number;
+  repo: string;
+  branch: string;
+  worktreePath: string;
+  headSha: string;
+  startedAt: string;
+  finishedAt: string;
+  status: "passed" | "failed";
+  jobs: RunResultJobEntry[];
+}
+
+export interface RunResultInput {
+  repo: string;
+  branch: string;
+  worktreePath: string;
+  headSha: string;
+  startedAt: Date;
+  finishedAt: Date;
+  results: JobResult[];
+}
+
+export type StateDirEnv = Partial<Record<"AGENT_CI_STATE_DIR" | "XDG_STATE_HOME" | "HOME", string>>;
+
+/**
+ * Resolve the root directory for per-branch run-result JSON files.
+ *
+ * Priority:
+ *   1. `AGENT_CI_STATE_DIR` override (used as-is)
+ *   2. `$XDG_STATE_HOME/agent-ci` on Linux (falling back to `~/.local/state/agent-ci`)
+ *   3. `~/Library/Application Support/agent-ci` on macOS
+ *   4. Elsewhere: `~/.local/state/agent-ci`
+ */
+export function resolveStateDir(
+  env: StateDirEnv = process.env as StateDirEnv,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (env.AGENT_CI_STATE_DIR) {
+    return env.AGENT_CI_STATE_DIR;
+  }
+  const home = env.HOME ?? os.homedir();
+  if (platform === "darwin") {
+    return path.join(home, "Library", "Application Support", "agent-ci");
+  }
+  const xdgState = env.XDG_STATE_HOME || path.join(home, ".local", "state");
+  return path.join(xdgState, "agent-ci");
+}
+
+/** Hex-ish short hash of the absolute worktree path — disambiguates branches that are checked out in multiple worktrees. */
+export function worktreePathHash(worktreePath: string): string {
+  return crypto.createHash("sha1").update(path.resolve(worktreePath)).digest("hex").slice(0, 8);
+}
+
+/** Replace filesystem-unfriendly characters in a branch segment. Slashes become `-` so `feat/foo` lands in one file. */
+function sanitizeBranch(branch: string): string {
+  return branch.replace(/[^A-Za-z0-9._-]/g, "-");
+}
+
+/**
+ * Absolute path of the JSON file for `{repo, branch, worktreePath}`.
+ * Filename is `<branch>.<worktree-hash>.json` to disambiguate multiple worktrees on the same branch.
+ */
+export function resolveRunResultPath(
+  stateDir: string,
+  repo: string,
+  branch: string,
+  worktreePath: string,
+): string {
+  return path.join(
+    stateDir,
+    repo,
+    `${sanitizeBranch(branch)}.${worktreePathHash(worktreePath)}.json`,
+  );
+}
+
+export function buildRunResultJson(input: RunResultInput): RunResultFile {
+  const jobs: RunResultJobEntry[] = input.results.map((r) => ({
+    name: r.name,
+    workflow: r.workflow,
+    status: r.succeeded ? "passed" : "failed",
+    durationMs: r.durationMs,
+    ...(r.failedStep ? { failingStep: r.failedStep } : {}),
+  }));
+  const status: "passed" | "failed" = input.results.every((r) => r.succeeded) ? "passed" : "failed";
+  return {
+    schemaVersion: RUN_RESULT_SCHEMA_VERSION,
+    repo: input.repo,
+    branch: input.branch,
+    worktreePath: path.resolve(input.worktreePath),
+    headSha: input.headSha,
+    startedAt: input.startedAt.toISOString(),
+    finishedAt: input.finishedAt.toISOString(),
+    status,
+    jobs,
+  };
+}
+
+/**
+ * Write the run-result JSON atomically (write to `*.tmp` then rename).
+ * Returns the final file path. Never throws — a failed persist must not fail the run.
+ */
+export function writeRunResult(
+  input: RunResultInput,
+  opts: { stateDir?: string } = {},
+): string | null {
+  try {
+    const stateDir = opts.stateDir ?? resolveStateDir();
+    const filePath = resolveRunResultPath(stateDir, input.repo, input.branch, input.worktreePath);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const tmpPath = `${filePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(buildRunResultJson(input), null, 2) + "\n");
+    fs.renameSync(tmpPath, filePath);
+    return filePath;
+  } catch {
+    return null;
+  }
+}

--- a/packages/cli/src/runner/result-builder.test.ts
+++ b/packages/cli/src/runner/result-builder.test.ts
@@ -58,6 +58,42 @@ describe("parseTimelineSteps", () => {
     expect(steps).toHaveLength(1);
     expect(steps[0].name).toBe("Build");
   });
+
+  it("attaches per-step logPath when logDir is given and the file exists", async () => {
+    const { parseTimelineSteps } = await import("./result-builder.js");
+    const stepsDir = path.join(tmpDir, "steps");
+    fs.mkdirSync(stepsDir, { recursive: true });
+    // Sanitized name match
+    fs.writeFileSync(path.join(stepsDir, "Run-tests.log"), "a");
+    // Record-id fallback
+    fs.writeFileSync(path.join(stepsDir, "uuid-build.log"), "b");
+
+    const timelinePath = path.join(tmpDir, "timeline.json");
+    fs.writeFileSync(
+      timelinePath,
+      JSON.stringify([
+        { type: "Task", name: "Run tests", result: "Succeeded" },
+        { type: "Task", name: "Build", result: "Failed", id: "uuid-build" },
+        { type: "Task", name: "Deploy", result: "Skipped" },
+      ]),
+    );
+
+    const steps = parseTimelineSteps(timelinePath, tmpDir);
+    expect(steps[0].logPath).toBe(path.join(stepsDir, "Run-tests.log"));
+    expect(steps[1].logPath).toBe(path.join(stepsDir, "uuid-build.log"));
+    expect(steps[2].logPath).toBeUndefined();
+  });
+
+  it("leaves logPath undefined when logDir is omitted", async () => {
+    const { parseTimelineSteps } = await import("./result-builder.js");
+    const timelinePath = path.join(tmpDir, "timeline.json");
+    fs.writeFileSync(
+      timelinePath,
+      JSON.stringify([{ type: "Task", name: "Build", result: "Succeeded" }]),
+    );
+    const steps = parseTimelineSteps(timelinePath);
+    expect(steps[0].logPath).toBeUndefined();
+  });
 });
 
 // ── sanitizeStepName ──────────────────────────────────────────────────────────

--- a/packages/cli/src/runner/result-builder.ts
+++ b/packages/cli/src/runner/result-builder.ts
@@ -11,28 +11,50 @@ import {
 
 /**
  * Read `timeline.json` and map task records into `StepResult[]`.
+ *
+ * When `logDir` is provided, attach `logPath` to each step by locating the
+ * step's log under `<logDir>/steps/`. The DTU keys per-step log files by one
+ * of: sanitized step name, record id, or log id — we try all three and use
+ * the first that exists on disk. Passing-run log directories get cleaned up
+ * after the run, so `logPath` is only set when the file is present.
  */
-export function parseTimelineSteps(timelinePath: string): StepResult[] {
+export function parseTimelineSteps(timelinePath: string, logDir?: string): StepResult[] {
   try {
     if (!fs.existsSync(timelinePath)) {
       return [];
     }
     const records: any[] = JSON.parse(fs.readFileSync(timelinePath, "utf-8"));
+    const stepsDir = logDir ? path.join(logDir, "steps") : null;
     return records
       .filter((r: any) => r.type === "Task" && r.name)
-      .map((r: any) => ({
-        name: r.name,
-        status:
-          r.result === "Succeeded" || r.result === "succeeded"
-            ? ("passed" as const)
-            : r.result === "Failed" || r.result === "failed"
-              ? ("failed" as const)
-              : r.result === "Skipped" || r.result === "skipped"
-                ? ("skipped" as const)
-                : r.state === "completed"
-                  ? ("passed" as const)
-                  : ("skipped" as const),
-      }));
+      .map((r: any) => {
+        const step: StepResult = {
+          name: r.name,
+          status:
+            r.result === "Succeeded" || r.result === "succeeded"
+              ? ("passed" as const)
+              : r.result === "Failed" || r.result === "failed"
+                ? ("failed" as const)
+                : r.result === "Skipped" || r.result === "skipped"
+                  ? ("skipped" as const)
+                  : r.state === "completed"
+                    ? ("passed" as const)
+                    : ("skipped" as const),
+        };
+        if (stepsDir) {
+          for (const id of [sanitizeStepName(r.name), r.id, r.log?.id]) {
+            if (!id) {
+              continue;
+            }
+            const candidate = path.join(stepsDir, `${id}.log`);
+            if (fs.existsSync(candidate)) {
+              step.logPath = candidate;
+              break;
+            }
+          }
+        }
+        return step;
+      });
   } catch {
     return [];
   }
@@ -290,7 +312,7 @@ export function buildJobResult(opts: BuildJobResultOpts): JobResult {
     stepOutputs,
   } = opts;
 
-  const steps = parseTimelineSteps(timelinePath);
+  const steps = parseTimelineSteps(timelinePath, logDir);
   const result: JobResult = {
     name: containerName,
     workflow: job.workflowPath ? path.basename(job.workflowPath) : "unknown",


### PR DESCRIPTION
## Problem

There is no easy way to see the current branch's CI status from outside `agent-ci` itself. If you want the latest result in a tmux pane, a status bar, or an editor plugin, you either have to run the tool again or scrape its human-readable output.

Closes #288.

## Solution

After every `agent-ci run` (and `run --all`), write the final result to a JSON file at a well-known path. External tools can then just read that file.

1. The file lives under a per-user state directory: `$AGENT_CI_STATE_DIR` if set, otherwise `~/Library/Application Support/agent-ci` on macOS, or `$XDG_STATE_HOME/agent-ci` (falling back to `~/.local/state/agent-ci`) on other systems.
2. The file name is `<branch>.<worktree-hash>.json` inside a `<org>/<repo>/` folder. The worktree hash keeps two worktrees on the same branch from overwriting each other.
3. The write is atomic: we write to a temporary file and rename it into place, so a reader never sees a half-written file.
4. The JSON includes the commit that was tested (`headSha`), so readers can decide for themselves whether the result is still current. We do not write a "running" state or a crash marker; consumers check the SHA instead.
5. Each job entry carries the full step list with per-step `logPath`, plus a job-level `debugLogPath`. When a step fails, the job entry also gets `failingStep` (the step name), and the matching step in `steps[]` keeps its own `logPath`. Path fields are only included when the file is still on disk at write time, so consumers never see dangling paths after a passing run cleans up its logs.

## What the file looks like

Path on macOS:

```
~/Library/Application Support/agent-ci/redwoodjs/agent-ci/pp-add-288-branch-run-results.f67561ba.json
```

A real entry from this branch (trimmed to one job):

```json
{
  "schemaVersion": 1,
  "repo": "redwoodjs/agent-ci",
  "branch": "pp-add-288-branch-run-results",
  "worktreePath": "/Users/peterp/wt/redwoodjs/agent-ci.git/pp-add-288-branch-run-results",
  "headSha": "7b9654b82ff634fd9197ba21b524eedc2fdbe6db",
  "startedAt": "2026-04-22T08:19:40.649Z",
  "finishedAt": "2026-04-22T08:28:10.288Z",
  "status": "passed",
  "jobs": [
    {
      "name": "agent-ci-1192-j1",
      "workflow": "cache.yml",
      "status": "passed",
      "durationMs": 12949,
      "debugLogPath": "/var/folders/.../agent-ci-1192-j1/logs/debug.log",
      "steps": [
        { "name": "Set up job", "status": "passed",
          "logPath": "/var/folders/.../agent-ci-1192-j1/logs/steps/Set-up-job.log" },
        { "name": "Run actions/checkout@v4", "status": "passed",
          "logPath": "/var/folders/.../agent-ci-1192-j1/logs/steps/Run-actions-checkout-v4.log" },
        { "name": "Run pnpm install", "status": "passed",
          "logPath": "/var/folders/.../agent-ci-1192-j1/logs/steps/Run-pnpm-install.log" },
        { "name": "Complete job", "status": "passed",
          "logPath": "/var/folders/.../agent-ci-1192-j1/logs/steps/Complete-job.log" }
      ]
    }
  ]
}
```

When a job fails, its entry gains `failingStep` (the step name). To get the log for that failing step, look it up in `steps[]` — the matching entry's `logPath` is the one you want. Skipped steps appear in `steps[]` with no `logPath`.

## Test plan

- [x] Unit tests in `run-result-writer.test.ts` covering path resolution per platform, the env override, worktree-hash disambiguation, atomic rename, step-list shape, and path fields being dropped when the file is gone
- [x] Unit tests in `runner/result-builder.test.ts` for `parseTimelineSteps` attaching per-step `logPath` via sanitized-name and record-id fallbacks
- [x] Full `@redwoodjs/agent-ci` test suite — 670 passing
- [x] `pnpm agent-ci-dev run --all` — all 39 jobs pass, exit 0
- [x] End-to-end check: the file on disk carries `steps[]` with `logPath` for every step, plus `debugLogPath` for each job