### PR TITLE
Load AGENT_CI_* config from .env.agent-ci; rename DOCKER_HOST to AGENT_CI_DOCKER_HOST

### DIFF
--- a/.changeset/rename-docker-host-to-agent-ci-docker-host.md
+++ b/.changeset/rename-docker-host-to-agent-ci-docker-host.md
@@ -1,0 +1,12 @@
+---
+"@redwoodjs/agent-ci": major
+"dtu-github-actions": major
+---
+
+Rename `DOCKER_HOST` to `AGENT_CI_DOCKER_HOST` and load `AGENT_CI_*` vars from `.env.agent-ci`.
+
+**Breaking:** agent-ci no longer honours the standard `DOCKER_HOST` env var. If it is set in the shell, agent-ci exits immediately with an error asking you to rename it. Rename it in your shell (or move it to `.env.agent-ci`) as `AGENT_CI_DOCKER_HOST`. This avoids the long-standing collision where users wanted agent-ci to target one daemon (e.g. a Lima/OrbStack VM) while their shell's `docker` CLI targeted another.
+
+**New:** `AGENT_CI_*`-prefixed keys in `.env.agent-ci` are now loaded into the CLI process environment at startup, so Docker/network configuration (e.g. `AGENT_CI_DOCKER_HOST`, `AGENT_CI_DTU_HOST`, `AGENT_CI_DOCKER_EXTRA_HOSTS`) no longer has to be exported in the shell. Shell env vars still take precedence over `.env.agent-ci`. Non-prefixed keys in the file remain workflow secrets (`${{ secrets.FOO }}`) as before.
+
+Closes #308.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -157,6 +157,8 @@ If a workflow references a var (`${{ vars.FOO }}`) and no matching `--var FOO=..
 
 All configuration is available via environment variables. For persistent machine-local overrides, create a `.env.agent-ci` file in your project root — Agent CI loads it automatically (`KEY=VALUE` syntax, `#` comments supported).
 
+Only `AGENT_CI_*`-prefixed keys from `.env.agent-ci` are applied to the CLI process environment (so they influence Docker/network resolution, etc.). Non-prefixed keys in the file are still resolved as workflow secrets via `${{ secrets.FOO }}`. Shell environment variables always take precedence over `.env.agent-ci` entries.
+
 ### General
 
 | Variable                | Default                         | Description                                                                                                               |
@@ -168,14 +170,14 @@ All configuration is available via environment variables. For persistent machine
 
 ### Docker
 
-| Variable                                      | Default                             | Description                                                                                           |
-| --------------------------------------------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `DOCKER_HOST`                                 | `unix:///var/run/docker.sock`       | Docker daemon socket or URL. Set to `ssh://user@host` to use a remote daemon.                         |
-| `AGENT_CI_DTU_HOST`                           | `host.docker.internal`              | Hostname or IP that runner containers use to reach the DTU mock server on the host.                   |
-| `AGENT_CI_DOCKER_EXTRA_HOSTS`                 | `host.docker.internal:host-gateway` | Comma-separated `host:ip` entries passed to Docker `ExtraHosts`. Fully replaces the default when set. |
-| `AGENT_CI_DOCKER_HOST_GATEWAY`                | `host-gateway`                      | Override the default `host-gateway` token or IP for the automatic host mapping.                       |
-| `AGENT_CI_DOCKER_DISABLE_DEFAULT_EXTRA_HOSTS` | unset                               | Set to `1` to disable the default `host.docker.internal` mapping.                                     |
-| `AGENT_CI_DOCKER_BRIDGE_GATEWAY`              | auto-detected                       | Fallback gateway IP when Agent CI runs inside Docker and cannot detect its container IP.              |
+| Variable                                      | Default                             | Description                                                                                                                                                                                                       |
+| --------------------------------------------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AGENT_CI_DOCKER_HOST`                        | `unix:///var/run/docker.sock`       | Docker daemon socket or URL. Set to `ssh://user@host` or `tcp://…` to use a remote daemon. **Note:** the standard `DOCKER_HOST` env var is not honoured — setting it causes agent-ci to exit with a rename error. |
+| `AGENT_CI_DTU_HOST`                           | `host.docker.internal`              | Hostname or IP that runner containers use to reach the DTU mock server on the host.                                                                                                                               |
+| `AGENT_CI_DOCKER_EXTRA_HOSTS`                 | `host.docker.internal:host-gateway` | Comma-separated `host:ip` entries passed to Docker `ExtraHosts`. Fully replaces the default when set.                                                                                                             |
+| `AGENT_CI_DOCKER_HOST_GATEWAY`                | `host-gateway`                      | Override the default `host-gateway` token or IP for the automatic host mapping.                                                                                                                                   |
+| `AGENT_CI_DOCKER_DISABLE_DEFAULT_EXTRA_HOSTS` | unset                               | Set to `1` to disable the default `host.docker.internal` mapping.                                                                                                                                                 |
+| `AGENT_CI_DOCKER_BRIDGE_GATEWAY`              | auto-detected                       | Fallback gateway IP when Agent CI runs inside Docker and cannot detect its container IP.                                                                                                                          |
 
 ---
 
@@ -231,11 +233,13 @@ Default image mapping:
 
 ## Remote Docker
 
-Agent CI connects to Docker via the `DOCKER_HOST` environment variable. By default it uses the local socket (`unix:///var/run/docker.sock`), but you can point it at any remote Docker daemon:
+Agent CI connects to Docker via the `AGENT_CI_DOCKER_HOST` environment variable. By default it uses the local socket (`unix:///var/run/docker.sock`), but you can point it at any remote Docker daemon:
 
 ```bash
-DOCKER_HOST=ssh://user@remote-server npx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml
+AGENT_CI_DOCKER_HOST=ssh://user@remote-server npx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml
 ```
+
+> **Note:** the standard `DOCKER_HOST` env var is **not** honoured. If you have it set for the regular Docker CLI, agent-ci exits with an error asking you to rename to `AGENT_CI_DOCKER_HOST`. This lets agent-ci target a different daemon than your shell's `docker` CLI without the two colliding — and it lets the value live in `.env.agent-ci`.
 
 ### Docker host resolution for job containers
 
@@ -253,7 +257,7 @@ If your setup is custom, use environment overrides:
 - `AGENT_CI_DOCKER_DISABLE_DEFAULT_EXTRA_HOSTS=1` — disable the default `host.docker.internal` mapping
 - `AGENT_CI_DOCKER_BRIDGE_GATEWAY` — fallback gateway IP used when Agent CI runs inside Docker and cannot detect its container IP, and as an explicit DTU host override outside Docker when `AGENT_CI_DTU_HOST` is not set
 
-When using a remote daemon (`DOCKER_HOST=ssh://...`), `host-gateway` resolves relative to the remote Docker host. If DTU is not reachable from that host, set `AGENT_CI_DTU_HOST` and `AGENT_CI_DOCKER_EXTRA_HOSTS` explicitly for your network.
+When using a remote daemon (`AGENT_CI_DOCKER_HOST=ssh://...`), `host-gateway` resolves relative to the remote Docker host. If DTU is not reachable from that host, set `AGENT_CI_DTU_HOST` and `AGENT_CI_DOCKER_EXTRA_HOSTS` explicitly for your network.
 
 ---
 

--- a/packages/cli/docs/docker-socket.md
+++ b/packages/cli/docs/docker-socket.md
@@ -51,13 +51,21 @@ Why the top-level `~/.colima/docker.sock` and not `~/.colima/<profile>/docker.so
 
 ### Rootless Docker / custom locations
 
-If your daemon's socket lives somewhere else (e.g. `/run/user/1000/docker.sock` for rootless), set `DOCKER_HOST` explicitly:
+If your daemon's socket lives somewhere else (e.g. `/run/user/1000/docker.sock` for rootless), set `AGENT_CI_DOCKER_HOST` explicitly:
 
 ```sh
-export DOCKER_HOST=unix:///run/user/1000/docker.sock
+export AGENT_CI_DOCKER_HOST=unix:///run/user/1000/docker.sock
 ```
 
-agent-ci honours `DOCKER_HOST` ahead of `/var/run/docker.sock` and uses your explicit path for both the API client and the container bind-mount.
+Or, persistently, add it to `.env.agent-ci` at the repo root:
+
+```
+AGENT_CI_DOCKER_HOST=unix:///run/user/1000/docker.sock
+```
+
+agent-ci honours `AGENT_CI_DOCKER_HOST` ahead of `/var/run/docker.sock` and uses your explicit path for both the API client and the container bind-mount.
+
+> **Note:** the standard `DOCKER_HOST` env var is **not** honoured by agent-ci. If you have it set in your shell for the regular Docker CLI, agent-ci will exit with an error asking you to rename to `AGENT_CI_DOCKER_HOST`. This avoids collisions between "what agent-ci should target" (often a Lima/OrbStack VM) and "what the shell's Docker CLI targets".
 
 ## Diagnosing "but it's right there"
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,7 +2,7 @@
 import { execSync } from "child_process";
 import path from "path";
 import fs from "fs";
-import { config, loadMachineSecrets, resolveRepoSlug } from "./config.js";
+import { applyAgentCiEnv, config, loadMachineSecrets, resolveRepoSlug } from "./config.js";
 import { getNextLogNum } from "./output/logger.js";
 import {
   setWorkingDirectory,
@@ -87,6 +87,24 @@ function findSignalsDir(runnerName: string): string | null {
 }
 
 async function run() {
+  // Bootstrap: `.env.agent-ci` (AGENT_CI_* keys only) → process.env, shell wins.
+  applyAgentCiEnv(resolveRepoRoot());
+
+  // DOCKER_HOST was removed in favor of AGENT_CI_DOCKER_HOST so that the value
+  // can live in .env.agent-ci without colliding with the shell's expectation
+  // that DOCKER_HOST points at the real Docker daemon.
+  if (process.env.DOCKER_HOST) {
+    console.error(
+      "[Agent CI] Error: DOCKER_HOST is no longer supported.\n" +
+        "  Rename it to AGENT_CI_DOCKER_HOST (shell env or .env.agent-ci).",
+    );
+    process.exit(1);
+  }
+  if (process.env.AGENT_CI_DOCKER_HOST) {
+    // Forward to DOCKER_HOST so dockerode's default client picks it up.
+    process.env.DOCKER_HOST = process.env.AGENT_CI_DOCKER_HOST;
+  }
+
   const args = process.argv.slice(2);
   const command = args[0];
 

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -4,6 +4,7 @@ import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  applyAgentCiEnv,
   config,
   getFirstRemoteUrl,
   loadMachineSecrets,
@@ -278,5 +279,89 @@ describe("loadMachineSecrets", () => {
 
     const secrets = loadMachineSecrets(dir, ["FROM_FILE", "FROM_ENV"]);
     expect(secrets).toEqual({ FROM_FILE: "file-val", FROM_ENV: "env-val" });
+  });
+});
+
+// ─── applyAgentCiEnv ─────────────────────────────────────────────────────────
+
+describe("applyAgentCiEnv", () => {
+  let tmpDir: string;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  function saveEnv(...keys: string[]) {
+    for (const k of keys) {
+      savedEnv[k] = process.env[k];
+    }
+  }
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = v;
+      }
+    }
+    for (const k of Object.keys(savedEnv)) {
+      delete savedEnv[k];
+    }
+  });
+
+  function writeEnvFile(content: string): string {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-ci-env-"));
+    fs.writeFileSync(path.join(tmpDir, ".env.agent-ci"), content);
+    return tmpDir;
+  }
+
+  it("does nothing when .env.agent-ci is missing", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-ci-env-"));
+    tmpDir = dir;
+    saveEnv("AGENT_CI_DOCKER_HOST");
+    delete process.env.AGENT_CI_DOCKER_HOST;
+
+    applyAgentCiEnv(dir);
+
+    expect(process.env.AGENT_CI_DOCKER_HOST).toBeUndefined();
+  });
+
+  it("copies AGENT_CI_* keys from file into process.env", () => {
+    const dir = writeEnvFile(
+      "AGENT_CI_DOCKER_HOST=unix:///tmp/foo.sock\nAGENT_CI_DTU_HOST=10.0.0.1\n",
+    );
+    saveEnv("AGENT_CI_DOCKER_HOST", "AGENT_CI_DTU_HOST");
+    delete process.env.AGENT_CI_DOCKER_HOST;
+    delete process.env.AGENT_CI_DTU_HOST;
+
+    applyAgentCiEnv(dir);
+
+    expect(process.env.AGENT_CI_DOCKER_HOST).toBe("unix:///tmp/foo.sock");
+    expect(process.env.AGENT_CI_DTU_HOST).toBe("10.0.0.1");
+  });
+
+  it("does not overwrite values already set in process.env", () => {
+    const dir = writeEnvFile("AGENT_CI_DOCKER_HOST=from-file\n");
+    saveEnv("AGENT_CI_DOCKER_HOST");
+    process.env.AGENT_CI_DOCKER_HOST = "from-shell";
+
+    applyAgentCiEnv(dir);
+
+    expect(process.env.AGENT_CI_DOCKER_HOST).toBe("from-shell");
+  });
+
+  it("ignores keys that do not start with AGENT_CI_", () => {
+    const dir = writeEnvFile("MY_TOKEN=secret\nFOO=bar\nAGENT_CI_X=y\n");
+    saveEnv("MY_TOKEN", "FOO", "AGENT_CI_X");
+    delete process.env.MY_TOKEN;
+    delete process.env.FOO;
+    delete process.env.AGENT_CI_X;
+
+    applyAgentCiEnv(dir);
+
+    expect(process.env.MY_TOKEN).toBeUndefined();
+    expect(process.env.FOO).toBeUndefined();
+    expect(process.env.AGENT_CI_X).toBe("y");
   });
 });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -63,6 +63,36 @@ export const config: {
   GITHUB_API_URL: process.env.GITHUB_API_URL || "http://localhost:8910",
 };
 
+function parseEnvFile(filePath: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  if (!fs.existsSync(filePath)) {
+    return result;
+  }
+  const lines = fs.readFileSync(filePath, "utf-8").split("\n");
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx < 1) {
+      continue;
+    }
+    const key = trimmed.slice(0, eqIdx).trim();
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (key) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
 /**
  * Load machine-local secrets from `.env.agent-ci` at the given base directory.
  * The file uses KEY=VALUE syntax (lines starting with # are ignored).
@@ -78,32 +108,7 @@ export function loadMachineSecrets(
   envFallbackKeys?: string[],
 ): Record<string, string> {
   const envMachinePath = path.join(baseDir ?? PROJECT_ROOT, ".env.agent-ci");
-  const secrets: Record<string, string> = {};
-  if (fs.existsSync(envMachinePath)) {
-    const lines = fs.readFileSync(envMachinePath, "utf-8").split("\n");
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith("#")) {
-        continue;
-      }
-      const eqIdx = trimmed.indexOf("=");
-      if (eqIdx < 1) {
-        continue;
-      }
-      const key = trimmed.slice(0, eqIdx).trim();
-      let value = trimmed.slice(eqIdx + 1).trim();
-      // Strip optional surrounding quotes
-      if (
-        (value.startsWith('"') && value.endsWith('"')) ||
-        (value.startsWith("'") && value.endsWith("'"))
-      ) {
-        value = value.slice(1, -1);
-      }
-      if (key) {
-        secrets[key] = value;
-      }
-    }
-  }
+  const secrets = parseEnvFile(envMachinePath);
   // Fill missing secrets from process.env (shell env vars act as fallback)
   if (envFallbackKeys) {
     for (const key of envFallbackKeys) {
@@ -113,4 +118,25 @@ export function loadMachineSecrets(
     }
   }
   return secrets;
+}
+
+/**
+ * Apply `AGENT_CI_*` entries from `.env.agent-ci` to `process.env`.
+ *
+ * Shell env wins: a key already present in `process.env` is left untouched.
+ * Only `AGENT_CI_*`-prefixed keys are copied — workflow secret values that
+ * coexist in this file stay in the file and are read via `loadMachineSecrets`.
+ */
+export function applyAgentCiEnv(baseDir?: string): void {
+  const envMachinePath = path.join(baseDir ?? PROJECT_ROOT, ".env.agent-ci");
+  const parsed = parseEnvFile(envMachinePath);
+  for (const [key, value] of Object.entries(parsed)) {
+    if (!key.startsWith("AGENT_CI_")) {
+      continue;
+    }
+    if (process.env[key] !== undefined) {
+      continue;
+    }
+    process.env[key] = value;
+  }
 }

--- a/packages/cli/src/docker/docker-socket.test.ts
+++ b/packages/cli/src/docker/docker-socket.test.ts
@@ -10,7 +10,7 @@ const mockedExecSync = vi.mocked(execSync);
 
 afterEach(() => {
   vi.restoreAllMocks();
-  delete process.env.DOCKER_HOST;
+  delete process.env.AGENT_CI_DOCKER_HOST;
 });
 
 async function importFresh() {
@@ -19,10 +19,10 @@ async function importFresh() {
 }
 
 describe("resolveDockerSocket", () => {
-  // ── DOCKER_HOST set ──────────────────────────────────────────────────────
+  // ── AGENT_CI_DOCKER_HOST set ──────────────────────────────────────────────────────
 
-  it("uses DOCKER_HOST when set to a unix socket that exists", async () => {
-    process.env.DOCKER_HOST = "unix:///tmp/test-docker.sock";
+  it("uses AGENT_CI_DOCKER_HOST when set to a unix socket that exists", async () => {
+    process.env.AGENT_CI_DOCKER_HOST = "unix:///tmp/test-docker.sock";
     vi.spyOn(fs, "realpathSync").mockReturnValue("/tmp/test-docker.sock");
     vi.spyOn(fs, "accessSync").mockReturnValue(undefined);
 
@@ -34,8 +34,8 @@ describe("resolveDockerSocket", () => {
     expect(result.bindMountPath).toBe("/tmp/test-docker.sock");
   });
 
-  it("uses original DOCKER_HOST path as bindMountPath even when it resolves elsewhere", async () => {
-    process.env.DOCKER_HOST = "unix:///var/run/docker.sock";
+  it("uses original AGENT_CI_DOCKER_HOST path as bindMountPath even when it resolves elsewhere", async () => {
+    process.env.AGENT_CI_DOCKER_HOST = "unix:///var/run/docker.sock";
     vi.spyOn(fs, "realpathSync").mockReturnValue("/Users/test/.docker/run/docker.sock");
     vi.spyOn(fs, "accessSync").mockReturnValue(undefined);
 
@@ -46,8 +46,8 @@ describe("resolveDockerSocket", () => {
     expect(result.bindMountPath).toBe("/var/run/docker.sock");
   });
 
-  it("returns non-unix DOCKER_HOST as-is (e.g. ssh://)", async () => {
-    process.env.DOCKER_HOST = "ssh://user@remote";
+  it("returns non-unix AGENT_CI_DOCKER_HOST as-is (e.g. ssh://)", async () => {
+    process.env.AGENT_CI_DOCKER_HOST = "ssh://user@remote";
 
     const { resolveDockerSocket } = await importFresh();
     const result = resolveDockerSocket();
@@ -57,22 +57,24 @@ describe("resolveDockerSocket", () => {
     expect(result.bindMountPath).toBe("");
   });
 
-  it("throws with doc link when DOCKER_HOST points to non-existent socket", async () => {
-    process.env.DOCKER_HOST = "unix:///nonexistent/docker.sock";
+  it("throws with doc link when AGENT_CI_DOCKER_HOST points to non-existent socket", async () => {
+    process.env.AGENT_CI_DOCKER_HOST = "unix:///nonexistent/docker.sock";
     vi.spyOn(fs, "realpathSync").mockImplementation(() => {
       throw new Error("ENOENT");
     });
 
     const { resolveDockerSocket } = await importFresh();
 
-    expect(() => resolveDockerSocket()).toThrow("DOCKER_HOST=unix:///nonexistent/docker.sock");
+    expect(() => resolveDockerSocket()).toThrow(
+      "AGENT_CI_DOCKER_HOST=unix:///nonexistent/docker.sock",
+    );
     expect(() => resolveDockerSocket()).toThrow("docs/docker-socket.md");
   });
 
   // ── Default socket path ────────────────────────────────────────────────
 
   it("resolves /var/run/docker.sock symlink", async () => {
-    delete process.env.DOCKER_HOST;
+    delete process.env.AGENT_CI_DOCKER_HOST;
     vi.spyOn(fs, "existsSync").mockReturnValue(true);
     vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
       if (String(p) === "/var/run/docker.sock") {
@@ -94,7 +96,7 @@ describe("resolveDockerSocket", () => {
   });
 
   it("uses /var/run/docker.sock as bindMountPath when it resolves to Docker Desktop path (regression #197)", async () => {
-    delete process.env.DOCKER_HOST;
+    delete process.env.AGENT_CI_DOCKER_HOST;
     vi.spyOn(fs, "existsSync").mockReturnValue(true);
     vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
       if (String(p) === "/var/run/docker.sock") {
@@ -114,7 +116,7 @@ describe("resolveDockerSocket", () => {
   // ── EACCES fallthrough ─────────────────────────────────────────────────
 
   it("falls through to docker context when default socket is not accessible, and uses /var/run/docker.sock for bind mount (regression #209)", async () => {
-    delete process.env.DOCKER_HOST;
+    delete process.env.AGENT_CI_DOCKER_HOST;
     // Exact #209 cell: Linux + Docker Desktop, user not in docker group.
     // - /var/run/docker.sock exists (owned by root:docker 660) — exists but EACCES for us
     // - Active docker context points at the Desktop socket — what our API client must use
@@ -153,7 +155,7 @@ describe("resolveDockerSocket", () => {
   // ── Missing / dangling /var/run/docker.sock ─────────────────────────────
 
   it("throws with doc link when /var/run/docker.sock is missing", async () => {
-    delete process.env.DOCKER_HOST;
+    delete process.env.AGENT_CI_DOCKER_HOST;
     vi.spyOn(fs, "existsSync").mockReturnValue(false);
     vi.spyOn(fs, "realpathSync").mockImplementation(() => {
       throw new Error("ENOENT");
@@ -167,7 +169,7 @@ describe("resolveDockerSocket", () => {
   });
 
   it("appends Docker Desktop toggle hint when ~/.docker/run/docker.sock exists but /var/run/docker.sock is missing", async () => {
-    delete process.env.DOCKER_HOST;
+    delete process.env.AGENT_CI_DOCKER_HOST;
     vi.spyOn(fs, "existsSync").mockImplementation((p) => {
       const s = String(p);
       if (s === "/var/run/docker.sock") {
@@ -194,7 +196,7 @@ describe("resolveDockerSocket", () => {
     // Regression for #263 debugging session: /var/run/docker.sock → ~/.orbstack/...
     // but OrbStack is stopped, so the link dangles. fs.existsSync returns false for
     // dangling symlinks, which is the signal we want.
-    delete process.env.DOCKER_HOST;
+    delete process.env.AGENT_CI_DOCKER_HOST;
     vi.spyOn(fs, "existsSync").mockReturnValue(false);
     vi.spyOn(fs, "realpathSync").mockImplementation(() => {
       throw new Error("ENOENT");
@@ -206,7 +208,7 @@ describe("resolveDockerSocket", () => {
   });
 
   it("throws with doc link when /var/run/docker.sock exists but EACCES and no readable context", async () => {
-    delete process.env.DOCKER_HOST;
+    delete process.env.AGENT_CI_DOCKER_HOST;
     vi.spyOn(fs, "existsSync").mockReturnValue(true);
     vi.spyOn(fs, "realpathSync").mockReturnValue("/var/run/docker.sock");
     vi.spyOn(fs, "accessSync").mockImplementation(() => {

--- a/packages/cli/src/docker/docker-socket.ts
+++ b/packages/cli/src/docker/docker-socket.ts
@@ -44,7 +44,7 @@ function socketFromDockerContext(): string | undefined {
 export interface DockerSocket {
   /** Filesystem path to the socket (no unix:// prefix), with symlinks resolved. Used for the Docker API client. */
   socketPath: string;
-  /** Full URI suitable for DOCKER_HOST (e.g. "unix:///path/to/socket"). */
+  /** Full URI suitable for AGENT_CI_DOCKER_HOST (e.g. "unix:///path/to/socket"). */
   uri: string;
   /**
    * Path to use as the bind-mount source when mounting the Docker socket into a container.
@@ -67,16 +67,17 @@ export interface DockerSocket {
  *     its shared-mount list. Our process's permissions are irrelevant here —
  *     only path recognition matters.
  *
- * The bind-mount invariant: unless the user has set DOCKER_HOST explicitly,
- * `/var/run/docker.sock` must exist and be the bind-mount source. Every Docker
- * provider either creates it directly (Docker Desktop, native dockerd) or can
- * be pointed at it via a symlink (OrbStack does this automatically; Colima is
- * a manual `ln -sf`). We refuse to guess provider-specific paths — those tend
- * to fail later at bind-mount time with confusing errors (#197, #209, #263).
+ * The bind-mount invariant: unless the user has set AGENT_CI_DOCKER_HOST
+ * explicitly, `/var/run/docker.sock` must exist and be the bind-mount source.
+ * Every Docker provider either creates it directly (Docker Desktop, native
+ * dockerd) or can be pointed at it via a symlink (OrbStack does this
+ * automatically; Colima is a manual `ln -sf`). We refuse to guess
+ * provider-specific paths — those tend to fail later at bind-mount time with
+ * confusing errors (#197, #209, #263).
  *
  * Resolution order:
- *  1. `DOCKER_HOST` env var wins outright (local paths validated; non-unix
- *     schemes returned as-is).
+ *  1. `AGENT_CI_DOCKER_HOST` env var wins outright (local paths validated;
+ *     non-unix schemes returned as-is).
  *  2. `/var/run/docker.sock` must exist. If we can R/W it, its resolved path
  *     is the API `socketPath`; otherwise we look up the active docker context
  *     to find a readable path (#209), but `bindMountPath` stays as
@@ -84,8 +85,8 @@ export interface DockerSocket {
  *  3. Neither → throw with a doc link.
  */
 export function resolveDockerSocket(): DockerSocket {
-  // 1. Explicit DOCKER_HOST wins.
-  const envHost = process.env.DOCKER_HOST?.trim();
+  // 1. Explicit AGENT_CI_DOCKER_HOST wins.
+  const envHost = process.env.AGENT_CI_DOCKER_HOST?.trim();
   if (envHost) {
     if (!envHost.startsWith("unix://")) {
       // Non-unix scheme (ssh://, tcp://) — container bind-mount is out of scope.
@@ -96,7 +97,9 @@ export function resolveDockerSocket(): DockerSocket {
     if (resolved) {
       return { socketPath: resolved, uri: `unix://${resolved}`, bindMountPath: socketPath };
     }
-    throw unusableSocketError(`DOCKER_HOST=${envHost} does not resolve to a working socket.`);
+    throw unusableSocketError(
+      `AGENT_CI_DOCKER_HOST=${envHost} does not resolve to a working socket.`,
+    );
   }
 
   // 2. /var/run/docker.sock must exist. existsSync returns false for dangling
@@ -138,7 +141,7 @@ function unusableSocketError(detail: string): Error {
     `agent-ci couldn't use a Docker socket at /var/run/docker.sock.`,
     detail,
     ``,
-    `A working Docker socket is required there (or set DOCKER_HOST explicitly).`,
+    `A working Docker socket is required there (or set AGENT_CI_DOCKER_HOST explicitly).`,
   ];
   if (dockerDesktopRunningWithoutDefaultSocket()) {
     lines.push(

--- a/packages/cli/src/docker/repro-197.test.ts
+++ b/packages/cli/src/docker/repro-197.test.ts
@@ -24,7 +24,7 @@ vi.mock("node:child_process", () => ({
 
 afterEach(() => {
   vi.restoreAllMocks();
-  delete process.env.DOCKER_HOST;
+  delete process.env.AGENT_CI_DOCKER_HOST;
 });
 
 async function importFreshSocket() {
@@ -34,7 +34,7 @@ async function importFreshSocket() {
 
 describe("issue-197 reproduction: Docker Desktop bind mount path", () => {
   it("resolves to the real path for API client but keeps the symlink path for bind mounts", async () => {
-    delete process.env.DOCKER_HOST;
+    delete process.env.AGENT_CI_DOCKER_HOST;
     // Simulate Docker Desktop: /var/run/docker.sock → ~/.docker/run/docker.sock
     vi.spyOn(fs, "existsSync").mockReturnValue(true);
     vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
@@ -57,7 +57,7 @@ describe("issue-197 reproduction: Docker Desktop bind mount path", () => {
   });
 
   it("container bind string uses /var/run/docker.sock, not the resolved path (the failing case)", async () => {
-    delete process.env.DOCKER_HOST;
+    delete process.env.AGENT_CI_DOCKER_HOST;
     vi.spyOn(fs, "existsSync").mockReturnValue(true);
     vi.spyOn(fs, "realpathSync").mockImplementation((p) => {
       if (String(p) === "/var/run/docker.sock") {
@@ -94,8 +94,8 @@ describe("issue-197 reproduction: Docker Desktop bind mount path", () => {
     expect(binds).not.toContain("/Users/test/.docker/run/docker.sock:/var/run/docker.sock");
   });
 
-  it("DOCKER_HOST unix socket keeps the original path for bind mounts even if it resolves elsewhere", async () => {
-    process.env.DOCKER_HOST = "unix:///var/run/docker.sock";
+  it("AGENT_CI_DOCKER_HOST unix socket keeps the original path for bind mounts even if it resolves elsewhere", async () => {
+    process.env.AGENT_CI_DOCKER_HOST = "unix:///var/run/docker.sock";
     vi.spyOn(fs, "realpathSync").mockReturnValue("/Users/test/.docker/run/docker.sock");
     vi.spyOn(fs, "accessSync").mockReturnValue(undefined);
 

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -95,9 +95,9 @@ export function getDocker(): Docker {
     } else if (socket.uri.startsWith("ssh://")) {
       _docker = new Docker({ host: socket.uri, protocol: "ssh" as const });
     } else {
-      // Let dockerode/docker-modem parse non-unix, non-ssh DOCKER_HOST values
-      // from the environment. This preserves tcp:// support without changing the
-      // existing unix:// or ssh:// behavior.
+      // Let dockerode/docker-modem parse non-unix, non-ssh host URIs from the
+      // environment. cli.ts forwards AGENT_CI_DOCKER_HOST → DOCKER_HOST at
+      // bootstrap so dockerode's default client still picks up tcp:// URIs.
       _docker = new Docker();
     }
   }


### PR DESCRIPTION
## Problem

The README told users that configuration in a `.env.agent-ci` file at the repo root would be picked up automatically. In practice, only workflow secrets were read from this file. Docker and network settings such as `AGENT_CI_DTU_HOST` and `AGENT_CI_DOCKER_EXTRA_HOSTS` were silently ignored unless you also exported them in your shell. On Lima / Colima / custom-network setups this produced confusing "connection refused" errors — the user had done what the README said, and nothing happened.

A second, related snag: agent-ci also honored the standard `DOCKER_HOST` environment variable — the same variable the regular `docker` command-line tool uses. This meant you could not point agent-ci at one Docker daemon (for example, a Lima VM) and your shell's Docker command at another, without the two colliding. And `DOCKER_HOST` was the one setting you could not cleanly move into `.env.agent-ci` either.

Closes #308.

## Solution

1. At startup, agent-ci now reads any entry beginning with `AGENT_CI_` from `.env.agent-ci` and applies it to its own environment. Docker and network configuration now works from the file just like secrets always did. Values already set in the shell still win when both are present. Non-prefixed entries in the file stay put and continue to work as workflow secrets.

2. `DOCKER_HOST` is replaced by `AGENT_CI_DOCKER_HOST`. If the old `DOCKER_HOST` is still set when agent-ci runs, it exits immediately with an error telling the user to rename it. This is a breaking change — anyone who had `DOCKER_HOST` configured for agent-ci needs to rename it once. The benefit is that the setting can now live in `.env.agent-ci` and agent-ci can target a different Docker daemon than your shell's `docker` command without the two stepping on each other.

## Test plan

- [x] `AGENT_CI_DOCKER_HOST` in `.env.agent-ci` is picked up without exporting it in the shell
- [x] Setting `DOCKER_HOST` in the shell produces the rename error and exits
- [x] Shell value of `AGENT_CI_DOCKER_HOST` overrides the value in `.env.agent-ci`
- [x] Non-prefixed keys in `.env.agent-ci` still resolve as workflow secrets
- [x] `AGENT_CI_DOCKER_HOST=unix://…`, `ssh://…`, and `tcp://…` all continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)