### PR TITLE
fix(workflow): honor step-level if: conditions

### DIFF
--- a/.changeset/step-if-honored.md
+++ b/.changeset/step-if-honored.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Fix: honor step-level `if:` conditions. Previously every step ran regardless of its `if:` clause, because `parseWorkflowSteps` never extracted `step.if` from the workflow, and the server fell back to `condition: "success()"` for every step. Now the condition is forwarded to the runner's EvaluateStepIf, so gates like `if: contains(runner.name, 'blacksmith')`, `if: always()`, and `if: ${{ false }}` behave as they do on real GitHub Actions.

--- a/.github/workflows/smoke-step-if.yml
+++ b/.github/workflows/smoke-step-if.yml
@@ -1,0 +1,57 @@
+name: "Smoke: step-level if: conditions"
+
+# Proves that the step-level `if:` field is honored by the runner:
+# skipped steps don't execute their `run:` script, and truthy gates do.
+#
+# Strategy: each "should be skipped" step runs `exit 1`. If the gate
+# leaks, the job fails. A terminal step asserts the expected files are
+# present (written by "should run" steps) and the forbidden ones absent.
+
+on:
+  pull_request_target:
+    types: [opened, labeled, synchronize]
+
+jobs:
+  step-if:
+    if: '!github.event.pull_request.draft && (contains(fromJSON(''["MEMBER", "OWNER", "COLLABORATOR"]''), github.event.pull_request.author_association) || contains(github.event.pull_request.labels.*.name, ''safe-to-run''))'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skipped by naked false expression
+        if: contains(runner.name, 'this-substring-will-never-match-xyzzy')
+        run: |
+          echo "❌ naked-contains gate leaked" > /tmp/leak-naked
+          exit 1
+
+      - name: Skipped by wrapped false expression
+        if: ${{ contains(runner.name, 'this-substring-will-never-match-xyzzy') }}
+        run: |
+          echo "❌ wrapped-contains gate leaked" > /tmp/leak-wrapped
+          exit 1
+
+      - name: Skipped by literal false
+        if: ${{ false }}
+        run: |
+          echo "❌ literal-false gate leaked" > /tmp/leak-literal
+          exit 1
+
+      - name: Runs under always()
+        if: always()
+        run: echo "ran" > /tmp/ran-always
+
+      - name: Runs under literal true
+        if: ${{ true }}
+        run: echo "ran" > /tmp/ran-true
+
+      - name: Runs under negation of a matching contains()
+        if: ${{ !contains(runner.name, 'this-substring-will-never-match-xyzzy') }}
+        run: echo "ran" > /tmp/ran-negation
+
+      - name: Assert expected skip/run outcomes
+        run: |
+          for f in /tmp/leak-naked /tmp/leak-wrapped /tmp/leak-literal; do
+            [ ! -e "$f" ] || { echo "❌ $f exists — a gated step leaked"; exit 1; }
+          done
+          for f in /tmp/ran-always /tmp/ran-true /tmp/ran-negation; do
+            [ -e "$f" ] || { echo "❌ $f missing — a truthy gate was not honored"; exit 1; }
+          done
+          echo "✅ all step-if gates behaved as expected"

--- a/packages/cli/src/workflow/workflow-parser.test.ts
+++ b/packages/cli/src/workflow/workflow-parser.test.ts
@@ -1318,7 +1318,7 @@ describe("expandExpressions real-world patterns", () => {
 
 // ─── Job-level if conditions ──────────────────────────────────────────────────
 
-import { evaluateJobIf, parseJobIf } from "./workflow-parser.js";
+import { evaluateJobIf, parseJobIf, parseStepIf } from "./workflow-parser.js";
 
 describe("parseJobIf", () => {
   let tmpDir: string;
@@ -1375,6 +1375,48 @@ jobs:
       - run: echo ok
 `);
     expect(parseJobIf(filePath, "check")).toBe("always()");
+  });
+});
+
+describe("parseStepIf", () => {
+  it("returns undefined for null or undefined", () => {
+    expect(parseStepIf(undefined)).toBeUndefined();
+    expect(parseStepIf(null)).toBeUndefined();
+  });
+
+  it("returns undefined for an empty string", () => {
+    expect(parseStepIf("")).toBeUndefined();
+    expect(parseStepIf("   ")).toBeUndefined();
+  });
+
+  it("returns a naked expression unchanged", () => {
+    expect(parseStepIf("contains(runner.name, 'blacksmith')")).toBe(
+      "contains(runner.name, 'blacksmith')",
+    );
+    expect(parseStepIf("always()")).toBe("always()");
+  });
+
+  it("strips a ${{ }} wrapper", () => {
+    expect(parseStepIf("${{ contains(runner.name, 'blacksmith') }}")).toBe(
+      "contains(runner.name, 'blacksmith')",
+    );
+    expect(parseStepIf("${{ !contains(runner.name, 'blacksmith') }}")).toBe(
+      "!contains(runner.name, 'blacksmith')",
+    );
+  });
+
+  it("coerces boolean YAML values to string", () => {
+    expect(parseStepIf(true)).toBe("true");
+    expect(parseStepIf(false)).toBe("false");
+  });
+
+  it("trims whitespace inside and outside the wrapper", () => {
+    expect(parseStepIf("   always()   ")).toBe("always()");
+    expect(parseStepIf("${{   always()   }}")).toBe("always()");
+  });
+
+  it("returns undefined when the wrapper contains only whitespace", () => {
+    expect(parseStepIf("${{  }}")).toBeUndefined();
   });
 });
 
@@ -1580,6 +1622,46 @@ jobs:
     const steps = await parseWorkflowSteps(filePath, "test", undefined, undefined, needsCtx);
 
     expect((steps[0] as any).Name).toBe("Shard 3");
+  });
+
+  it("forwards step-level if: conditions as step.condition", async () => {
+    const filePath = writeWorkflowTree(`
+name: Step If Test
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: no-if
+        run: echo one
+      - name: naked
+        if: contains(runner.name, 'blacksmith')
+        run: echo two
+      - name: wrapped
+        if: \${{ !contains(runner.name, 'blacksmith') }}
+        run: echo three
+      - name: always
+        if: always()
+        run: echo four
+      - name: false-literal
+        if: \${{ false }}
+        run: echo five
+      - name: uses-with-if
+        if: \${{ runner.os == 'Linux' }}
+        uses: actions/checkout@v4
+`);
+    const steps = await parseWorkflowSteps(filePath, "test");
+    const conds = steps.map((s: any) => s.condition);
+    // no-if → undefined (server defaults to success())
+    expect(conds[0]).toBeUndefined();
+    // naked expression passes through unchanged
+    expect(conds[1]).toBe("contains(runner.name, 'blacksmith')");
+    // ${{ }} wrapper is stripped
+    expect(conds[2]).toBe("!contains(runner.name, 'blacksmith')");
+    expect(conds[3]).toBe("always()");
+    expect(conds[4]).toBe("false");
+    // applies to `uses` steps too
+    expect(conds[5]).toBe("runner.os == 'Linux'");
   });
 });
 

--- a/packages/cli/src/workflow/workflow-parser.ts
+++ b/packages/cli/src/workflow/workflow-parser.ts
@@ -1055,6 +1055,7 @@ export async function parseWorkflowSteps(
         if (workingDirectory) {
           inputs.workingDirectory = workingDirectory;
         }
+        const condition = parseStepIf(rawStep.if);
         return {
           Type: "Action",
           Name: stepName,
@@ -1077,6 +1078,7 @@ export async function parseWorkflowSteps(
             vars,
             runnerContext,
           ),
+          ...(condition !== undefined ? { condition } : {}),
         };
       } else if ("uses" in step) {
         // Basic support for 'uses' steps
@@ -1094,6 +1096,7 @@ export async function parseWorkflowSteps(
 
         const isCheckout = !isLocalAction && name.trim().toLowerCase() === "actions/checkout";
         const stepWith = rawStep.with || {};
+        const condition = parseStepIf(rawStep.if);
 
         return {
           Type: "Action",
@@ -1185,6 +1188,7 @@ export async function parseWorkflowSteps(
             vars,
             runnerContext,
           ),
+          ...(condition !== undefined ? { condition } : {}),
         };
       }
       return null;
@@ -1541,6 +1545,32 @@ export function parseJobIf(filePath: string, jobId: string): string | null {
   const wrapped = expr.match(/^\$\{\{\s*([\s\S]*?)\s*\}\}$/);
   if (wrapped) {
     expr = wrapped[1];
+  }
+  return expr;
+}
+
+/**
+ * Normalize a step-level `if:` value into a condition string for the runner's
+ * EvaluateStepIf. Accepts the raw YAML value (may be string, boolean, null).
+ * Strips a surrounding `${{ }}` wrapper so the runner sees a bare expression,
+ * matching the format it uses for the default `success()`.
+ * Returns undefined when no condition should be forwarded (the server then
+ * defaults to `success()`).
+ */
+export function parseStepIf(rawIf: unknown): string | undefined {
+  if (rawIf === undefined || rawIf === null) {
+    return undefined;
+  }
+  let expr = String(rawIf).trim();
+  if (expr === "") {
+    return undefined;
+  }
+  const wrapped = expr.match(/^\$\{\{\s*([\s\S]*?)\s*\}\}$/);
+  if (wrapped) {
+    expr = wrapped[1].trim();
+    if (expr === "") {
+      return undefined;
+    }
   }
   return expr;
 }


### PR DESCRIPTION
## Summary

- Step-level `if:` conditions were completely ignored: every step ran regardless of its gate.
- Root cause: `parseWorkflowSteps` never extracted `step.if` from the workflow, so the DTU server fell back to `condition: "success()"` for every step (`packages/dtu-github-actions/src/server/routes/actions/generators.ts:174`).
- Fix: new `parseStepIf` helper strips the optional `${{ }}` wrapper and threads the bare expression through as `step.condition`. The runner's `EvaluateStepIf` then evaluates it natively, matching GitHub Actions behavior.

## Why it had been hiding

Almost no smoke workflow exercised step-level `if:`. The two that did use `if: always()` (which is true regardless) or `if: steps.*.outputs.cache-hit != 'true'` (which tolerates re-running), so the bug never produced a visible failure.

## Reproduction (before fix)

A workflow with:

```yaml
- name: should skip
  if: ${{ false }}
  run: echo "leaked"
```

…would run the step. Complementary gates like `runner.name == ''` **and** `runner.name != ''` both ran in the same job. After this change, each gate produces the outcome real GitHub Actions does.

## Test plan

- [x] Unit: new `parseStepIf` cases (wrapped/naked/boolean/whitespace).
- [x] Unit: `parseWorkflowSteps` forwards `condition` for run and uses steps.
- [x] Smoke: `.github/workflows/smoke-step-if.yml` fails loudly if any false gate leaks; asserts truthy gates run.
- [x] `pnpm agent-ci-dev run --all` → 40 of 40 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)