### PR TITLE
fix(cli): parse ssh:// AGENT_CI_DOCKER_HOST into host/user/port (#322)

### DIFF
--- a/.changeset/ssh-docker-host-uri-parsing.md
+++ b/.changeset/ssh-docker-host-uri-parsing.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Fix `AGENT_CI_DOCKER_HOST=ssh://...` failing with `getaddrinfo ENOTFOUND`. The runner now parses the SSH URI and passes `host`, `username`, and `port` to dockerode separately instead of handing the raw URI string through as a hostname. Closes #322.

--- a/packages/cli/src/runner/local-job-ssh.test.ts
+++ b/packages/cli/src/runner/local-job-ssh.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import Docker from "dockerode";
+import type { DockerSocket } from "../docker/docker-socket.js";
+
+// End-to-end reproduction for #322: when AGENT_CI_DOCKER_HOST is an ssh:// URI,
+// the Docker client must be wired so docker-modem ends up with the parsed
+// hostname (and the username/port carried separately), not the full raw URI.
+//
+// Pre-fix, getDocker() did `new Docker({ host: socket.uri, protocol: "ssh" })`.
+// That left modem.host = "ssh://user@remote-host", causing ssh2 to DNS-resolve
+// the literal URI and fail with `getaddrinfo ENOTFOUND`.
+describe("getDocker SSH wiring (#322)", () => {
+  it("constructs a Docker client whose modem has the parsed hostname, not the URI", async () => {
+    const mod = await import("./local-job.js");
+    const socket: DockerSocket = {
+      socketPath: "",
+      uri: "ssh://user@remote-host",
+      bindMountPath: "",
+    };
+
+    const docker = mod.__test_createDockerClient(socket) as Docker;
+
+    expect(docker.modem.host).toBe("remote-host");
+    expect(docker.modem.host).not.toBe("ssh://user@remote-host");
+    expect(docker.modem.username).toBe("user");
+    expect(docker.modem.protocol).toBe("ssh");
+  });
+});

--- a/packages/cli/src/runner/local-job.test.ts
+++ b/packages/cli/src/runner/local-job.test.ts
@@ -29,7 +29,7 @@ describe("getDocker client construction", () => {
     expect(dockerCtor).toHaveBeenCalledWith({ socketPath: "/tmp/docker.sock" });
   });
 
-  it("uses ssh transport for ssh URIs", async () => {
+  it("parses ssh URIs into host/username/port (#322)", async () => {
     const mod = await import("./local-job.js");
     const socket: DockerSocket = {
       socketPath: "",
@@ -39,9 +39,52 @@ describe("getDocker client construction", () => {
 
     mod.__test_createDockerClient(socket);
 
+    // Regression: previously we passed the full URI as `host`, which caused
+    // ssh2 to DNS-resolve `ssh://user@remote-host` and fail with ENOTFOUND.
     expect(dockerCtor).toHaveBeenCalledWith({
-      host: "ssh://user@remote-host",
       protocol: "ssh",
+      host: "remote-host",
+      port: 22,
+      username: "user",
+      sshOptions: { agent: process.env.SSH_AUTH_SOCK },
+    });
+  });
+
+  it("parses ssh URIs with explicit port", async () => {
+    const mod = await import("./local-job.js");
+    const socket: DockerSocket = {
+      socketPath: "",
+      uri: "ssh://deploy@remote-host:2222",
+      bindMountPath: "",
+    };
+
+    mod.__test_createDockerClient(socket);
+
+    expect(dockerCtor).toHaveBeenCalledWith({
+      protocol: "ssh",
+      host: "remote-host",
+      port: 2222,
+      username: "deploy",
+      sshOptions: { agent: process.env.SSH_AUTH_SOCK },
+    });
+  });
+
+  it("parses ssh URIs without an explicit username", async () => {
+    const mod = await import("./local-job.js");
+    const socket: DockerSocket = {
+      socketPath: "",
+      uri: "ssh://remote-host",
+      bindMountPath: "",
+    };
+
+    mod.__test_createDockerClient(socket);
+
+    expect(dockerCtor).toHaveBeenCalledWith({
+      protocol: "ssh",
+      host: "remote-host",
+      port: 22,
+      username: undefined,
+      sshOptions: { agent: process.env.SSH_AUTH_SOCK },
     });
   });
 

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -94,7 +94,17 @@ export function getDocker(): Docker {
     if (socket.socketPath) {
       _docker = new Docker({ socketPath: socket.socketPath });
     } else if (socket.uri.startsWith("ssh://")) {
-      _docker = new Docker({ host: socket.uri, protocol: "ssh" as const });
+      // dockerode/docker-modem expects `host` to be the hostname only, with
+      // username/port carried separately. Passing the raw URI made ssh2 try
+      // to DNS-resolve `ssh://user@host`, failing with ENOTFOUND (#322).
+      const parsed = new URL(socket.uri);
+      _docker = new Docker({
+        protocol: "ssh" as const,
+        host: parsed.hostname,
+        port: parsed.port ? Number(parsed.port) : 22,
+        username: parsed.username ? decodeURIComponent(parsed.username) : undefined,
+        sshOptions: { agent: process.env.SSH_AUTH_SOCK },
+      });
     } else {
       // Let dockerode/docker-modem parse non-unix, non-ssh host URIs from the
       // environment. cli.ts forwards AGENT_CI_DOCKER_HOST → DOCKER_HOST at


### PR DESCRIPTION
## Problem

When `AGENT_CI_DOCKER_HOST` is set to an SSH URI (e.g. `ssh://user@remote-host`), Agent CI fails to connect to the remote Docker daemon — with `getaddrinfo ENOTFOUND` (or `Invalid username` when no user is otherwise configured). Reported in #322 by @KoheiKanagu.

The runner constructed dockerode with the full URI as `host`:

```ts
} else if (socket.uri.startsWith("ssh://")) {
  _docker = new Docker({ host: socket.uri, protocol: "ssh" as const });
}
```

dockerode/docker-modem expects `host` to be the hostname only, with `username` and `port` carried separately. Passing the raw URI leaves `modem.host = "ssh://user@remote-host"`, which `ssh2` then tries to DNS-resolve as a literal hostname.

I reproduced this locally:

| | `host` | `username` | `port` | `protocol` |
|---|---|---|---|---|
| Correct (via `DOCKER_HOST` env) | `remote-host` | `user` | `""` | `ssh` |
| Pre-fix code | `ssh://user@remote-host` | `undefined` | `undefined` | `ssh` |

## Solution

Parse the URI and pass structured values to dockerode — the same shape docker-modem produces internally when it parses `DOCKER_HOST` itself. Also forwards `SSH_AUTH_SOCK` via `sshOptions.agent`, which docker-modem only auto-populates on the `DOCKER_HOST` code path.

A new end-to-end test (`local-job-ssh.test.ts`) constructs a real `Docker` client (no mocks) and asserts on the resulting `docker.modem.host` / `username` / `protocol` — this is the test that would have caught the original bug. The existing mocked unit tests in `local-job.test.ts` are updated to the new constructor shape and extended with explicit-port and no-username cases.

Closes #322.

## Test plan

- [x] `pnpm vitest run src/runner/local-job.test.ts src/runner/local-job-ssh.test.ts` — 6/6 passing
- [x] Manually confirmed the new `local-job-ssh.test.ts` fails on the pre-fix code (asserts `host = "remote-host"` but receives `"ssh://user@remote-host"`)
- [x] `pnpm typecheck` clean
- [x] `pnpm agent-ci-dev run --all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)