### PR TITLE
docs(skills): cover --json NDJSON stream and exit-77 pause contract

### DIFF
--- a/.changeset/skill-docs-json-pause.md
+++ b/.changeset/skill-docs-json-pause.md
@@ -1,0 +1,8 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Update agent-facing skill docs (`packages/cli/SKILL.md`, top-level `skills/agent-ci/SKILL.md`) to cover the `--json` NDJSON event stream and the exit-77 pause contract added in #315 / #289. Internal `agent-ci-dev` command + pi skill switch from plaintext "Step failed" grep to NDJSON event matching for more robust pause/finish detection. Stale "no pipes / no redirects" warnings in the experimental skill-eval variants are corrected — pipes and redirects are safe with `--pause-on-failure` now that the launcher detaches automatically.
+
+Refs #289, #315.

--- a/.claude/commands/agent-ci-dev.md
+++ b/.claude/commands/agent-ci-dev.md
@@ -5,23 +5,25 @@ aliases: [validate]
 
 // turbo-all
 
-1. Run agent-ci in the **background** so you can monitor and react to failures:
+1. Run agent-ci in the **background** with the NDJSON event stream enabled so you can monitor and react to failures:
 
 ```bash
-pnpm agent-ci-dev run --all -q -p 2>&1
+pnpm agent-ci-dev run --all -q -p --json 2>&1
 ```
 
-Use `run_in_background: true` on the Bash tool. This returns an output file path.
+Use `run_in_background: true` on the Bash tool. This returns an output file path. The launcher detaches automatically when stdout isn't a TTY; the foreground process exits **77** the instant a step pauses, while the worker keeps the container alive for `retry`.
 
-2. Set up a **Monitor** on the output file to catch pass/fail events:
+2. Set up a **Monitor** on the output file to catch pause/finish events from the NDJSON stream:
 
 ```bash
-tail -f <output-file> 2>/dev/null | grep --line-buffered "Step failed"
+tail -f <output-file> 2>/dev/null | grep --line-buffered -E '"event":"(run\.paused|run\.finish)"'
 ```
 
-3. Wait for either a monitor event (failure) or a background task completion notification (success). If agent-ci exits successfully, stop the monitor with `TaskStop` and you're done.
+`run.paused` carries the `runner` name and `retry_cmd` you'll need in step 4. `run.finish` carries `status: passed|failed`.
 
-4. If a step fails, the runner pauses and waits. **CI was passing before your work started**, so the failure is caused by your changes. Investigate and fix it:
+3. Wait for either a monitor event (pause/finish) or a background task completion notification. If `run.finish` reports `status: passed` (or the background task exits 0 with no pause), stop the monitor with `TaskStop` and you're done.
+
+4. If a step fails, the runner pauses and waits (foreground exit code 77; `run.paused` event in the log). **CI was passing before your work started**, so the failure is caused by your changes. Investigate and fix it:
 
 - Read the output file for the full failure details.
 - Identify and fix the issue in your code.

--- a/.pi/skills/agent-ci-dev/SKILL.md
+++ b/.pi/skills/agent-ci-dev/SKILL.md
@@ -11,32 +11,32 @@ This skill relies on two pi-native tools added by `.pi/extensions/background-she
 
 ## Steps
 
-1. **Start agent-ci in the background** with `bash_background`:
+1. **Start agent-ci in the background** with `bash_background`, with the NDJSON event stream enabled:
 
    ```json
-   { "command": "pnpm agent-ci-dev run --all -q -p" }
+   { "command": "pnpm agent-ci-dev run --all -q -p --json" }
    ```
 
-   This returns `{ taskId, outputFile, pid }` without blocking.
+   This returns `{ taskId, outputFile, pid }` without blocking. Because stdout isn't a TTY, the launcher detaches automatically: the foreground process exits **77** the moment a step pauses, while the worker keeps the container alive for `retry`.
 
-2. **Wait for a failure or completion** with `monitor_wait`, covering both happy and failure paths in one regex (silence is not success — a crash or hang with a success-only filter looks identical to still-running):
+2. **Wait for a pause or completion** with `monitor_wait`, matching the NDJSON event discriminators (silence is not success — a crash or hang with a success-only filter looks identical to still-running):
 
    ```json
    {
      "taskId": "<from step 1>",
-     "pattern": "Step failed|Traceback|Error|FAILED",
+     "pattern": "\"event\":\"(run\\.paused|run\\.finish)\"",
      "timeoutMs": 600000
    }
    ```
 
    `monitor_wait` returns when **any** of the following happens:
-   - the regex matches a new line → `stoppedBecause: "match"`, inspect `matches`
-   - the task exits → `stoppedBecause: "exit"`, inspect `state` (`succeeded` or `failed`) and `exitCode`
+   - the regex matches a new line → `stoppedBecause: "match"`, inspect `matches`. A `run.paused` line carries the `runner` name + `retry_cmd`; a `run.finish` line carries `status: passed|failed`.
+   - the task exits → `stoppedBecause: "exit"`, inspect `state` (`succeeded` or `failed`) and `exitCode`. Exit code **77** means a step paused — treat it like a `run.paused` match.
    - the timeout elapses → `stoppedBecause: "timeout"`, loop back and call `monitor_wait` again (it resumes from the previous byte offset automatically)
 
-3. **On success** (`state: "succeeded"`), you're done.
+3. **On success** (`run.finish` with `status: passed`, or `state: "succeeded"`), you're done.
 
-4. **On failure**, read the full output file for details:
+4. **On failure** (`run.paused` match or `exitCode: 77`), read the full output file for details:
 
    ```bash
    tail -n 200 <outputFile>

--- a/experiments/skill-evals/variants/v2-run-first.md
+++ b/experiments/skill-evals/variants/v2-run-first.md
@@ -45,4 +45,5 @@ Repeat **run → fix → retry** until all jobs pass. Do not push to trigger rem
 - **Do not skip running agent-ci** because the fix "looks obvious." The eval is whether agent-ci passes, not whether the code looks right.
 - **Do not disable lint rules, delete failing tests, or remove CI steps** to make CI pass. Fix the underlying issue.
 - **Do not omit `--pause-on-failure`** — it's what makes the retry loop fast.
-- **Do not pipe the output through `tail` or `head`** — it buffers everything until exit and disables pause-on-failure interaction.
+
+Pipes, redirects, and backgrounding are all safe with `--pause-on-failure`: when stdout isn't a TTY the launcher detaches the run and the foreground process exits **77** the instant a step pauses, while the worker keeps the container alive for `retry`. For programmatic monitoring add `--json` (or `AGENT_CI_JSON=1`) to emit an NDJSON event stream — match `"event":"run.paused"` and `"event":"run.finish"` instead of grepping plaintext.

--- a/experiments/skill-evals/variants/v3-no-mangling.md
+++ b/experiments/skill-evals/variants/v3-no-mangling.md
@@ -18,15 +18,9 @@ Run the full CI pipeline locally before pushing. CI was green before you started
 npx @redwoodjs/agent-ci run --quiet --all --pause-on-failure
 ```
 
-Run this command **directly**. Do not redirect its output.
+Pipes, redirects, and backgrounding are all safe. When stdout isn't a TTY (any pipe, file redirect, or background process) the launcher detaches the run automatically: the foreground process exits **77** the instant a step pauses, while the worker keeps the container paused so you can `retry`. `| tee log`, `> log.txt`, and `&` work as expected.
 
-Specifically:
-
-- **No pipes.** `| tail -N`, `| head -N`, `| grep`, `| cat`, `| tee`, anything — the shell buffers the whole stream and agent-ci's pause message never reaches you. The run will appear to hang.
-- **No file redirects.** `> log.txt`, `&> log.txt`, `> /dev/null` — same problem. You will see nothing until the process exits, which won't happen until you issue retry.
-- **No backgrounding.** No trailing `&`, no `& sleep 20`. Pause-on-failure needs a live channel back to you.
-
-Bare `2>&1` (merge stderr into stdout) on its own is fine — it doesn't redirect or buffer. Anything _after_ a `2>&1` (a pipe, a file, an `&`) is not.
+For machine-readable monitoring, add `--json` (or set `AGENT_CI_JSON=1`) to emit an NDJSON event stream — one JSON object per line. Watch for `"event":"run.paused"` (carries `runner` and `retry_cmd`) and `"event":"run.finish"` (carries `status: passed|failed`).
 
 If the output is long, let it be long. Read it.
 
@@ -44,7 +38,7 @@ To re-run from an earlier step:
 npx @redwoodjs/agent-ci retry --name <runner-name> --from-step <N>
 ```
 
-Retry the same way — **directly**, no pipes or redirects.
+Retry behaves the same as `run`: it tails the same log, exits 77 if a step re-fails, and is safe to pipe or redirect.
 
 ## Do not
 

--- a/packages/cli/SKILL.md
+++ b/packages/cli/SKILL.md
@@ -22,6 +22,10 @@ Cache is bind-mounted (instant). When a step fails, the container pauses — you
 - Retry after fix: `npx @redwoodjs/agent-ci retry --name <runner>`
 - Abort: `npx @redwoodjs/agent-ci abort --name <runner>`
 
+## Agent output mode
+
+Pass `--json` (or set `AGENT_CI_JSON=1`) to emit an NDJSON event stream on stdout — one JSON object per line, with `run.start`/`paused`/`finish`, `job.start`/`finish`, `step.start`/`finish`, and `diagnostic` events. `run.start` carries `schemaVersion: 1`. Pair with `--pause-on-failure`: when stdout isn't a TTY the launcher detaches and the foreground process exits **77** the instant a `run.paused` event fires, so callers can react cleanly without parsing plaintext.
+
 ## Common mistakes
 
 - Don't push to remote CI to test changes — use `npx @redwoodjs/agent-ci run` locally first

--- a/skills/agent-ci/SKILL.md
+++ b/skills/agent-ci/SKILL.md
@@ -18,6 +18,8 @@ Run the full CI pipeline locally before pushing. CI was green before you started
 npx @redwoodjs/agent-ci run --quiet --all --pause-on-failure
 ```
 
+Pipes are safe — pause-on-failure works through `| tee log`, `> log.txt`, etc. When stdout isn't a TTY the launcher detaches the run and the foreground process exits **77** the moment a step pauses, freeing the pipe while the container stays paused for `retry`.
+
 ## Retry
 
 When a step fails, the run pauses automatically. Fix the issue, then retry:
@@ -33,3 +35,16 @@ npx @redwoodjs/agent-ci retry --name <runner-name> --from-step <N>
 ```
 
 Repeat until all jobs pass. Do not push to trigger remote CI when agent-ci can run it locally.
+
+## Machine-readable output (`--json`)
+
+For programmatic monitoring, add `--json` (or set `AGENT_CI_JSON=1`) to emit an NDJSON event stream on stdout — one JSON object per line. Events:
+
+- `run.start` (with `schemaVersion: 1`, `runId`)
+- `job.start`, `job.finish` (`status: passed|failed`)
+- `step.start`, `step.finish` (`status: passed|failed|skipped`)
+- `run.paused` (carries `runner` + `retry_cmd`)
+- `run.finish` (`status: passed|failed`)
+- `diagnostic`
+
+`--json` is decoupled from `--quiet`, and the diff renderer is auto-suppressed under `--json` so ANSI sequences don't collide with the stream. Combined with the exit-77 pause signal above, this gives agents a robust contract: parse `run.paused` events, react, and call `retry` — no plaintext grep required.


### PR DESCRIPTION
## Summary

Brings the agent-facing skill surfaces in line with the `--json` NDJSON event stream (#289) and the non-TTY pause-on-failure unblock (#315). The README documents both, but the skill files agents actually load did not — and two skill-eval variants still warned against pipes/redirects that are now the supported path.

- `skills/agent-ci/SKILL.md` (published with the npm package) and `packages/cli/SKILL.md`: add `--json` / `AGENT_CI_JSON=1`, list the event types (`run.start|paused|finish`, `job.start|finish`, `step.start|finish`, `diagnostic`, `schemaVersion: 1`), and note that pipes are safe via the detached-launcher exit-77 contract.
- `.claude/commands/agent-ci-dev.md` and `.pi/skills/agent-ci-dev/SKILL.md`: switch the monitor pattern from grepping plaintext `"Step failed"` to matching `"event":"(run.paused|run.finish)"`, and call out exit-77 alongside `run.paused`.
- `experiments/skill-evals/variants/v2-run-first.md` and `v3-no-mangling.md`: drop stale "no pipes / no redirects / no backgrounding" warnings — those scenarios now route through the detached worker and exit 77 on pause.

Refs #289, #315.

## Test plan

- [x] `pnpm agent-ci-dev run --workflow .github/workflows/smoke-runner-image.yml -q --json` — passes.
- [x] `pnpm agent-ci-dev run --all -q -p --json` — only `smoke-runner-image > runner-image-override > Run nested agent-ci` flakes under parallel load (Docker-in-Docker contention); same workflow passes clean in isolation on this branch and on `main`. Pre-existing, unrelated to docs-only changes.
- [x] `pnpm typecheck` — passes (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)