### PR TITLE
fix(macos-vm): swallow tart-ip timeout in getIp so waitForIp can retry (#329)

### DIFF
--- a/.changeset/cold-mac-vms-retry.md
+++ b/.changeset/cold-mac-vms-retry.md
@@ -1,0 +1,10 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+fix(macos-vm): let `waitForIp` retry on cold-boot `tart ip` timeouts
+
+`getIp` swallows the `runCommand` rejection that fires when `tart ip` hangs past 5s waiting for a DHCP lease, so `waitForIp` can keep polling for the full 90s budget instead of dying on the first iteration.
+
+Fixes #329.

--- a/packages/cli/src/runner/macos-vm/repro-329.test.ts
+++ b/packages/cli/src/runner/macos-vm/repro-329.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Reproduction for https://github.com/redwoodjs/agent-ci/issues/329
+ *
+ * On cold boot, `tart ip <name>` hangs until the VM grabs a DHCP lease.
+ * runCommand's 5s timeout fires, kills the child, and *rejects* — so getIp's
+ * caller (waitForIp) saw a thrown error on the very first iteration and
+ * killed the macOS VM job before the 90s budget had a chance to elapse.
+ *
+ * Fix: getIp swallows the runCommand rejection and returns null so waitForIp
+ * keeps polling. This test mocks spawn to emit 'error' (the same code path
+ * runCommand takes when the SIGKILL backstop fires) and asserts getIp
+ * resolves to null instead of throwing.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { EventEmitter } from "node:events";
+import * as childProcess from "node:child_process";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeFakeChild(): EventEmitter & {
+  stdout: EventEmitter & { setEncoding: (e: string) => void };
+  stderr: EventEmitter & { setEncoding: (e: string) => void };
+  stdin: { write: (s: string) => void; end: () => void };
+  kill: (signal: string) => void;
+} {
+  const child = new EventEmitter() as ReturnType<typeof makeFakeChild>;
+  const stdout = new EventEmitter() as typeof child.stdout;
+  stdout.setEncoding = () => {};
+  const stderr = new EventEmitter() as typeof child.stderr;
+  stderr.setEncoding = () => {};
+  child.stdout = stdout;
+  child.stderr = stderr;
+  child.stdin = { write: () => {}, end: () => {} };
+  child.kill = () => {};
+  return child;
+}
+
+describe("issue-329 reproduction: getIp swallows runCommand rejection", () => {
+  it("returns null when the underlying spawn errors (cold-boot timeout path)", async () => {
+    const child = makeFakeChild();
+    vi.mocked(childProcess.spawn).mockReturnValue(child as never);
+
+    const { getIp } = await import("./tart.js");
+    const promise = getIp("agent-ci-macos-cold-boot");
+
+    // Same code path runCommand hits when its timer fires and the SIGKILL
+    // backstop blows the child away: 'error' propagates as a Promise rejection.
+    queueMicrotask(() => child.emit("error", new Error("simulated tart ip timeout")));
+
+    await expect(promise).resolves.toBeNull();
+  });
+
+  it("returns null when the underlying spawn exits non-zero", async () => {
+    const child = makeFakeChild();
+    vi.mocked(childProcess.spawn).mockReturnValue(child as never);
+
+    const { getIp } = await import("./tart.js");
+    const promise = getIp("vm-not-yet-leased");
+
+    queueMicrotask(() => child.emit("close", 1));
+
+    await expect(promise).resolves.toBeNull();
+  });
+
+  it("returns the IP on the success path", async () => {
+    const child = makeFakeChild();
+    vi.mocked(childProcess.spawn).mockReturnValue(child as never);
+
+    const { getIp } = await import("./tart.js");
+    const promise = getIp("vm-ready");
+
+    queueMicrotask(() => {
+      child.stdout.emit("data", "192.168.64.42\n");
+      child.emit("close", 0);
+    });
+
+    await expect(promise).resolves.toBe("192.168.64.42");
+  });
+});

--- a/packages/cli/src/runner/macos-vm/tart.ts
+++ b/packages/cli/src/runner/macos-vm/tart.ts
@@ -222,8 +222,11 @@ export function runBackground(
 
 export async function getIp(name: string): Promise<string | null> {
   const [cmd, args] = tartIpArgs(name);
-  const r = await runCommand(cmd, args, { timeoutMs: 5000 });
-  if (r.code !== 0) {
+  // On cold boot the VM hasn't grabbed a DHCP lease yet, so `tart ip` hangs
+  // until the runCommand timeout fires and rejects. Treat that the same as a
+  // non-zero exit — return null so waitForIp can keep polling. (#329)
+  const r = await runCommand(cmd, args, { timeoutMs: 5000 }).catch(() => null);
+  if (!r || r.code !== 0) {
     return null;
   }
   const ip = r.stdout.trim();


### PR DESCRIPTION
## Problem

Issue #329: every fresh macOS virtual machine job fails before the machine has a chance to come online.

After booting a VM, we ask it for its IP address by running `tart ip`. The VM needs a few seconds to get one from the network — that's normal, and we allow up to 90 seconds of polling for it. But each individual `tart ip` call has a 5-second safety timeout. When the VM hasn't picked up an IP yet, that 5-second timeout fires, and our wrapper throws an error instead of returning "no IP yet." The error escapes the retry loop on the very first attempt, killing the job before the VM is ready.

## Solution

Catch the timeout and treat it the same as "the command exited non-zero": return `null`, let the retry loop keep polling. The loop now gets to use its full 90-second budget instead of dying on the first iteration.

## Test plan

- [x] New unit tests cover three cases: the timeout path, the non-zero-exit path, and the success path.
- [x] Existing macOS VM tests still pass.
- [x] Local agent-ci dev run (`pnpm agent-ci-dev run --all`) passes.

Credit to @douglance for the diagnosis and the suggested fix on the issue.