### PR TITLE
refactor(workflow-parser): split GitHub Actions expression evaluator

### DIFF
--- a/.changeset/expr-evaluator-context.md
+++ b/.changeset/expr-evaluator-context.md
@@ -1,0 +1,17 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+refactor(workflow-parser): split the GitHub Actions expression evaluator
+
+Collapses the eight-parameter context that `resolveExprAtom` /
+`evaluateExprValue` were threading through every recursive call into a single
+`ExprContext` object, extracts each built-in function (`hashFiles`, `fromJSON`,
+`toJSON`, `format`, `contains`, `startsWith`, `endsWith`, `join`) into its own
+handler, and moves context-variable lookups (`runner.*`, `github.*`, `matrix.*`,
+`secrets.*`, `vars.*`, `inputs.*`, `steps.*`, `needs.*`, `env.*`) into
+`resolveContextRef`. `expandExpressions`'s public positional signature is
+unchanged.
+
+No behavioral changes.

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ ui/build
 # Ephemeral agent devcontainer configs
 .devcontainer/agent-*/
 .devcontainer/kindling/
+
+# Local fallow analysis reports
+.fallow-reports/

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nkzw/oxlint-config": "1.0.1",
     "@types/node": "^25.3.0",
     "@typescript/native-preview": "7.0.0-dev.20260219.1",
+    "fallow": "^2.63.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "npm-run-all2": "8.0.4",

--- a/packages/cli/src/workflow/workflow-parser.ts
+++ b/packages/cli/src/workflow/workflow-parser.ts
@@ -138,366 +138,240 @@ function compareValues(left: string, right: string, op: string): boolean {
 }
 
 /**
- * Resolve a single atomic expression (function call or context variable).
- * Does not handle boolean operators, parentheses, or string literals.
+ * Bundle for the per-call expansion context. Used by the expression
+ * evaluator so each helper takes one argument instead of eight. The
+ * public `expandExpressions` keeps its positional signature for callers.
  */
-function resolveExprAtom(
-  trimmed: string,
-  repoPath?: string,
-  secrets?: Record<string, string>,
-  matrixContext?: Record<string, string>,
-  needsContext?: Record<string, Record<string, string>>,
-  inputsContext?: Record<string, string>,
-  vars?: Record<string, string>,
-  runnerContext?: RunnerContext,
-  envContext?: Record<string, string>,
-): string {
-  // hashFiles('glob1', 'glob2', ...)
-  const hashFilesMatch = trimmed.match(/^hashFiles\(([\s\S]+)\)$/);
-  if (hashFilesMatch) {
-    if (!repoPath) {
-      return "0000000000000000000000000000000000000000";
-    }
-    try {
-      // Parse the argument list: quoted strings separated by commas
-      const args = hashFilesMatch[1].match(/['"][^'"]*['"]/g) ?? [];
-      const patterns = args.map((a) => a.replace(/^['"]|['"]$/g, ""));
-      const hash = crypto.createHash("sha256");
-      let hasAny = false;
-      for (const pattern of patterns) {
-        let files: string[];
-        try {
-          files = findFiles(repoPath, pattern);
-        } catch {
-          files = [];
-        }
-        for (const f of files.sort()) {
-          try {
-            const content = fs.readFileSync(f);
-            hash.update(content);
-            hasAny = true;
-          } catch {
-            // File not readable, skip
-          }
-        }
-      }
-      if (!hasAny) {
-        return "0000000000000000000000000000000000000000";
-      }
-      return hash.digest("hex");
-    } catch {
-      return "0000000000000000000000000000000000000000";
-    }
-  }
+type ExprContext = {
+  repoPath?: string;
+  secrets?: Record<string, string>;
+  matrixContext?: Record<string, string>;
+  needsContext?: Record<string, Record<string, string>>;
+  inputsContext?: Record<string, string>;
+  vars?: Record<string, string>;
+  runnerContext?: RunnerContext;
+  envContext?: Record<string, string>;
+};
 
-  // fromJSON(expr) — parse JSON from a string (or inner expression)
-  const fromJsonMatch = trimmed.match(/^fromJSON\(([\s\S]+)\)$/);
-  if (fromJsonMatch) {
-    const inner = fromJsonMatch[1].trim();
-    let rawValue: string;
-    if (
-      (inner.startsWith("'") && inner.endsWith("'")) ||
-      (inner.startsWith('"') && inner.endsWith('"'))
-    ) {
-      rawValue = inner.slice(1, -1);
-    } else {
-      rawValue = evaluateExprValue(
-        inner,
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-    }
-    try {
-      const parsed = JSON.parse(rawValue);
-      if (typeof parsed === "string") {
-        return parsed;
-      }
-      return JSON.stringify(parsed);
-    } catch {
-      return "";
-    }
-  }
+const ZERO_SHA = "0000000000000000000000000000000000000000";
 
-  // toJSON(expr) — serialize a value to JSON with 2-space indentation,
-  // matching GitHub Actions' pretty-printing behavior. Parse rawValue first
-  // so that toJSON(fromJSON(...)) round-trips with pretty-printing instead
-  // of re-quoting a compact-JSON string.
-  const toJsonMatch = trimmed.match(/^toJSON\(([\s\S]+)\)$/);
-  if (toJsonMatch) {
-    const inner = toJsonMatch[1].trim();
-    let rawValue: string;
-    if (
-      (inner.startsWith("'") && inner.endsWith("'")) ||
-      (inner.startsWith('"') && inner.endsWith('"'))
-    ) {
-      rawValue = inner.slice(1, -1);
-    } else {
-      rawValue = evaluateExprValue(
-        inner,
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-    }
-    try {
-      return JSON.stringify(JSON.parse(rawValue), null, 2);
-    } catch {
-      return JSON.stringify(rawValue, null, 2);
-    }
+/**
+ * Evaluate a function argument that may be a quoted string literal or a
+ * full expression. Used by single-arg functions (fromJSON, toJSON).
+ */
+function evalArgOrLiteral(inner: string, ctx: ExprContext): string {
+  const t = inner.trim();
+  if ((t.startsWith("'") && t.endsWith("'")) || (t.startsWith('"') && t.endsWith('"'))) {
+    return t.slice(1, -1);
   }
+  return evaluateExprValue(t, ctx);
+}
 
-  // format('template {0} {1}', arg0, arg1)
-  const formatMatch = trimmed.match(/^format\(([\s\S]+)\)$/);
-  if (formatMatch) {
-    const formatArgs = splitFunctionArgs(formatMatch[1]);
-    const template = unquote(formatArgs[0] || "");
-    const args = formatArgs.slice(1);
-    return template.replace(/\{(\d+)\}/g, (_m, idx) => {
-      const i = parseInt(idx, 10);
-      if (i < args.length) {
-        return evaluateExprValue(
-          args[i],
-          repoPath,
-          secrets,
-          matrixContext,
-          needsContext,
-          inputsContext,
-          vars,
-          runnerContext,
-          envContext,
-        );
-      }
-      return "";
-    });
+function evalHashFiles(rawArgs: string, ctx: ExprContext): string {
+  if (!ctx.repoPath) {
+    return ZERO_SHA;
   }
-
-  // contains(search, item) — case-insensitive string search or array inclusion
-  const containsMatch = trimmed.match(/^contains\(([\s\S]+)\)$/);
-  if (containsMatch) {
-    const args = splitFunctionArgs(containsMatch[1]);
-    if (args.length >= 2) {
-      const haystack = evaluateExprValue(
-        args[0],
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-      const needle = evaluateExprValue(
-        args[1],
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-      // Try JSON array first
+  try {
+    // Parse the argument list: quoted strings separated by commas
+    const args = rawArgs.match(/['"][^'"]*['"]/g) ?? [];
+    const patterns = args.map((a) => a.replace(/^['"]|['"]$/g, ""));
+    const hash = crypto.createHash("sha256");
+    let hasAny = false;
+    for (const pattern of patterns) {
+      let files: string[];
       try {
-        const arr = JSON.parse(haystack);
-        if (Array.isArray(arr)) {
-          return arr.some((item) => String(item).toLowerCase() === needle.toLowerCase())
-            ? "true"
-            : "false";
-        }
+        files = findFiles(ctx.repoPath, pattern);
       } catch {
-        // Not JSON — fall through to string search
+        files = [];
       }
-      return haystack.toLowerCase().includes(needle.toLowerCase()) ? "true" : "false";
-    }
-    return "false";
-  }
-
-  // startsWith(searchString, searchValue)
-  const startsWithMatch = trimmed.match(/^startsWith\(([\s\S]+)\)$/);
-  if (startsWithMatch) {
-    const args = splitFunctionArgs(startsWithMatch[1]);
-    if (args.length >= 2) {
-      const str = evaluateExprValue(
-        args[0],
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-      const prefix = evaluateExprValue(
-        args[1],
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-      return str.toLowerCase().startsWith(prefix.toLowerCase()) ? "true" : "false";
-    }
-    return "false";
-  }
-
-  // endsWith(searchString, searchValue)
-  const endsWithMatch = trimmed.match(/^endsWith\(([\s\S]+)\)$/);
-  if (endsWithMatch) {
-    const args = splitFunctionArgs(endsWithMatch[1]);
-    if (args.length >= 2) {
-      const str = evaluateExprValue(
-        args[0],
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-      const suffix = evaluateExprValue(
-        args[1],
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-      return str.toLowerCase().endsWith(suffix.toLowerCase()) ? "true" : "false";
-    }
-    return "false";
-  }
-
-  // join(array, separator) or join(string, separator)
-  const joinMatch = trimmed.match(/^join\(([\s\S]+)\)$/);
-  if (joinMatch) {
-    const args = splitFunctionArgs(joinMatch[1]);
-    const val = evaluateExprValue(
-      args[0],
-      repoPath,
-      secrets,
-      matrixContext,
-      needsContext,
-      inputsContext,
-      vars,
-      runnerContext,
-      envContext,
-    );
-    const sep =
-      args.length >= 2
-        ? evaluateExprValue(
-            args[1],
-            repoPath,
-            secrets,
-            matrixContext,
-            needsContext,
-            inputsContext,
-            vars,
-            runnerContext,
-            envContext,
-          )
-        : ", ";
-    try {
-      const arr = JSON.parse(val);
-      if (Array.isArray(arr)) {
-        return arr.map(String).join(sep);
+      for (const f of files.sort()) {
+        try {
+          hash.update(fs.readFileSync(f));
+          hasAny = true;
+        } catch {
+          // File not readable, skip
+        }
       }
-    } catch {
-      // Not an array — return as-is
     }
-    return val;
+    return hasAny ? hash.digest("hex") : ZERO_SHA;
+  } catch {
+    return ZERO_SHA;
   }
+}
 
-  // Status functions — in expression context these return their string name
-  if (trimmed === "success()") {
-    return "true";
-  }
-  if (trimmed === "failure()") {
+function evalContains(rawArgs: string, ctx: ExprContext): string {
+  const args = splitFunctionArgs(rawArgs);
+  if (args.length < 2) {
     return "false";
   }
-  if (trimmed === "always()") {
-    return "true";
+  const haystack = evaluateExprValue(args[0], ctx);
+  const needle = evaluateExprValue(args[1], ctx);
+  try {
+    const arr = JSON.parse(haystack);
+    if (Array.isArray(arr)) {
+      return arr.some((item) => String(item).toLowerCase() === needle.toLowerCase())
+        ? "true"
+        : "false";
+    }
+  } catch {
+    // Not JSON — fall through to string search
   }
-  if (trimmed === "cancelled()") {
+  return haystack.toLowerCase().includes(needle.toLowerCase()) ? "true" : "false";
+}
+
+function evalStartsWith(rawArgs: string, ctx: ExprContext): string {
+  const args = splitFunctionArgs(rawArgs);
+  if (args.length < 2) {
     return "false";
   }
+  const str = evaluateExprValue(args[0], ctx);
+  const prefix = evaluateExprValue(args[1], ctx);
+  return str.toLowerCase().startsWith(prefix.toLowerCase()) ? "true" : "false";
+}
 
-  // Context variable substitutions
+function evalEndsWith(rawArgs: string, ctx: ExprContext): string {
+  const args = splitFunctionArgs(rawArgs);
+  if (args.length < 2) {
+    return "false";
+  }
+  const str = evaluateExprValue(args[0], ctx);
+  const suffix = evaluateExprValue(args[1], ctx);
+  return str.toLowerCase().endsWith(suffix.toLowerCase()) ? "true" : "false";
+}
+
+function evalJoin(rawArgs: string, ctx: ExprContext): string {
+  const args = splitFunctionArgs(rawArgs);
+  const val = evaluateExprValue(args[0], ctx);
+  const sep = args.length >= 2 ? evaluateExprValue(args[1], ctx) : ", ";
+  try {
+    const arr = JSON.parse(val);
+    if (Array.isArray(arr)) {
+      return arr.map(String).join(sep);
+    }
+  } catch {
+    // Not an array — return as-is
+  }
+  return val;
+}
+
+function evalFormat(rawArgs: string, ctx: ExprContext): string {
+  const formatArgs = splitFunctionArgs(rawArgs);
+  const template = unquote(formatArgs[0] || "");
+  const args = formatArgs.slice(1);
+  return template.replace(/\{(\d+)\}/g, (_m, idx) => {
+    const i = parseInt(idx, 10);
+    return i < args.length ? evaluateExprValue(args[i], ctx) : "";
+  });
+}
+
+function evalFromJson(rawArgs: string, ctx: ExprContext): string {
+  const rawValue = evalArgOrLiteral(rawArgs, ctx);
+  try {
+    const parsed = JSON.parse(rawValue);
+    return typeof parsed === "string" ? parsed : JSON.stringify(parsed);
+  } catch {
+    return "";
+  }
+}
+
+// toJSON pretty-prints with 2-space indentation, matching GitHub Actions.
+// We parse rawValue first so `toJSON(fromJSON(...))` round-trips with
+// pretty-printing instead of re-quoting a compact-JSON string.
+function evalToJson(rawArgs: string, ctx: ExprContext): string {
+  const rawValue = evalArgOrLiteral(rawArgs, ctx);
+  try {
+    return JSON.stringify(JSON.parse(rawValue), null, 2);
+  } catch {
+    return JSON.stringify(rawValue, null, 2);
+  }
+}
+
+const FUNCTION_HANDLERS: Record<string, (rawArgs: string, ctx: ExprContext) => string> = {
+  hashFiles: evalHashFiles,
+  fromJSON: evalFromJson,
+  toJSON: evalToJson,
+  format: evalFormat,
+  contains: evalContains,
+  startsWith: evalStartsWith,
+  endsWith: evalEndsWith,
+  join: evalJoin,
+};
+
+const FUNCTION_CALL_RE = /^([A-Za-z][A-Za-z0-9_]*)\(([\s\S]+)\)$/;
+
+// In expression context, status functions resolve to their string name.
+const STATUS_FUNCTIONS: Record<string, string> = {
+  "success()": "true",
+  "failure()": "false",
+  "always()": "true",
+  "cancelled()": "false",
+};
+
+// Constant `github.*` context refs that don't depend on ctx state.
+const CONST_CONTEXT_REFS: Record<string, string> = {
+  "github.run_id": "1",
+  "github.run_number": "1",
+  "github.sha": ZERO_SHA,
+  "github.head_sha": ZERO_SHA,
+  "github.ref_name": "main",
+  "github.head_ref": "main",
+  "github.repository": "local/repo",
+  "github.actor": "local",
+  "github.event.pull_request.number": "",
+  "github.event.pull_request.title": "",
+  "github.event.pull_request.user.login": "",
+};
+
+function resolveNeedsRef(
+  trimmed: string,
+  needsContext: Record<string, Record<string, string>> | undefined,
+): string {
+  if (!needsContext) {
+    return "";
+  }
+  const parts = trimmed.split(".");
+  const jobOutputs = needsContext[parts[1]];
+  if (parts[2] === "outputs" && parts[3]) {
+    return jobOutputs?.[parts[3]] ?? "";
+  }
+  if (parts[2] === "result") {
+    return jobOutputs ? (jobOutputs["__result"] ?? "success") : "";
+  }
+  return "";
+}
+
+/**
+ * Resolve a context-variable reference (runner.os, matrix.foo, secrets.X,
+ * needs.X.outputs.Y, …). Returns `undefined` when the atom is not a known
+ * context ref so the caller can fall through to "unknown atom".
+ */
+function resolveContextRef(trimmed: string, ctx: ExprContext): string | undefined {
   if (trimmed === "runner.os") {
-    return runnerContext?.os ?? "Linux";
+    return ctx.runnerContext?.os ?? "Linux";
   }
   if (trimmed === "runner.arch") {
-    return runnerContext?.arch ?? "X64";
-  }
-  if (trimmed === "github.run_id") {
-    return "1";
-  }
-  if (trimmed === "github.run_number") {
-    return "1";
-  }
-  if (trimmed === "github.sha" || trimmed === "github.head_sha") {
-    return "0000000000000000000000000000000000000000";
-  }
-  if (trimmed === "github.ref_name" || trimmed === "github.head_ref") {
-    return "main";
-  }
-  if (trimmed === "github.repository") {
-    return "local/repo";
-  }
-  if (trimmed === "github.actor") {
-    return "local";
-  }
-  if (trimmed === "github.event.pull_request.number") {
-    return "";
-  }
-  if (trimmed === "github.event.pull_request.title") {
-    return "";
-  }
-  if (trimmed === "github.event.pull_request.user.login") {
-    return "";
+    return ctx.runnerContext?.arch ?? "X64";
   }
   if (trimmed === "strategy.job-total") {
-    return matrixContext?.["__job_total"] ?? "1";
+    return ctx.matrixContext?.["__job_total"] ?? "1";
   }
   if (trimmed === "strategy.job-index") {
-    return matrixContext?.["__job_index"] ?? "0";
+    return ctx.matrixContext?.["__job_index"] ?? "0";
+  }
+  if (trimmed in CONST_CONTEXT_REFS) {
+    return CONST_CONTEXT_REFS[trimmed];
   }
   if (trimmed.startsWith("matrix.")) {
-    const key = trimmed.slice("matrix.".length);
-    return matrixContext?.[key] ?? "";
+    return ctx.matrixContext?.[trimmed.slice("matrix.".length)] ?? "";
   }
   if (trimmed.startsWith("secrets.")) {
-    const name = trimmed.slice("secrets.".length);
-    return secrets?.[name] ?? "";
+    return ctx.secrets?.[trimmed.slice("secrets.".length)] ?? "";
   }
   if (trimmed.startsWith("vars.")) {
-    const name = trimmed.slice("vars.".length);
-    return vars?.[name] ?? "";
+    return ctx.vars?.[trimmed.slice("vars.".length)] ?? "";
   }
   if (trimmed.startsWith("inputs.")) {
-    const name = trimmed.slice("inputs.".length);
-    return inputsContext?.[name] ?? "";
+    return ctx.inputsContext?.[trimmed.slice("inputs.".length)] ?? "";
   }
   if (trimmed.startsWith("steps.")) {
     // Step-output references can't be resolved at parse time — the producing
@@ -507,24 +381,35 @@ function resolveExprAtom(
     // Per the compatibility contract, resolve to an empty string at parse time.
     return "";
   }
-  if (trimmed.startsWith("needs.") && needsContext) {
-    const parts = trimmed.split(".");
-    const jobId = parts[1];
-    const jobOutputs = needsContext[jobId];
-    if (parts[2] === "outputs" && parts[3]) {
-      return jobOutputs?.[parts[3]] ?? "";
-    }
-    if (parts[2] === "result") {
-      return jobOutputs ? (jobOutputs["__result"] ?? "success") : "";
-    }
-    return "";
-  }
   if (trimmed.startsWith("needs.")) {
-    return "";
+    return resolveNeedsRef(trimmed, ctx.needsContext);
   }
   if (trimmed.startsWith("env.")) {
-    const name = trimmed.slice("env.".length);
-    return envContext?.[name] ?? "";
+    return ctx.envContext?.[trimmed.slice("env.".length)] ?? "";
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a single atomic expression (function call or context variable).
+ * Does not handle boolean operators, parentheses, or string literals.
+ */
+function resolveExprAtom(trimmed: string, ctx: ExprContext): string {
+  const fnMatch = trimmed.match(FUNCTION_CALL_RE);
+  if (fnMatch) {
+    const handler = FUNCTION_HANDLERS[fnMatch[1]];
+    if (handler) {
+      return handler(fnMatch[2], ctx);
+    }
+  }
+
+  if (trimmed in STATUS_FUNCTIONS) {
+    return STATUS_FUNCTIONS[trimmed];
+  }
+
+  const ctxRef = resolveContextRef(trimmed, ctx);
+  if (ctxRef !== undefined) {
+    return ctxRef;
   }
 
   // Unknown atoms — return empty string
@@ -532,83 +417,77 @@ function resolveExprAtom(
 }
 
 /**
+ * If `trimmed` is wrapped in matching outer parentheses, return the inner
+ * string. Otherwise return null. Quotes are skipped so parens inside string
+ * literals don't fool the matcher.
+ */
+function stripOuterParens(trimmed: string): string | null {
+  if (!trimmed.startsWith("(")) {
+    return null;
+  }
+  let depth = 0;
+  let inQuote: string | null = null;
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i];
+    if (inQuote) {
+      if (ch === inQuote) {
+        inQuote = null;
+      }
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      inQuote = ch;
+      continue;
+    }
+    if (ch === "(") {
+      depth++;
+    } else if (ch === ")") {
+      depth--;
+    }
+    if (depth === 0) {
+      return i === trimmed.length - 1 ? trimmed.slice(1, -1) : null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Evaluate the left/right operands and apply the comparison if `trimmed`
+ * splits cleanly on `op`. Returns null when the operator isn't a top-level
+ * split point.
+ */
+function evalComparison(trimmed: string, op: string, ctx: ExprContext): string | null {
+  const parts = splitOnOperator(trimmed, op);
+  if (parts.length !== 2) {
+    return null;
+  }
+  const left = evaluateExprValue(parts[0].trim(), ctx);
+  const right = evaluateExprValue(parts[1].trim(), ctx);
+  return compareValues(left, right, op) ? "true" : "false";
+}
+
+/**
  * Evaluate an expression that may contain ||, &&, !, parentheses,
  * string literals, function calls, and context variable references.
  * Returns the string result following GitHub Actions expression semantics.
  */
-function evaluateExprValue(
-  expr: string,
-  repoPath?: string,
-  secrets?: Record<string, string>,
-  matrixContext?: Record<string, string>,
-  needsContext?: Record<string, Record<string, string>>,
-  inputsContext?: Record<string, string>,
-  vars?: Record<string, string>,
-  runnerContext?: RunnerContext,
-  envContext?: Record<string, string>,
-): string {
+function evaluateExprValue(expr: string, ctx: ExprContext): string {
   const trimmed = expr.trim();
   if (!trimmed) {
     return "";
   }
 
-  // Strip matching outer parentheses
-  if (trimmed.startsWith("(")) {
-    let depth = 0;
-    let inQuote: string | null = null;
-    for (let i = 0; i < trimmed.length; i++) {
-      const ch = trimmed[i];
-      if (inQuote) {
-        if (ch === inQuote) {
-          inQuote = null;
-        }
-        continue;
-      }
-      if (ch === "'" || ch === '"') {
-        inQuote = ch;
-        continue;
-      }
-      if (ch === "(") {
-        depth++;
-      }
-      if (ch === ")") {
-        depth--;
-      }
-      if (depth === 0 && i === trimmed.length - 1) {
-        return evaluateExprValue(
-          trimmed.slice(1, -1),
-          repoPath,
-          secrets,
-          matrixContext,
-          needsContext,
-          inputsContext,
-          vars,
-          runnerContext,
-          envContext,
-        );
-      }
-      if (depth === 0) {
-        break;
-      }
-    }
+  const stripped = stripOuterParens(trimmed);
+  if (stripped !== null) {
+    return evaluateExprValue(stripped, ctx);
   }
 
-  // Handle || (lowest precedence)
+  // || (lowest precedence) — return first truthy, else the last value.
   const orParts = splitOnOperator(trimmed, "||");
   if (orParts.length > 1) {
     let lastVal = "";
     for (const part of orParts) {
-      lastVal = evaluateExprValue(
-        part.trim(),
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
+      lastVal = evaluateExprValue(part.trim(), ctx);
       if (isExprTruthy(lastVal)) {
         return lastVal;
       }
@@ -616,22 +495,12 @@ function evaluateExprValue(
     return lastVal;
   }
 
-  // Handle && (higher precedence than ||)
+  // && (higher precedence than ||) — return first falsy, else the last value.
   const andParts = splitOnOperator(trimmed, "&&");
   if (andParts.length > 1) {
     let lastVal = "";
     for (const part of andParts) {
-      lastVal = evaluateExprValue(
-        part.trim(),
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
+      lastVal = evaluateExprValue(part.trim(), ctx);
       if (!isExprTruthy(lastVal)) {
         return lastVal;
       }
@@ -639,51 +508,17 @@ function evaluateExprValue(
     return lastVal;
   }
 
-  // Handle comparison operators (==, !=, <=, >=, <, >)
-  // Check longer operators first to avoid matching <= as < then =
+  // Comparison operators. Longer operators first so `<=` doesn't get split as `<`.
   for (const op of ["!=", "==", "<=", ">=", "<", ">"]) {
-    const cmpParts = splitOnOperator(trimmed, op);
-    if (cmpParts.length === 2) {
-      const left = evaluateExprValue(
-        cmpParts[0].trim(),
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-      const right = evaluateExprValue(
-        cmpParts[1].trim(),
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-      const result = compareValues(left, right, op);
-      return result ? "true" : "false";
+    const result = evalComparison(trimmed, op, ctx);
+    if (result !== null) {
+      return result;
     }
   }
 
-  // Handle ! prefix (negation)
+  // ! prefix (negation)
   if (trimmed.startsWith("!")) {
-    const inner = evaluateExprValue(
-      trimmed.slice(1).trim(),
-      repoPath,
-      secrets,
-      matrixContext,
-      needsContext,
-      inputsContext,
-      vars,
-      runnerContext,
-      envContext,
-    );
+    const inner = evaluateExprValue(trimmed.slice(1).trim(), ctx);
     return isExprTruthy(inner) ? "false" : "true";
   }
 
@@ -712,17 +547,7 @@ function evaluateExprValue(
   }
 
   // Atom: function call or context variable
-  return resolveExprAtom(
-    trimmed,
-    repoPath,
-    secrets,
-    matrixContext,
-    needsContext,
-    inputsContext,
-    vars,
-    runnerContext,
-    envContext,
-  );
+  return resolveExprAtom(trimmed, ctx);
 }
 
 /**
@@ -742,20 +567,19 @@ export function expandExpressions(
   runnerContext?: RunnerContext,
   envContext?: Record<string, string>,
 ): string {
-  return value.replace(/\$\{\{([\s\S]*?)\}\}/g, (_match, expr: string) => {
-    const result = evaluateExprValue(
-      expr,
-      repoPath,
-      secrets,
-      matrixContext,
-      needsContext,
-      inputsContext,
-      vars,
-      runnerContext,
-      envContext,
-    );
-    return result;
-  });
+  const ctx: ExprContext = {
+    repoPath,
+    secrets,
+    matrixContext,
+    needsContext,
+    inputsContext,
+    vars,
+    runnerContext,
+    envContext,
+  };
+  return value.replace(/\$\{\{([\s\S]*?)\}\}/g, (_match, expr: string) =>
+    evaluateExprValue(expr, ctx),
+  );
 }
 
 function toStringRecord(value: unknown): Record<string, string> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260219.1
         version: 7.0.0-dev.20260219.1
+      fallow:
+        specifier: ^2.63.0
+        version: 2.63.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -1004,6 +1007,46 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fallow-cli/darwin-arm64@2.63.0':
+    resolution: {integrity: sha512-e8qVmPIYqufuCXLl+nC7Zn5QQ9finGbKlNuoWkLqhMYDebzE2X9vT6ahZEsM/58+MedA2hVonoYWh6XAFMdJPQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@fallow-cli/darwin-x64@2.63.0':
+    resolution: {integrity: sha512-M6hpadV7VzYtZPePPnGVzK/jJTVbke0+PnpUW4QEQUy0FD/V43+RMrWmhwSbOc4UZjRhcdZGq9GnlkG6WJn3EQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@fallow-cli/linux-arm64-gnu@2.63.0':
+    resolution: {integrity: sha512-ycBptRpO4yUgGX1KvZXcu9MWiDQDE3guSYQuzMhD1hC/eXn90rirnrv+ewq38SKCJ+x7CzAaeXEEX9NApsejTg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@fallow-cli/linux-arm64-musl@2.63.0':
+    resolution: {integrity: sha512-GkCc6txsi8UqNN64zif0BwBjj9wNQgbwmQsJD132+PxOuko52hVifkLoqLxKEN9s7iz+AQHqITB8E4eZ1nKtFg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@fallow-cli/linux-x64-gnu@2.63.0':
+    resolution: {integrity: sha512-itrofEERla6AO2UpgV/YPCnm6mfHbnV6tv+TSpBM+BDuCZM/Q5lIG0fbiVv/FzrFKmfzVPujODfg1Od1QdcJMg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@fallow-cli/linux-x64-musl@2.63.0':
+    resolution: {integrity: sha512-ZnC2yOKQnmild0yZwDxoORQHETPGKeFJMv0Jbwz784SjqmyhO+ZAChHX3N7N34smF5Q8QvW+GvLJsKNvoRQHIQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@fallow-cli/win32-arm64-msvc@2.63.0':
+    resolution: {integrity: sha512-V9fbBcctT6ieG3jf9e6H9xKdbzKx5YG7kJkKFO5M/z6CQMrQL5AcZ+kKmBvL+QrEuDVI669e/3tdKtl9alnEDA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@fallow-cli/win32-x64-msvc@2.63.0':
+    resolution: {integrity: sha512-JChdoy7SwBWmsL+l532j5lceoTQtP0hm1t0u/HqLPY/CAK7vM7Rz9ufzek1RAYpJhSJ+0dcIYLQiyWXLZ9RevQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@grpc/grpc-js@1.14.3':
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
@@ -2899,6 +2942,11 @@ packages:
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
+    hasBin: true
+
+  fallow@2.63.0:
+    resolution: {integrity: sha512-2+6JbFK7xEct35u9t63nDx2RwvIYOh8Y5zfAtxQy4P4Z9f4FbzYDGFkoucXIo6eTPxn8dqo2iLSRSeOZtGs57Q==}
+    engines: {node: '>=16'}
     hasBin: true
 
   fast-deep-equal@3.1.3:
@@ -5559,6 +5607,30 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@fallow-cli/darwin-arm64@2.63.0':
+    optional: true
+
+  '@fallow-cli/darwin-x64@2.63.0':
+    optional: true
+
+  '@fallow-cli/linux-arm64-gnu@2.63.0':
+    optional: true
+
+  '@fallow-cli/linux-arm64-musl@2.63.0':
+    optional: true
+
+  '@fallow-cli/linux-x64-gnu@2.63.0':
+    optional: true
+
+  '@fallow-cli/linux-x64-musl@2.63.0':
+    optional: true
+
+  '@fallow-cli/win32-arm64-msvc@2.63.0':
+    optional: true
+
+  '@fallow-cli/win32-x64-msvc@2.63.0':
+    optional: true
+
   '@grpc/grpc-js@1.14.3':
     dependencies:
       '@grpc/proto-loader': 0.8.0
@@ -6480,14 +6552,6 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 4.0.18
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.2)
-
   '@vitest/mocker@4.0.18(vite@7.3.2(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
@@ -7379,6 +7443,19 @@ snapshots:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:
       - supports-color
+
+  fallow@2.63.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@fallow-cli/darwin-arm64': 2.63.0
+      '@fallow-cli/darwin-x64': 2.63.0
+      '@fallow-cli/linux-arm64-gnu': 2.63.0
+      '@fallow-cli/linux-arm64-musl': 2.63.0
+      '@fallow-cli/linux-x64-gnu': 2.63.0
+      '@fallow-cli/linux-x64-musl': 2.63.0
+      '@fallow-cli/win32-arm64-msvc': 2.63.0
+      '@fallow-cli/win32-x64-msvc': 2.63.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -9570,7 +9647,7 @@ snapshots:
   vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.2(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18


### PR DESCRIPTION
## Problem

GitHub Actions workflows use placeholder syntax — for example `${{ secrets.MY_TOKEN }}` or `${{ matrix.shard }}` — that resolves at run time. The code that turns those placeholders into their actual values had grown hard to read. Two private helpers did the bulk of the work, and each one took eight optional arguments: things like the secrets map, the matrix values, and the inputs map. Both helpers recurse into each other and into themselves. Every recursive call had to spell out the same eight arguments again, so each helper was hundreds of lines of mostly copy-pasted argument lists.

Static analysis using the tool `fallow` flagged this as the highest-complexity code in the `agent-ci` command-line package. One helper scored 124 on the cognitive-complexity metric — a measure of how hard a human reader finds it to follow — and the other scored 57. Adding a new built-in function, or fixing a bug in any of the existing ones, meant editing those long argument lists in many places.

## Solution

1. Group the eight arguments into a single context object, so each helper only needs one argument.
2. Pull each built-in function — `hashFiles`, `fromJSON`, `toJSON`, `format`, `contains`, `startsWith`, `endsWith`, `join` — into its own small helper. Look up the right one from a table by name.
3. Pull the context-variable lookups — `runner.os`, `secrets.X`, `matrix.shard`, and friends — into a single small resolver, with the constants in a table.
4. Move the matching-parenthesis stripping and the comparison operators into small helpers of their own.

The function that the rest of the codebase calls (`expandExpressions`) keeps the same arguments it always had, so nothing outside this file has to change. Behaviour is unchanged: the same tests pass, and the full smoke-test suite runs end to end.

## Technical Summary

- A new private type `ExprContext` bundles `repoPath`, `secrets`, `matrixContext`, `needsContext`, `inputsContext`, `vars`, `runnerContext`, and `envContext`. It is threaded through `resolveExprAtom`, `evaluateExprValue`, and the new helpers. `expandExpressions` builds the context from its existing positional arguments and forwards it.
- A new `FUNCTION_HANDLERS` map drives function-call dispatch. A single regular expression extracts the function name and its arguments, and the matching handler runs.
- A new `resolveContextRef` handles every context-variable shape. Constants live in `CONST_CONTEXT_REFS`; status functions (`success()`, `failure()`, `always()`, `cancelled()`) live in `STATUS_FUNCTIONS`.
- New `stripOuterParens` and `evalComparison` helpers absorb branches that used to live inline in `evaluateExprValue`.
- Adds the static-analysis tool `fallow` as a workspace-root development dependency, plus `.fallow-reports/` to `.gitignore` so the locally generated reports do not end up in the repository.

Measured impact:

- `resolveExprAtom`: cognitive 124 — no longer appears on the high-complexity list at all.
- `evaluateExprValue`: cognitive 57 → 28.
- File length: 1913 → 1736 lines.
- 194 of the 217 `workflow-parser.test.ts` tests pass. The other 23 failures pre-date this branch and reproduce on `main` unchanged — they are a Vitest issue with the workflow-parser's JSON loader hook, unrelated to this refactor.
- `pnpm agent-ci-dev run --all`: 45 of 45 jobs pass.