### PR TITLE
chore: drop three unused runtime dependencies

### DIFF
--- a/.changeset/drop-unused-deps.md
+++ b/.changeset/drop-unused-deps.md
@@ -1,0 +1,19 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+chore: remove unused runtime dependencies
+
+Three runtime dependencies were declared in `package.json` files but
+never imported by any source file in the package:
+
+- `log-update` from `@redwoodjs/agent-ci` (the diff-renderer module
+  replaced it long ago; only stale code comments remain).
+- `jsonc-parser` from `dtu-github-actions`.
+- `yaml` from `@redwoodjs/ts-runner` (the `cli` package still depends
+  on `yaml`; this only drops the unused declaration in `ts-runner`).
+
+Smaller `node_modules`, smaller published packages, and one fewer
+thing to keep up to date when the upstream releases a new version.
+No runtime behaviour change.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,6 @@
     "@actions/workflow-parser": "0.3.43",
     "dockerode": "^4.0.2",
     "dtu-github-actions": "workspace:*",
-    "log-update": "^7.2.0",
     "minimatch": "^10.2.1",
     "yaml": "^2.8.2"
   },

--- a/packages/dtu-github-actions/package.json
+++ b/packages/dtu-github-actions/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "body-parser": "^2.2.2",
-    "jsonc-parser": "^3.3.1",
     "minimatch": "^10.2.4",
     "polka": "^0.5.2",
     "zod": "^3.24.1"

--- a/packages/ts-runner/package.json
+++ b/packages/ts-runner/package.json
@@ -33,9 +33,6 @@
     "typecheck": "tsgo",
     "ts-runner": "tsx src/cli.ts"
   },
-  "dependencies": {
-    "yaml": "^2.8.2"
-  },
   "devDependencies": {
     "@types/node": "^22.10.2",
     "tsx": "^4.21.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,9 +123,6 @@ importers:
       dtu-github-actions:
         specifier: workspace:*
         version: link:../dtu-github-actions
-      log-update:
-        specifier: ^7.2.0
-        version: 7.2.0
       minimatch:
         specifier: ^10.2.1
         version: 10.2.4
@@ -151,9 +148,6 @@ importers:
       body-parser:
         specifier: ^2.2.2
         version: 2.2.2
-      jsonc-parser:
-        specifier: ^3.3.1
-        version: 3.3.1
       minimatch:
         specifier: ^10.2.4
         version: 10.2.4
@@ -181,10 +175,6 @@ importers:
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/ts-runner:
-    dependencies:
-      yaml:
-        specifier: ^2.8.2
-        version: 2.8.2
     devDependencies:
       '@types/node':
         specifier: ^22.10.2
@@ -3529,10 +3519,6 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
-  log-update@7.2.0:
-    resolution: {integrity: sha512-iLs7dGSyjZiUgvrUvuD3FndAxVJk+TywBkkkwUSm9HdYoskJalWg5qVsEiXeufPvRVPbCUmNQewg798rx+sPXg==}
-    engines: {node: '>=20'}
-
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
@@ -4297,10 +4283,6 @@ packages:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
 
-  slice-ansi@8.0.0:
-    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
-    engines: {node: '>=20'}
-
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -4388,10 +4370,6 @@ packages:
 
   strip-ansi@7.1.2:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
-    engines: {node: '>=12'}
-
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
   strip-bom-string@1.0.0:
@@ -4827,10 +4805,6 @@ packages:
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
-
-  wrap-ansi@10.0.0:
-    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
-    engines: {node: '>=20'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -8054,14 +8028,6 @@ snapshots:
       strip-ansi: 7.1.2
       wrap-ansi: 9.0.2
 
-  log-update@7.2.0:
-    dependencies:
-      ansi-escapes: 7.3.0
-      cli-cursor: 5.0.0
-      slice-ansi: 8.0.0
-      strip-ansi: 7.2.0
-      wrap-ansi: 10.0.0
-
   long@5.3.2: {}
 
   longest-streak@3.1.0: {}
@@ -9169,11 +9135,6 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  slice-ansi@8.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
-
   smart-buffer@4.2.0: {}
 
   socks-proxy-agent@8.0.5:
@@ -9271,10 +9232,6 @@ snapshots:
       ansi-regex: 5.0.1
 
   strip-ansi@7.1.2:
-    dependencies:
-      ansi-regex: 6.2.2
-
-  strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
 
@@ -9814,12 +9771,6 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-
-  wrap-ansi@10.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 8.2.0
-      strip-ansi: 7.2.0
 
   wrap-ansi@7.0.0:
     dependencies:


### PR DESCRIPTION
## Problem

Three runtime dependencies were declared in three different `package.json` files but were never imported by any source file in the package that declared them. Each one bloats `node_modules`, adds bytes to the published tarball, and shows up on every dependency-update report we get — for no benefit.

The static-analysis tool fallow flagged all three after the configuration added in #338. They are:

- `log-update` in `@redwoodjs/agent-ci`. We used to use it to render the live progress display, but the diff-renderer module replaced that long ago. Only stale code comments still mention the name.
- `jsonc-parser` in `dtu-github-actions`. Nothing in the package imports it.
- `yaml` in `@redwoodjs/ts-runner`. The `@redwoodjs/agent-ci` package still depends on `yaml` and continues to use it; only the unused declaration in `ts-runner` is removed.

Three packages flagged in the website project (`clsx`, `tailwind-merge`, `react-server-dom-webpack`) are intentionally left in place. They may be implicit peer dependencies needed by rwsdk's server-component runtime, and verifying that needs a fresh website install plus a runtime check — out of scope for this change.

## Solution

Delete the three unused dependency declarations from their respective `package.json` files. Re-resolve `pnpm-lock.yaml`. Add a patch-level changeset.

## Technical Summary

- `packages/cli/package.json`: remove `log-update` from `dependencies`.
- `packages/dtu-github-actions/package.json`: remove `jsonc-parser` from `dependencies`.
- `packages/ts-runner/package.json`: remove `yaml` (the only entry in `dependencies`), leaving the package with `devDependencies` only.
- `pnpm-lock.yaml`: re-resolved.
- `.changeset/drop-unused-deps.md`: patch bump for both publishable packages.
- `pnpm check` passes (typecheck, lint, format, compatibility-table, diff-parse).

Stacked on top of #337. Once #337 merges, this can be rebased onto `main` cleanly.