### PR TITLE
refactor(local-job): lift the timeline-sync closure to module scope

### DIFF
--- a/.changeset/expr-evaluator-context.md
+++ b/.changeset/expr-evaluator-context.md
@@ -1,0 +1,17 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+refactor(workflow-parser): split the GitHub Actions expression evaluator
+
+Collapses the eight-parameter context that `resolveExprAtom` /
+`evaluateExprValue` were threading through every recursive call into a single
+`ExprContext` object, extracts each built-in function (`hashFiles`, `fromJSON`,
+`toJSON`, `format`, `contains`, `startsWith`, `endsWith`, `join`) into its own
+handler, and moves context-variable lookups (`runner.*`, `github.*`, `matrix.*`,
+`secrets.*`, `vars.*`, `inputs.*`, `steps.*`, `needs.*`, `env.*`) into
+`resolveContextRef`. `expandExpressions`'s public positional signature is
+unchanged.
+
+No behavioral changes.

--- a/.changeset/local-job-extract-helpers.md
+++ b/.changeset/local-job-extract-helpers.md
@@ -1,0 +1,24 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+refactor(local-job): extract three helpers out of `executeLocalJob`
+
+`executeLocalJob` had grown to ~860 lines and scored 73 on the
+cognitive-complexity metric — the highest in the `cli` package after
+the previous round of refactors. Three self-contained blocks of code
+inside it have been moved into module-scope helpers:
+
+- `pullContainerImageWithProgress(docker, image, store, containerName)`
+  — the ~100-line Docker pull with per-layer download / extract
+  progress reporting (direct-container mode).
+- `seedRunnerBinaryToHost(docker, hostRunnerSeedDir)` — the one-time
+  extraction of the actions-runner binary from the seed image
+  (direct-container mode).
+- `waitForContainerExit(container, waitPromise, timeoutMs)` — the
+  promise-race that force-stops the container if the runner does not
+  exit within the timeout.
+
+`executeLocalJob` is now ~715 lines, cognitive 56. No behaviour
+change; the full local smoke suite passes.

--- a/.changeset/local-job-timeline-sync.md
+++ b/.changeset/local-job-timeline-sync.md
@@ -1,0 +1,29 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+refactor(local-job): lift the timeline-sync closure to module scope
+
+`executeLocalJob` had a ~190-line `updateStoreFromTimeline` closure
+that read `timeline.json` plus the paused-signal file every 100ms and
+updated the RunStateStore. The closure captured six mutable `let`
+variables defined just above it; fallow's previous report flagged it
+as the biggest remaining complexity hotspot (cognitive 70).
+
+This change pulls the closure to module scope as two helpers:
+
+- `syncTimelineToStore(state, ctx)` — drives one poll tick. Cognitive
+  score 22.
+- `buildStepsFromTimeline(steps, state)` — folds the raw timeline
+  records into the `StepState[]` shape the renderer expects. Cognitive
+  score 45.
+
+Both take an explicit `TimelineSyncState` object that the polling loop
+mutates between ticks, plus a read-only `TimelineSyncContext` with the
+paths, store reference, and `onNewPause` callback.
+
+Also drops `padW` / `totalSteps` from the old closure — they were
+computed but never used (legacy padding logic).
+
+No behaviour change; the full local smoke suite passes 45/45.

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ ui/build
 # Ephemeral agent devcontainer configs
 .devcontainer/agent-*/
 .devcontainer/kindling/
+
+# Local fallow analysis reports
+.fallow-reports/

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nkzw/oxlint-config": "1.0.1",
     "@types/node": "^25.3.0",
     "@typescript/native-preview": "7.0.0-dev.20260219.1",
+    "fallow": "^2.63.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "npm-run-all2": "8.0.4",

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -130,6 +130,190 @@ const SEED_IMAGE = UPSTREAM_RUNNER_IMAGE;
 
 import { writeRunnerCredentials } from "./runner-credentials.js";
 
+const CONTAINER_EXIT_TIMEOUT_MS = 30_000;
+
+/**
+ * Pull a Docker image and report per-layer download / extraction progress to
+ * the RunStateStore. Resolves once the pull completes. Rejects on any error
+ * the daemon surfaces.
+ */
+async function pullContainerImageWithProgress(
+  docker: Docker,
+  image: string,
+  store: RunStateStore | undefined,
+  containerName: string,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    docker.pull(image, (err: Error | null, stream: NodeJS.ReadableStream) => {
+      if (err) {
+        return reject(err);
+      }
+      // Track per-layer progress across download and extraction phases
+      const downloadProgress = new Map<string, { current: number; total: number }>();
+      const extractProgress = new Map<string, { current: number; total: number }>();
+      let lastProgressUpdate = 0;
+      let currentPhase: "downloading" | "extracting" = "downloading";
+
+      const flushProgress = (force = false) => {
+        const map = currentPhase === "downloading" ? downloadProgress : extractProgress;
+        if (map.size === 0) {
+          return;
+        }
+        const now = Date.now();
+        if (!force && now - lastProgressUpdate < 250) {
+          return;
+        }
+        lastProgressUpdate = now;
+        let totalBytes = 0;
+        let currentBytes = 0;
+        for (const layer of map.values()) {
+          totalBytes += layer.total;
+          currentBytes += layer.current;
+        }
+        store?.updateJob(containerName, {
+          pullProgress: { phase: currentPhase, currentBytes, totalBytes },
+        });
+      };
+
+      docker.modem.followProgress(
+        stream,
+        (followErr: Error | null) => {
+          if (followErr) {
+            return reject(followErr);
+          }
+          store?.updateJob(containerName, { pullProgress: undefined });
+          resolve();
+        },
+        (event: {
+          status?: string;
+          id?: string;
+          progressDetail?: { current?: number; total?: number };
+        }) => {
+          if (!event.id) {
+            return;
+          }
+
+          const detail = event.progressDetail;
+          const hasByteCounts =
+            detail &&
+            typeof detail.current === "number" &&
+            typeof detail.total === "number" &&
+            detail.total > 0;
+
+          if (event.status === "Downloading" && hasByteCounts) {
+            downloadProgress.set(event.id, {
+              current: detail.current!,
+              total: detail.total!,
+            });
+          } else if (event.status === "Download complete") {
+            const existing = downloadProgress.get(event.id);
+            if (existing) {
+              existing.current = existing.total;
+            }
+          } else if (event.status === "Extracting" && hasByteCounts) {
+            const phaseChanged = currentPhase !== "extracting";
+            currentPhase = "extracting";
+            extractProgress.set(event.id, {
+              current: detail.current!,
+              total: detail.total!,
+            });
+            // Force update on first extraction event so the phase change is visible immediately
+            if (phaseChanged) {
+              flushProgress(true);
+              return;
+            }
+          } else if (event.status === "Pull complete") {
+            const existing = extractProgress.get(event.id);
+            if (existing) {
+              existing.current = existing.total;
+            }
+          } else {
+            return;
+          }
+
+          flushProgress();
+        },
+      );
+    });
+  });
+}
+
+/**
+ * Extract the actions-runner binary from the SEED_IMAGE to `hostRunnerSeedDir`
+ * once and reuse it on subsequent calls. Direct-container mode injects this
+ * runner into the user's chosen image so we don't have to fork their entrypoint.
+ *
+ * Skipped when the seed dir already has a `.seeded` marker and `run.sh`.
+ */
+async function seedRunnerBinaryToHost(docker: Docker, hostRunnerSeedDir: string): Promise<void> {
+  await fs.promises.mkdir(hostRunnerSeedDir, { recursive: true });
+  const markerFile = path.join(hostRunnerSeedDir, ".seeded");
+  const runShExists = fs.existsSync(path.join(hostRunnerSeedDir, "run.sh"));
+  const needsSeed = !fs.existsSync(markerFile) || !runShExists;
+  if (needsSeed) {
+    if (!runShExists && fs.existsSync(markerFile)) {
+      debugRunner(`Runner seed is incomplete (run.sh missing), re-extracting...`);
+    } else {
+      debugRunner(`Extracting runner binary to host (one-time)...`);
+    }
+    const tmpName = `agent-ci-seed-runner-${Date.now()}`;
+    const seedContainer = await docker.createContainer({
+      Image: SEED_IMAGE,
+      name: tmpName,
+      Cmd: ["true"],
+    });
+    execSync(`docker cp ${tmpName}:/home/runner/. "${hostRunnerSeedDir}/"`, { stdio: "pipe" });
+    await seedContainer.remove();
+    const configShPath = path.join(hostRunnerSeedDir, "config.sh");
+    let configSh = await fs.promises.readFile(configShPath, "utf8");
+    configSh = configSh.replace(
+      /# Check dotnet Core.*?^fi$/ms,
+      "# Dependency checks removed for container injection",
+    );
+    await fs.promises.writeFile(configShPath, configSh);
+    await fs.promises.writeFile(markerFile, new Date().toISOString());
+    ensureRunnerWriteable(hostRunnerSeedDir);
+    debugRunner(`Runner extracted.`);
+  }
+  for (const staleFile of [".runner", ".credentials", ".credentials_rsaparams"]) {
+    try {
+      fs.rmSync(path.join(hostRunnerSeedDir, staleFile));
+    } catch {
+      /* not present */
+    }
+  }
+}
+
+/**
+ * Wait for a container's exit, but bail out after `timeoutMs` and stop the
+ * container if the runner keeps the entrypoint alive past that. Returns the
+ * exit code the daemon reports.
+ */
+async function waitForContainerExit(
+  container: Docker.Container,
+  containerWaitPromise: Promise<{ StatusCode: number }>,
+  timeoutMs: number,
+): Promise<number> {
+  let waitResult: { StatusCode: number };
+  try {
+    waitResult = await Promise.race([
+      containerWaitPromise,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("Container exit timeout")), timeoutMs),
+      ),
+    ]);
+  } catch {
+    debugRunner(`Runner did not exit within ${timeoutMs / 1000}s, force-stopping container…`);
+    try {
+      await container.stop({ t: 5 });
+    } catch {
+      /* already stopped */
+    }
+    waitResult = await container.wait();
+  }
+  return waitResult.StatusCode;
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 export async function executeLocalJob(
@@ -417,144 +601,14 @@ export async function executeLocalJob(
     }
 
     if (useDirectContainer) {
-      await fs.promises.mkdir(hostRunnerSeedDir, { recursive: true });
-      const markerFile = path.join(hostRunnerSeedDir, ".seeded");
-      const runShExists = fs.existsSync(path.join(hostRunnerSeedDir, "run.sh"));
-      const needsSeed = !fs.existsSync(markerFile) || !runShExists;
-      if (needsSeed) {
-        if (!runShExists && fs.existsSync(markerFile)) {
-          debugRunner(`Runner seed is incomplete (run.sh missing), re-extracting...`);
-        } else {
-          debugRunner(`Extracting runner binary to host (one-time)...`);
-        }
-        const tmpName = `agent-ci-seed-runner-${Date.now()}`;
-        const seedContainer = await getDocker().createContainer({
-          Image: SEED_IMAGE,
-          name: tmpName,
-          Cmd: ["true"],
-        });
-        const { execSync } = await import("node:child_process");
-        execSync(`docker cp ${tmpName}:/home/runner/. "${hostRunnerSeedDir}/"`, { stdio: "pipe" });
-        await seedContainer.remove();
-        const configShPath = path.join(hostRunnerSeedDir, "config.sh");
-        let configSh = await fs.promises.readFile(configShPath, "utf8");
-        configSh = configSh.replace(
-          /# Check dotnet Core.*?^fi$/ms,
-          "# Dependency checks removed for container injection",
-        );
-        await fs.promises.writeFile(configShPath, configSh);
-        await fs.promises.writeFile(markerFile, new Date().toISOString());
-        ensureRunnerWriteable(hostRunnerSeedDir);
-        debugRunner(`Runner extracted.`);
-      }
-      for (const staleFile of [".runner", ".credentials", ".credentials_rsaparams"]) {
-        try {
-          fs.rmSync(path.join(hostRunnerSeedDir, staleFile));
-        } catch {
-          /* not present */
-        }
-      }
+      await seedRunnerBinaryToHost(getDocker(), hostRunnerSeedDir);
       execSync(`cp -a "${hostRunnerSeedDir}" "${hostRunnerDir}"`, { stdio: "pipe" });
 
       const resolvedUrl = `${dockerApiUrl}/${githubRepo}`;
       writeRunnerCredentials(hostRunnerDir, containerName, resolvedUrl);
-    }
 
-    if (useDirectContainer) {
       debugRunner(`Pulling ${containerImage}...`);
-      await new Promise<void>((resolve, reject) => {
-        getDocker().pull(containerImage, (err: Error | null, stream: NodeJS.ReadableStream) => {
-          if (err) {
-            return reject(err);
-          }
-          // Track per-layer progress across download and extraction phases
-          const downloadProgress = new Map<string, { current: number; total: number }>();
-          const extractProgress = new Map<string, { current: number; total: number }>();
-          let lastProgressUpdate = 0;
-          let currentPhase: "downloading" | "extracting" = "downloading";
-
-          const flushProgress = (force = false) => {
-            const map = currentPhase === "downloading" ? downloadProgress : extractProgress;
-            if (map.size === 0) {
-              return;
-            }
-            const now = Date.now();
-            if (!force && now - lastProgressUpdate < 250) {
-              return;
-            }
-            lastProgressUpdate = now;
-            let totalBytes = 0;
-            let currentBytes = 0;
-            for (const layer of map.values()) {
-              totalBytes += layer.total;
-              currentBytes += layer.current;
-            }
-            store?.updateJob(containerName, {
-              pullProgress: { phase: currentPhase, currentBytes, totalBytes },
-            });
-          };
-
-          getDocker().modem.followProgress(
-            stream,
-            (err: Error | null) => {
-              if (err) {
-                return reject(err);
-              }
-              store?.updateJob(containerName, { pullProgress: undefined });
-              resolve();
-            },
-            (event: {
-              status?: string;
-              id?: string;
-              progressDetail?: { current?: number; total?: number };
-            }) => {
-              if (!event.id) {
-                return;
-              }
-
-              const detail = event.progressDetail;
-              const hasByteCounts =
-                detail &&
-                typeof detail.current === "number" &&
-                typeof detail.total === "number" &&
-                detail.total > 0;
-
-              if (event.status === "Downloading" && hasByteCounts) {
-                downloadProgress.set(event.id, {
-                  current: detail.current!,
-                  total: detail.total!,
-                });
-              } else if (event.status === "Download complete") {
-                const existing = downloadProgress.get(event.id);
-                if (existing) {
-                  existing.current = existing.total;
-                }
-              } else if (event.status === "Extracting" && hasByteCounts) {
-                const phaseChanged = currentPhase !== "extracting";
-                currentPhase = "extracting";
-                extractProgress.set(event.id, {
-                  current: detail.current!,
-                  total: detail.total!,
-                });
-                // Force update on first extraction event so the phase change is visible immediately
-                if (phaseChanged) {
-                  flushProgress(true);
-                  return;
-                }
-              } else if (event.status === "Pull complete") {
-                const existing = extractProgress.get(event.id);
-                if (existing) {
-                  existing.current = existing.total;
-                }
-              } else {
-                return;
-              }
-
-              flushProgress();
-            },
-          );
-        });
-      });
+      await pullContainerImageWithProgress(getDocker(), containerImage, store, containerName);
     }
 
     const containerEnv = buildContainerEnv({
@@ -897,27 +951,11 @@ export async function executeLocalJob(
     await pollPromise;
 
     // 8. Wait for completion
-    const CONTAINER_EXIT_TIMEOUT_MS = 30_000;
-    let waitResult: { StatusCode: number };
-    try {
-      waitResult = await Promise.race([
-        containerWaitPromise,
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error("Container exit timeout")), CONTAINER_EXIT_TIMEOUT_MS),
-        ),
-      ]);
-    } catch {
-      debugRunner(
-        `Runner did not exit within ${CONTAINER_EXIT_TIMEOUT_MS / 1000}s, force-stopping container…`,
-      );
-      try {
-        await container.stop({ t: 5 });
-      } catch {
-        /* already stopped */
-      }
-      waitResult = await container.wait();
-    }
-    const containerExitCode = waitResult.StatusCode;
+    const containerExitCode = await waitForContainerExit(
+      container,
+      containerWaitPromise,
+      CONTAINER_EXIT_TIMEOUT_MS,
+    );
 
     const jobSucceeded = isJobSuccessful({ lastFailedStep, containerExitCode, isBooting });
 

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -285,6 +285,236 @@ async function seedRunnerBinaryToHost(docker: Docker, hostRunnerSeedDir: string)
 }
 
 /**
+ * Mutable state tracked across timeline-poll ticks. The store-sync helper
+ * mutates the fields in place; the polling loop and the rest of
+ * `executeLocalJob` read them once the loop finishes.
+ */
+type TimelineSyncState = {
+  lastSeenAttempt: number;
+  isPaused: boolean;
+  pausedAtMs: number | null;
+  pausedStepName: string | null;
+  isBooting: boolean;
+  lastFailedStep: string | null;
+};
+
+/** Read-only inputs the store-sync helper needs but does not mutate. */
+type TimelineSyncContext = {
+  pauseOnFailure: boolean;
+  pausedSignalPath: string;
+  signalsDir: string;
+  timelinePath: string;
+  bootStart: number;
+  containerName: string;
+  store: RunStateStore | undefined;
+  /** Called the first time a pause is detected — sets up the Enter-to-retry stdin listener. */
+  onNewPause: () => void;
+};
+
+/** Result of folding the timeline-records list into a render-ready shape. */
+type BuiltSteps = {
+  newSteps: StepState[];
+  totalDurationMs: number | undefined;
+  jobFinished: boolean;
+};
+
+/**
+ * Fold the raw actions-runner timeline records into the `StepState[]` shape
+ * the renderer expects. Mutates `state.lastFailedStep` when a step result is
+ * "failed". Skips duplicate names; the second occurrence (e.g. for a "Post"
+ * step) triggers a synthetic "Post Setup" row at the end.
+ */
+function buildStepsFromTimeline(steps: any[], state: TimelineSyncState): BuiltSteps {
+  const seenNames = new Set<string>();
+  let hasPostSteps = false;
+  let completeJobRecord: any = null;
+
+  const preCountNames = new Set<string>();
+  for (const r of steps) {
+    if (!preCountNames.has(r.name)) {
+      preCountNames.add(r.name);
+    } else {
+      hasPostSteps = true;
+    }
+  }
+
+  let stepIdx = 0;
+  const newSteps: StepState[] = [];
+
+  for (const r of steps) {
+    if (seenNames.has(r.name)) {
+      continue;
+    }
+    seenNames.add(r.name);
+
+    if (r.name === "Complete job") {
+      completeJobRecord = r;
+      continue;
+    }
+    stepIdx++;
+
+    const durationMs =
+      r.startTime && r.finishTime
+        ? new Date(r.finishTime).getTime() - new Date(r.startTime).getTime()
+        : undefined;
+
+    let status: StepState["status"];
+    if (!r.result && r.state !== "completed") {
+      if (r.startTime) {
+        status = state.isPaused && state.pausedStepName === r.name ? "paused" : "running";
+      } else {
+        status = "pending";
+      }
+    } else {
+      const result = (r.result || "").toLowerCase();
+      if (result === "failed") {
+        state.lastFailedStep = r.name;
+        status = "failed";
+      } else if (result === "skipped") {
+        status = "skipped";
+      } else {
+        status = "completed";
+      }
+    }
+
+    newSteps.push({
+      name: r.name,
+      index: stepIdx,
+      status,
+      startedAt: r.startTime,
+      completedAt: r.finishTime,
+      durationMs,
+    });
+  }
+
+  const jobFinished = !!completeJobRecord?.result;
+
+  if (hasPostSteps && jobFinished) {
+    stepIdx++;
+    newSteps.push({ name: "Post Setup", index: stepIdx, status: "completed" });
+  }
+
+  if (completeJobRecord && jobFinished) {
+    stepIdx++;
+    const durationMs =
+      completeJobRecord.startTime && completeJobRecord.finishTime
+        ? new Date(completeJobRecord.finishTime).getTime() -
+          new Date(completeJobRecord.startTime).getTime()
+        : undefined;
+    newSteps.push({
+      name: "Complete job",
+      index: stepIdx,
+      status: "completed",
+      startedAt: completeJobRecord.startTime,
+      completedAt: completeJobRecord.finishTime,
+      durationMs,
+    });
+  }
+
+  // Total job duration spans first step start to last step end.
+  let totalDurationMs: number | undefined;
+  if (jobFinished) {
+    const allTimes = steps
+      .filter((r) => r.startTime && r.finishTime)
+      .map((r) => ({
+        start: new Date(r.startTime).getTime(),
+        end: new Date(r.finishTime).getTime(),
+      }));
+    if (allTimes.length > 0) {
+      const earliest = Math.min(...allTimes.map((t) => t.start));
+      const latest = Math.max(...allTimes.map((t) => t.end));
+      const ms = latest - earliest;
+      if (!isNaN(ms) && ms >= 0) {
+        totalDurationMs = ms;
+      }
+    }
+  }
+
+  return { newSteps, totalDurationMs, jobFinished };
+}
+
+/**
+ * One poll tick of the actions-runner timeline.json into the RunStateStore.
+ * Reads the paused-signal file (if `pauseOnFailure` is set) and the timeline
+ * JSON; updates the store and the mutable `state` in place. Errors are
+ * swallowed — this is best-effort and runs every 100ms.
+ */
+function syncTimelineToStore(state: TimelineSyncState, ctx: TimelineSyncContext): void {
+  try {
+    // ── Pause-on-failure: check for paused signal ───────────────────────────
+    if (ctx.pauseOnFailure && fs.existsSync(ctx.pausedSignalPath)) {
+      const content = fs.readFileSync(ctx.pausedSignalPath, "utf-8").trim();
+      const lines = content.split("\n");
+      state.pausedStepName = lines[0] || null;
+      const attempt = parseInt(lines[1] || "1", 10);
+      const isNewAttempt = attempt !== state.lastSeenAttempt;
+      if (isNewAttempt) {
+        state.lastSeenAttempt = attempt;
+        state.isPaused = true;
+        state.pausedAtMs = Date.now();
+        ctx.onNewPause();
+      }
+
+      // Read output captured by the wrapper script's tee — written directly
+      // to the signals dir so it's always available when paused.
+      const tailLines = tailLogFile(path.join(ctx.signalsDir, "step-output"), 20);
+
+      ctx.store?.updateJob(ctx.containerName, {
+        status: "paused",
+        pausedAtStep: state.pausedStepName || undefined,
+        ...(isNewAttempt && state.pausedAtMs !== null
+          ? { pausedAtMs: new Date(state.pausedAtMs).toISOString(), attempt: state.lastSeenAttempt }
+          : {}),
+        lastOutputLines: tailLines,
+      });
+    } else if (state.isPaused && !fs.existsSync(ctx.pausedSignalPath)) {
+      // Pause signal removed — job is retrying
+      state.isPaused = false;
+      state.pausedAtMs = null;
+      ctx.store?.updateJob(ctx.containerName, { status: "running", pausedAtMs: undefined });
+    }
+
+    if (!fs.existsSync(ctx.timelinePath)) {
+      return;
+    }
+
+    const records = JSON.parse(fs.readFileSync(ctx.timelinePath, "utf-8")) as any[];
+    const steps = records
+      .filter((r) => r.type === "Task" && r.name)
+      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+
+    if (steps.length === 0) {
+      return;
+    }
+
+    // ── Transition from booting to running on first timeline entry ──────────
+    if (state.isBooting) {
+      state.isBooting = false;
+      debugBoot(`${ctx.containerName} total: ${Date.now() - ctx.bootStart}ms`);
+      ctx.store?.updateJob(ctx.containerName, {
+        status: state.isPaused ? "paused" : "running",
+        bootDurationMs: Date.now() - ctx.bootStart,
+      });
+    }
+
+    const { newSteps, totalDurationMs, jobFinished } = buildStepsFromTimeline(steps, state);
+
+    ctx.store?.updateJob(ctx.containerName, {
+      steps: newSteps,
+      ...(jobFinished
+        ? {
+            status: state.lastFailedStep ? "failed" : "completed",
+            failedStep: state.lastFailedStep || undefined,
+            durationMs: totalDurationMs,
+          }
+        : {}),
+    });
+  } catch {
+    // Best-effort
+  }
+}
+
+/**
  * Wait for a container's exit, but bail out after `timeoutMs` and stop the
  * container if the runner keeps the entrypoint alive past that. Returns the
  * exit code the daemon reports.
@@ -686,16 +916,19 @@ export async function executeLocalJob(
     })) as NodeJS.ReadableStream;
 
     let tailDone = false;
-    let lastFailedStep: string | null = null;
-    let isPaused = false;
-    let pausedStepName: string | null = null;
-    let pausedAtMs: number | null = null;
-    let lastSeenAttempt = 0;
-    let isBooting = true;
     let stdinListening = false;
     const timelinePath = path.join(logDir, "timeline.json");
     const pausedSignalPath = path.join(dirs.signalsDir, "paused");
     const signalsRunDir = path.dirname(dirs.signalsDir);
+
+    const timelineState: TimelineSyncState = {
+      lastSeenAttempt: 0,
+      isPaused: false,
+      pausedAtMs: null,
+      pausedStepName: null,
+      isBooting: true,
+      lastFailedStep: null,
+    };
 
     // Listen for Enter key to trigger retry when paused
     const setupStdinRetry = () => {
@@ -710,7 +943,7 @@ export async function executeLocalJob(
           process.stdin.setRawMode(false);
           process.exit(130);
         }
-        if (key[0] === 13 && isPaused) {
+        if (key[0] === 13 && timelineState.isPaused) {
           syncWorkspaceForRetry(signalsRunDir);
           fs.writeFileSync(path.join(dirs.signalsDir, "retry"), "");
         }
@@ -725,204 +958,24 @@ export async function executeLocalJob(
       }
     };
 
-    // ── Timeline → store updater ──────────────────────────────────────────────
-    // Reads timeline.json and the paused signal, then updates the RunStateStore.
-    // The render loop in cli.ts reads the store and calls renderRunState().
-    const updateStoreFromTimeline = () => {
-      try {
-        // ── Pause-on-failure: check for paused signal ───────────────────────
-        if (pauseOnFailure && fs.existsSync(pausedSignalPath)) {
-          const content = fs.readFileSync(pausedSignalPath, "utf-8").trim();
-          const lines = content.split("\n");
-          pausedStepName = lines[0] || null;
-          const attempt = parseInt(lines[1] || "1", 10);
-          const isNewAttempt = attempt !== lastSeenAttempt;
-          if (isNewAttempt) {
-            lastSeenAttempt = attempt;
-            isPaused = true;
-            pausedAtMs = Date.now();
-            setupStdinRetry();
-          }
-
-          // Read output captured by the wrapper script's tee — written directly
-          // to the signals dir so it's always available when paused.
-          const tailLines = tailLogFile(path.join(dirs.signalsDir, "step-output"), 20);
-
-          store?.updateJob(containerName, {
-            status: "paused",
-            pausedAtStep: pausedStepName || undefined,
-            ...(isNewAttempt && pausedAtMs !== null
-              ? { pausedAtMs: new Date(pausedAtMs).toISOString(), attempt: lastSeenAttempt }
-              : {}),
-            lastOutputLines: tailLines,
-          });
-        } else if (isPaused && !fs.existsSync(pausedSignalPath)) {
-          // Pause signal removed — job is retrying
-          isPaused = false;
-          pausedAtMs = null;
-          store?.updateJob(containerName, { status: "running", pausedAtMs: undefined });
-        }
-
-        if (!fs.existsSync(timelinePath)) {
-          return;
-        }
-
-        const records = JSON.parse(fs.readFileSync(timelinePath, "utf-8")) as any[];
-        const steps = records
-          .filter((r) => r.type === "Task" && r.name)
-          .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
-
-        if (steps.length === 0) {
-          return;
-        }
-
-        // ── Transition from booting to running on first timeline entry ────────
-        if (isBooting) {
-          isBooting = false;
-          bt("total", bootStart);
-          store?.updateJob(containerName, {
-            status: isPaused ? "paused" : "running",
-            bootDurationMs: Date.now() - bootStart,
-          });
-        }
-
-        // ── Build StepState[] from timeline records ───────────────────────────
-        const seenNames = new Set<string>();
-        let hasPostSteps = false;
-        let completeJobRecord: any = null;
-
-        const preCountNames = new Set<string>();
-        for (const r of steps) {
-          if (!preCountNames.has(r.name)) {
-            preCountNames.add(r.name);
-          } else {
-            hasPostSteps = true;
-          }
-        }
-        const hasCompleteJob = preCountNames.has("Complete job");
-        // Total = unique names (minus "Complete job") + "Post Setup" (if any) + "Complete job"
-        const totalSteps =
-          preCountNames.size -
-          (hasCompleteJob ? 1 : 0) +
-          (hasPostSteps ? 1 : 0) +
-          (hasCompleteJob ? 1 : 0);
-        const padW = String(totalSteps).length;
-
-        let stepIdx = 0;
-        const newSteps: StepState[] = [];
-
-        for (const r of steps) {
-          if (seenNames.has(r.name)) {
-            continue;
-          }
-          seenNames.add(r.name);
-
-          if (r.name === "Complete job") {
-            completeJobRecord = r;
-            continue;
-          }
-          stepIdx++;
-
-          const durationMs =
-            r.startTime && r.finishTime
-              ? new Date(r.finishTime).getTime() - new Date(r.startTime).getTime()
-              : undefined;
-
-          let status: StepState["status"];
-          if (!r.result && r.state !== "completed") {
-            if (r.startTime) {
-              status = isPaused && pausedStepName === r.name ? "paused" : "running";
-            } else {
-              status = "pending";
-            }
-          } else {
-            const result = (r.result || "").toLowerCase();
-            if (result === "failed") {
-              lastFailedStep = r.name;
-              status = "failed";
-            } else if (result === "skipped") {
-              status = "skipped";
-            } else {
-              status = "completed";
-            }
-          }
-
-          newSteps.push({
-            name: r.name,
-            index: stepIdx,
-            status,
-            startedAt: r.startTime,
-            completedAt: r.finishTime,
-            durationMs,
-          });
-          void padW; // used for totalSteps calculation above
-        }
-
-        const jobFinished = !!completeJobRecord?.result;
-
-        if (hasPostSteps && jobFinished) {
-          stepIdx++;
-          newSteps.push({ name: "Post Setup", index: stepIdx, status: "completed" });
-        }
-
-        if (completeJobRecord && jobFinished) {
-          stepIdx++;
-          const durationMs =
-            completeJobRecord.startTime && completeJobRecord.finishTime
-              ? new Date(completeJobRecord.finishTime).getTime() -
-                new Date(completeJobRecord.startTime).getTime()
-              : undefined;
-          newSteps.push({
-            name: "Complete job",
-            index: stepIdx,
-            status: "completed",
-            startedAt: completeJobRecord.startTime,
-            completedAt: completeJobRecord.finishTime,
-            durationMs,
-          });
-        }
-
-        // Compute total duration from timeline step times
-        let totalDurationMs: number | undefined;
-        if (jobFinished) {
-          const allTimes = steps
-            .filter((r) => r.startTime && r.finishTime)
-            .map((r) => ({
-              start: new Date(r.startTime).getTime(),
-              end: new Date(r.finishTime).getTime(),
-            }));
-          if (allTimes.length > 0) {
-            const earliest = Math.min(...allTimes.map((t) => t.start));
-            const latest = Math.max(...allTimes.map((t) => t.end));
-            const ms = latest - earliest;
-            if (!isNaN(ms) && ms >= 0) {
-              totalDurationMs = ms;
-            }
-          }
-        }
-
-        store?.updateJob(containerName, {
-          steps: newSteps,
-          ...(jobFinished
-            ? {
-                status: lastFailedStep ? "failed" : "completed",
-                failedStep: lastFailedStep || undefined,
-                durationMs: totalDurationMs,
-              }
-            : {}),
-        });
-      } catch {
-        // Best-effort
-      }
+    const timelineCtx: TimelineSyncContext = {
+      pauseOnFailure,
+      pausedSignalPath,
+      signalsDir: dirs.signalsDir,
+      timelinePath,
+      bootStart,
+      containerName,
+      store,
+      onNewPause: setupStdinRetry,
     };
 
     const pollPromise = (async () => {
       while (!tailDone) {
-        updateStoreFromTimeline();
+        syncTimelineToStore(timelineState, timelineCtx);
         await new Promise((r) => setTimeout(r, 100));
       }
       // Final update
-      updateStoreFromTimeline();
+      syncTimelineToStore(timelineState, timelineCtx);
     })();
 
     // Start waiting for container exit in parallel with log streaming.
@@ -957,7 +1010,11 @@ export async function executeLocalJob(
       CONTAINER_EXIT_TIMEOUT_MS,
     );
 
-    const jobSucceeded = isJobSuccessful({ lastFailedStep, containerExitCode, isBooting });
+    const jobSucceeded = isJobSuccessful({
+      lastFailedStep: timelineState.lastFailedStep,
+      containerExitCode,
+      isBooting: timelineState.isBooting,
+    });
 
     // Update store with final exit code on failure
     if (!jobSucceeded) {
@@ -995,7 +1052,7 @@ export async function executeLocalJob(
       job,
       startTime,
       jobSucceeded,
-      lastFailedStep,
+      lastFailedStep: timelineState.lastFailedStep,
       containerExitCode,
       timelinePath,
       logDir,

--- a/packages/cli/src/workflow/workflow-parser.ts
+++ b/packages/cli/src/workflow/workflow-parser.ts
@@ -138,366 +138,240 @@ function compareValues(left: string, right: string, op: string): boolean {
 }
 
 /**
- * Resolve a single atomic expression (function call or context variable).
- * Does not handle boolean operators, parentheses, or string literals.
+ * Bundle for the per-call expansion context. Used by the expression
+ * evaluator so each helper takes one argument instead of eight. The
+ * public `expandExpressions` keeps its positional signature for callers.
  */
-function resolveExprAtom(
-  trimmed: string,
-  repoPath?: string,
-  secrets?: Record<string, string>,
-  matrixContext?: Record<string, string>,
-  needsContext?: Record<string, Record<string, string>>,
-  inputsContext?: Record<string, string>,
-  vars?: Record<string, string>,
-  runnerContext?: RunnerContext,
-  envContext?: Record<string, string>,
-): string {
-  // hashFiles('glob1', 'glob2', ...)
-  const hashFilesMatch = trimmed.match(/^hashFiles\(([\s\S]+)\)$/);
-  if (hashFilesMatch) {
-    if (!repoPath) {
-      return "0000000000000000000000000000000000000000";
-    }
-    try {
-      // Parse the argument list: quoted strings separated by commas
-      const args = hashFilesMatch[1].match(/['"][^'"]*['"]/g) ?? [];
-      const patterns = args.map((a) => a.replace(/^['"]|['"]$/g, ""));
-      const hash = crypto.createHash("sha256");
-      let hasAny = false;
-      for (const pattern of patterns) {
-        let files: string[];
-        try {
-          files = findFiles(repoPath, pattern);
-        } catch {
-          files = [];
-        }
-        for (const f of files.sort()) {
-          try {
-            const content = fs.readFileSync(f);
-            hash.update(content);
-            hasAny = true;
-          } catch {
-            // File not readable, skip
-          }
-        }
-      }
-      if (!hasAny) {
-        return "0000000000000000000000000000000000000000";
-      }
-      return hash.digest("hex");
-    } catch {
-      return "0000000000000000000000000000000000000000";
-    }
-  }
+type ExprContext = {
+  repoPath?: string;
+  secrets?: Record<string, string>;
+  matrixContext?: Record<string, string>;
+  needsContext?: Record<string, Record<string, string>>;
+  inputsContext?: Record<string, string>;
+  vars?: Record<string, string>;
+  runnerContext?: RunnerContext;
+  envContext?: Record<string, string>;
+};
 
-  // fromJSON(expr) — parse JSON from a string (or inner expression)
-  const fromJsonMatch = trimmed.match(/^fromJSON\(([\s\S]+)\)$/);
-  if (fromJsonMatch) {
-    const inner = fromJsonMatch[1].trim();
-    let rawValue: string;
-    if (
-      (inner.startsWith("'") && inner.endsWith("'")) ||
-      (inner.startsWith('"') && inner.endsWith('"'))
-    ) {
-      rawValue = inner.slice(1, -1);
-    } else {
-      rawValue = evaluateExprValue(
-        inner,
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-    }
-    try {
-      const parsed = JSON.parse(rawValue);
-      if (typeof parsed === "string") {
-        return parsed;
-      }
-      return JSON.stringify(parsed);
-    } catch {
-      return "";
-    }
-  }
+const ZERO_SHA = "0000000000000000000000000000000000000000";
 
-  // toJSON(expr) — serialize a value to JSON with 2-space indentation,
-  // matching GitHub Actions' pretty-printing behavior. Parse rawValue first
-  // so that toJSON(fromJSON(...)) round-trips with pretty-printing instead
-  // of re-quoting a compact-JSON string.
-  const toJsonMatch = trimmed.match(/^toJSON\(([\s\S]+)\)$/);
-  if (toJsonMatch) {
-    const inner = toJsonMatch[1].trim();
-    let rawValue: string;
-    if (
-      (inner.startsWith("'") && inner.endsWith("'")) ||
-      (inner.startsWith('"') && inner.endsWith('"'))
-    ) {
-      rawValue = inner.slice(1, -1);
-    } else {
-      rawValue = evaluateExprValue(
-        inner,
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-    }
-    try {
-      return JSON.stringify(JSON.parse(rawValue), null, 2);
-    } catch {
-      return JSON.stringify(rawValue, null, 2);
-    }
+/**
+ * Evaluate a function argument that may be a quoted string literal or a
+ * full expression. Used by single-arg functions (fromJSON, toJSON).
+ */
+function evalArgOrLiteral(inner: string, ctx: ExprContext): string {
+  const t = inner.trim();
+  if ((t.startsWith("'") && t.endsWith("'")) || (t.startsWith('"') && t.endsWith('"'))) {
+    return t.slice(1, -1);
   }
+  return evaluateExprValue(t, ctx);
+}
 
-  // format('template {0} {1}', arg0, arg1)
-  const formatMatch = trimmed.match(/^format\(([\s\S]+)\)$/);
-  if (formatMatch) {
-    const formatArgs = splitFunctionArgs(formatMatch[1]);
-    const template = unquote(formatArgs[0] || "");
-    const args = formatArgs.slice(1);
-    return template.replace(/\{(\d+)\}/g, (_m, idx) => {
-      const i = parseInt(idx, 10);
-      if (i < args.length) {
-        return evaluateExprValue(
-          args[i],
-          repoPath,
-          secrets,
-          matrixContext,
-          needsContext,
-          inputsContext,
-          vars,
-          runnerContext,
-          envContext,
-        );
-      }
-      return "";
-    });
+function evalHashFiles(rawArgs: string, ctx: ExprContext): string {
+  if (!ctx.repoPath) {
+    return ZERO_SHA;
   }
-
-  // contains(search, item) — case-insensitive string search or array inclusion
-  const containsMatch = trimmed.match(/^contains\(([\s\S]+)\)$/);
-  if (containsMatch) {
-    const args = splitFunctionArgs(containsMatch[1]);
-    if (args.length >= 2) {
-      const haystack = evaluateExprValue(
-        args[0],
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-      const needle = evaluateExprValue(
-        args[1],
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-      // Try JSON array first
+  try {
+    // Parse the argument list: quoted strings separated by commas
+    const args = rawArgs.match(/['"][^'"]*['"]/g) ?? [];
+    const patterns = args.map((a) => a.replace(/^['"]|['"]$/g, ""));
+    const hash = crypto.createHash("sha256");
+    let hasAny = false;
+    for (const pattern of patterns) {
+      let files: string[];
       try {
-        const arr = JSON.parse(haystack);
-        if (Array.isArray(arr)) {
-          return arr.some((item) => String(item).toLowerCase() === needle.toLowerCase())
-            ? "true"
-            : "false";
-        }
+        files = findFiles(ctx.repoPath, pattern);
       } catch {
-        // Not JSON — fall through to string search
+        files = [];
       }
-      return haystack.toLowerCase().includes(needle.toLowerCase()) ? "true" : "false";
-    }
-    return "false";
-  }
-
-  // startsWith(searchString, searchValue)
-  const startsWithMatch = trimmed.match(/^startsWith\(([\s\S]+)\)$/);
-  if (startsWithMatch) {
-    const args = splitFunctionArgs(startsWithMatch[1]);
-    if (args.length >= 2) {
-      const str = evaluateExprValue(
-        args[0],
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-      const prefix = evaluateExprValue(
-        args[1],
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-      return str.toLowerCase().startsWith(prefix.toLowerCase()) ? "true" : "false";
-    }
-    return "false";
-  }
-
-  // endsWith(searchString, searchValue)
-  const endsWithMatch = trimmed.match(/^endsWith\(([\s\S]+)\)$/);
-  if (endsWithMatch) {
-    const args = splitFunctionArgs(endsWithMatch[1]);
-    if (args.length >= 2) {
-      const str = evaluateExprValue(
-        args[0],
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-      const suffix = evaluateExprValue(
-        args[1],
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-      return str.toLowerCase().endsWith(suffix.toLowerCase()) ? "true" : "false";
-    }
-    return "false";
-  }
-
-  // join(array, separator) or join(string, separator)
-  const joinMatch = trimmed.match(/^join\(([\s\S]+)\)$/);
-  if (joinMatch) {
-    const args = splitFunctionArgs(joinMatch[1]);
-    const val = evaluateExprValue(
-      args[0],
-      repoPath,
-      secrets,
-      matrixContext,
-      needsContext,
-      inputsContext,
-      vars,
-      runnerContext,
-      envContext,
-    );
-    const sep =
-      args.length >= 2
-        ? evaluateExprValue(
-            args[1],
-            repoPath,
-            secrets,
-            matrixContext,
-            needsContext,
-            inputsContext,
-            vars,
-            runnerContext,
-            envContext,
-          )
-        : ", ";
-    try {
-      const arr = JSON.parse(val);
-      if (Array.isArray(arr)) {
-        return arr.map(String).join(sep);
+      for (const f of files.sort()) {
+        try {
+          hash.update(fs.readFileSync(f));
+          hasAny = true;
+        } catch {
+          // File not readable, skip
+        }
       }
-    } catch {
-      // Not an array — return as-is
     }
-    return val;
+    return hasAny ? hash.digest("hex") : ZERO_SHA;
+  } catch {
+    return ZERO_SHA;
   }
+}
 
-  // Status functions — in expression context these return their string name
-  if (trimmed === "success()") {
-    return "true";
-  }
-  if (trimmed === "failure()") {
+function evalContains(rawArgs: string, ctx: ExprContext): string {
+  const args = splitFunctionArgs(rawArgs);
+  if (args.length < 2) {
     return "false";
   }
-  if (trimmed === "always()") {
-    return "true";
+  const haystack = evaluateExprValue(args[0], ctx);
+  const needle = evaluateExprValue(args[1], ctx);
+  try {
+    const arr = JSON.parse(haystack);
+    if (Array.isArray(arr)) {
+      return arr.some((item) => String(item).toLowerCase() === needle.toLowerCase())
+        ? "true"
+        : "false";
+    }
+  } catch {
+    // Not JSON — fall through to string search
   }
-  if (trimmed === "cancelled()") {
+  return haystack.toLowerCase().includes(needle.toLowerCase()) ? "true" : "false";
+}
+
+function evalStartsWith(rawArgs: string, ctx: ExprContext): string {
+  const args = splitFunctionArgs(rawArgs);
+  if (args.length < 2) {
     return "false";
   }
+  const str = evaluateExprValue(args[0], ctx);
+  const prefix = evaluateExprValue(args[1], ctx);
+  return str.toLowerCase().startsWith(prefix.toLowerCase()) ? "true" : "false";
+}
 
-  // Context variable substitutions
+function evalEndsWith(rawArgs: string, ctx: ExprContext): string {
+  const args = splitFunctionArgs(rawArgs);
+  if (args.length < 2) {
+    return "false";
+  }
+  const str = evaluateExprValue(args[0], ctx);
+  const suffix = evaluateExprValue(args[1], ctx);
+  return str.toLowerCase().endsWith(suffix.toLowerCase()) ? "true" : "false";
+}
+
+function evalJoin(rawArgs: string, ctx: ExprContext): string {
+  const args = splitFunctionArgs(rawArgs);
+  const val = evaluateExprValue(args[0], ctx);
+  const sep = args.length >= 2 ? evaluateExprValue(args[1], ctx) : ", ";
+  try {
+    const arr = JSON.parse(val);
+    if (Array.isArray(arr)) {
+      return arr.map(String).join(sep);
+    }
+  } catch {
+    // Not an array — return as-is
+  }
+  return val;
+}
+
+function evalFormat(rawArgs: string, ctx: ExprContext): string {
+  const formatArgs = splitFunctionArgs(rawArgs);
+  const template = unquote(formatArgs[0] || "");
+  const args = formatArgs.slice(1);
+  return template.replace(/\{(\d+)\}/g, (_m, idx) => {
+    const i = parseInt(idx, 10);
+    return i < args.length ? evaluateExprValue(args[i], ctx) : "";
+  });
+}
+
+function evalFromJson(rawArgs: string, ctx: ExprContext): string {
+  const rawValue = evalArgOrLiteral(rawArgs, ctx);
+  try {
+    const parsed = JSON.parse(rawValue);
+    return typeof parsed === "string" ? parsed : JSON.stringify(parsed);
+  } catch {
+    return "";
+  }
+}
+
+// toJSON pretty-prints with 2-space indentation, matching GitHub Actions.
+// We parse rawValue first so `toJSON(fromJSON(...))` round-trips with
+// pretty-printing instead of re-quoting a compact-JSON string.
+function evalToJson(rawArgs: string, ctx: ExprContext): string {
+  const rawValue = evalArgOrLiteral(rawArgs, ctx);
+  try {
+    return JSON.stringify(JSON.parse(rawValue), null, 2);
+  } catch {
+    return JSON.stringify(rawValue, null, 2);
+  }
+}
+
+const FUNCTION_HANDLERS: Record<string, (rawArgs: string, ctx: ExprContext) => string> = {
+  hashFiles: evalHashFiles,
+  fromJSON: evalFromJson,
+  toJSON: evalToJson,
+  format: evalFormat,
+  contains: evalContains,
+  startsWith: evalStartsWith,
+  endsWith: evalEndsWith,
+  join: evalJoin,
+};
+
+const FUNCTION_CALL_RE = /^([A-Za-z][A-Za-z0-9_]*)\(([\s\S]+)\)$/;
+
+// In expression context, status functions resolve to their string name.
+const STATUS_FUNCTIONS: Record<string, string> = {
+  "success()": "true",
+  "failure()": "false",
+  "always()": "true",
+  "cancelled()": "false",
+};
+
+// Constant `github.*` context refs that don't depend on ctx state.
+const CONST_CONTEXT_REFS: Record<string, string> = {
+  "github.run_id": "1",
+  "github.run_number": "1",
+  "github.sha": ZERO_SHA,
+  "github.head_sha": ZERO_SHA,
+  "github.ref_name": "main",
+  "github.head_ref": "main",
+  "github.repository": "local/repo",
+  "github.actor": "local",
+  "github.event.pull_request.number": "",
+  "github.event.pull_request.title": "",
+  "github.event.pull_request.user.login": "",
+};
+
+function resolveNeedsRef(
+  trimmed: string,
+  needsContext: Record<string, Record<string, string>> | undefined,
+): string {
+  if (!needsContext) {
+    return "";
+  }
+  const parts = trimmed.split(".");
+  const jobOutputs = needsContext[parts[1]];
+  if (parts[2] === "outputs" && parts[3]) {
+    return jobOutputs?.[parts[3]] ?? "";
+  }
+  if (parts[2] === "result") {
+    return jobOutputs ? (jobOutputs["__result"] ?? "success") : "";
+  }
+  return "";
+}
+
+/**
+ * Resolve a context-variable reference (runner.os, matrix.foo, secrets.X,
+ * needs.X.outputs.Y, …). Returns `undefined` when the atom is not a known
+ * context ref so the caller can fall through to "unknown atom".
+ */
+function resolveContextRef(trimmed: string, ctx: ExprContext): string | undefined {
   if (trimmed === "runner.os") {
-    return runnerContext?.os ?? "Linux";
+    return ctx.runnerContext?.os ?? "Linux";
   }
   if (trimmed === "runner.arch") {
-    return runnerContext?.arch ?? "X64";
-  }
-  if (trimmed === "github.run_id") {
-    return "1";
-  }
-  if (trimmed === "github.run_number") {
-    return "1";
-  }
-  if (trimmed === "github.sha" || trimmed === "github.head_sha") {
-    return "0000000000000000000000000000000000000000";
-  }
-  if (trimmed === "github.ref_name" || trimmed === "github.head_ref") {
-    return "main";
-  }
-  if (trimmed === "github.repository") {
-    return "local/repo";
-  }
-  if (trimmed === "github.actor") {
-    return "local";
-  }
-  if (trimmed === "github.event.pull_request.number") {
-    return "";
-  }
-  if (trimmed === "github.event.pull_request.title") {
-    return "";
-  }
-  if (trimmed === "github.event.pull_request.user.login") {
-    return "";
+    return ctx.runnerContext?.arch ?? "X64";
   }
   if (trimmed === "strategy.job-total") {
-    return matrixContext?.["__job_total"] ?? "1";
+    return ctx.matrixContext?.["__job_total"] ?? "1";
   }
   if (trimmed === "strategy.job-index") {
-    return matrixContext?.["__job_index"] ?? "0";
+    return ctx.matrixContext?.["__job_index"] ?? "0";
+  }
+  if (trimmed in CONST_CONTEXT_REFS) {
+    return CONST_CONTEXT_REFS[trimmed];
   }
   if (trimmed.startsWith("matrix.")) {
-    const key = trimmed.slice("matrix.".length);
-    return matrixContext?.[key] ?? "";
+    return ctx.matrixContext?.[trimmed.slice("matrix.".length)] ?? "";
   }
   if (trimmed.startsWith("secrets.")) {
-    const name = trimmed.slice("secrets.".length);
-    return secrets?.[name] ?? "";
+    return ctx.secrets?.[trimmed.slice("secrets.".length)] ?? "";
   }
   if (trimmed.startsWith("vars.")) {
-    const name = trimmed.slice("vars.".length);
-    return vars?.[name] ?? "";
+    return ctx.vars?.[trimmed.slice("vars.".length)] ?? "";
   }
   if (trimmed.startsWith("inputs.")) {
-    const name = trimmed.slice("inputs.".length);
-    return inputsContext?.[name] ?? "";
+    return ctx.inputsContext?.[trimmed.slice("inputs.".length)] ?? "";
   }
   if (trimmed.startsWith("steps.")) {
     // Step-output references can't be resolved at parse time — the producing
@@ -507,24 +381,35 @@ function resolveExprAtom(
     // Per the compatibility contract, resolve to an empty string at parse time.
     return "";
   }
-  if (trimmed.startsWith("needs.") && needsContext) {
-    const parts = trimmed.split(".");
-    const jobId = parts[1];
-    const jobOutputs = needsContext[jobId];
-    if (parts[2] === "outputs" && parts[3]) {
-      return jobOutputs?.[parts[3]] ?? "";
-    }
-    if (parts[2] === "result") {
-      return jobOutputs ? (jobOutputs["__result"] ?? "success") : "";
-    }
-    return "";
-  }
   if (trimmed.startsWith("needs.")) {
-    return "";
+    return resolveNeedsRef(trimmed, ctx.needsContext);
   }
   if (trimmed.startsWith("env.")) {
-    const name = trimmed.slice("env.".length);
-    return envContext?.[name] ?? "";
+    return ctx.envContext?.[trimmed.slice("env.".length)] ?? "";
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a single atomic expression (function call or context variable).
+ * Does not handle boolean operators, parentheses, or string literals.
+ */
+function resolveExprAtom(trimmed: string, ctx: ExprContext): string {
+  const fnMatch = trimmed.match(FUNCTION_CALL_RE);
+  if (fnMatch) {
+    const handler = FUNCTION_HANDLERS[fnMatch[1]];
+    if (handler) {
+      return handler(fnMatch[2], ctx);
+    }
+  }
+
+  if (trimmed in STATUS_FUNCTIONS) {
+    return STATUS_FUNCTIONS[trimmed];
+  }
+
+  const ctxRef = resolveContextRef(trimmed, ctx);
+  if (ctxRef !== undefined) {
+    return ctxRef;
   }
 
   // Unknown atoms — return empty string
@@ -532,83 +417,77 @@ function resolveExprAtom(
 }
 
 /**
+ * If `trimmed` is wrapped in matching outer parentheses, return the inner
+ * string. Otherwise return null. Quotes are skipped so parens inside string
+ * literals don't fool the matcher.
+ */
+function stripOuterParens(trimmed: string): string | null {
+  if (!trimmed.startsWith("(")) {
+    return null;
+  }
+  let depth = 0;
+  let inQuote: string | null = null;
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i];
+    if (inQuote) {
+      if (ch === inQuote) {
+        inQuote = null;
+      }
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      inQuote = ch;
+      continue;
+    }
+    if (ch === "(") {
+      depth++;
+    } else if (ch === ")") {
+      depth--;
+    }
+    if (depth === 0) {
+      return i === trimmed.length - 1 ? trimmed.slice(1, -1) : null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Evaluate the left/right operands and apply the comparison if `trimmed`
+ * splits cleanly on `op`. Returns null when the operator isn't a top-level
+ * split point.
+ */
+function evalComparison(trimmed: string, op: string, ctx: ExprContext): string | null {
+  const parts = splitOnOperator(trimmed, op);
+  if (parts.length !== 2) {
+    return null;
+  }
+  const left = evaluateExprValue(parts[0].trim(), ctx);
+  const right = evaluateExprValue(parts[1].trim(), ctx);
+  return compareValues(left, right, op) ? "true" : "false";
+}
+
+/**
  * Evaluate an expression that may contain ||, &&, !, parentheses,
  * string literals, function calls, and context variable references.
  * Returns the string result following GitHub Actions expression semantics.
  */
-function evaluateExprValue(
-  expr: string,
-  repoPath?: string,
-  secrets?: Record<string, string>,
-  matrixContext?: Record<string, string>,
-  needsContext?: Record<string, Record<string, string>>,
-  inputsContext?: Record<string, string>,
-  vars?: Record<string, string>,
-  runnerContext?: RunnerContext,
-  envContext?: Record<string, string>,
-): string {
+function evaluateExprValue(expr: string, ctx: ExprContext): string {
   const trimmed = expr.trim();
   if (!trimmed) {
     return "";
   }
 
-  // Strip matching outer parentheses
-  if (trimmed.startsWith("(")) {
-    let depth = 0;
-    let inQuote: string | null = null;
-    for (let i = 0; i < trimmed.length; i++) {
-      const ch = trimmed[i];
-      if (inQuote) {
-        if (ch === inQuote) {
-          inQuote = null;
-        }
-        continue;
-      }
-      if (ch === "'" || ch === '"') {
-        inQuote = ch;
-        continue;
-      }
-      if (ch === "(") {
-        depth++;
-      }
-      if (ch === ")") {
-        depth--;
-      }
-      if (depth === 0 && i === trimmed.length - 1) {
-        return evaluateExprValue(
-          trimmed.slice(1, -1),
-          repoPath,
-          secrets,
-          matrixContext,
-          needsContext,
-          inputsContext,
-          vars,
-          runnerContext,
-          envContext,
-        );
-      }
-      if (depth === 0) {
-        break;
-      }
-    }
+  const stripped = stripOuterParens(trimmed);
+  if (stripped !== null) {
+    return evaluateExprValue(stripped, ctx);
   }
 
-  // Handle || (lowest precedence)
+  // || (lowest precedence) — return first truthy, else the last value.
   const orParts = splitOnOperator(trimmed, "||");
   if (orParts.length > 1) {
     let lastVal = "";
     for (const part of orParts) {
-      lastVal = evaluateExprValue(
-        part.trim(),
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
+      lastVal = evaluateExprValue(part.trim(), ctx);
       if (isExprTruthy(lastVal)) {
         return lastVal;
       }
@@ -616,22 +495,12 @@ function evaluateExprValue(
     return lastVal;
   }
 
-  // Handle && (higher precedence than ||)
+  // && (higher precedence than ||) — return first falsy, else the last value.
   const andParts = splitOnOperator(trimmed, "&&");
   if (andParts.length > 1) {
     let lastVal = "";
     for (const part of andParts) {
-      lastVal = evaluateExprValue(
-        part.trim(),
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
+      lastVal = evaluateExprValue(part.trim(), ctx);
       if (!isExprTruthy(lastVal)) {
         return lastVal;
       }
@@ -639,51 +508,17 @@ function evaluateExprValue(
     return lastVal;
   }
 
-  // Handle comparison operators (==, !=, <=, >=, <, >)
-  // Check longer operators first to avoid matching <= as < then =
+  // Comparison operators. Longer operators first so `<=` doesn't get split as `<`.
   for (const op of ["!=", "==", "<=", ">=", "<", ">"]) {
-    const cmpParts = splitOnOperator(trimmed, op);
-    if (cmpParts.length === 2) {
-      const left = evaluateExprValue(
-        cmpParts[0].trim(),
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-      const right = evaluateExprValue(
-        cmpParts[1].trim(),
-        repoPath,
-        secrets,
-        matrixContext,
-        needsContext,
-        inputsContext,
-        vars,
-        runnerContext,
-        envContext,
-      );
-      const result = compareValues(left, right, op);
-      return result ? "true" : "false";
+    const result = evalComparison(trimmed, op, ctx);
+    if (result !== null) {
+      return result;
     }
   }
 
-  // Handle ! prefix (negation)
+  // ! prefix (negation)
   if (trimmed.startsWith("!")) {
-    const inner = evaluateExprValue(
-      trimmed.slice(1).trim(),
-      repoPath,
-      secrets,
-      matrixContext,
-      needsContext,
-      inputsContext,
-      vars,
-      runnerContext,
-      envContext,
-    );
+    const inner = evaluateExprValue(trimmed.slice(1).trim(), ctx);
     return isExprTruthy(inner) ? "false" : "true";
   }
 
@@ -712,17 +547,7 @@ function evaluateExprValue(
   }
 
   // Atom: function call or context variable
-  return resolveExprAtom(
-    trimmed,
-    repoPath,
-    secrets,
-    matrixContext,
-    needsContext,
-    inputsContext,
-    vars,
-    runnerContext,
-    envContext,
-  );
+  return resolveExprAtom(trimmed, ctx);
 }
 
 /**
@@ -742,20 +567,19 @@ export function expandExpressions(
   runnerContext?: RunnerContext,
   envContext?: Record<string, string>,
 ): string {
-  return value.replace(/\$\{\{([\s\S]*?)\}\}/g, (_match, expr: string) => {
-    const result = evaluateExprValue(
-      expr,
-      repoPath,
-      secrets,
-      matrixContext,
-      needsContext,
-      inputsContext,
-      vars,
-      runnerContext,
-      envContext,
-    );
-    return result;
-  });
+  const ctx: ExprContext = {
+    repoPath,
+    secrets,
+    matrixContext,
+    needsContext,
+    inputsContext,
+    vars,
+    runnerContext,
+    envContext,
+  };
+  return value.replace(/\$\{\{([\s\S]*?)\}\}/g, (_match, expr: string) =>
+    evaluateExprValue(expr, ctx),
+  );
 }
 
 function toStringRecord(value: unknown): Record<string, string> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260219.1
         version: 7.0.0-dev.20260219.1
+      fallow:
+        specifier: ^2.63.0
+        version: 2.63.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -1004,6 +1007,46 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fallow-cli/darwin-arm64@2.63.0':
+    resolution: {integrity: sha512-e8qVmPIYqufuCXLl+nC7Zn5QQ9finGbKlNuoWkLqhMYDebzE2X9vT6ahZEsM/58+MedA2hVonoYWh6XAFMdJPQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@fallow-cli/darwin-x64@2.63.0':
+    resolution: {integrity: sha512-M6hpadV7VzYtZPePPnGVzK/jJTVbke0+PnpUW4QEQUy0FD/V43+RMrWmhwSbOc4UZjRhcdZGq9GnlkG6WJn3EQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@fallow-cli/linux-arm64-gnu@2.63.0':
+    resolution: {integrity: sha512-ycBptRpO4yUgGX1KvZXcu9MWiDQDE3guSYQuzMhD1hC/eXn90rirnrv+ewq38SKCJ+x7CzAaeXEEX9NApsejTg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@fallow-cli/linux-arm64-musl@2.63.0':
+    resolution: {integrity: sha512-GkCc6txsi8UqNN64zif0BwBjj9wNQgbwmQsJD132+PxOuko52hVifkLoqLxKEN9s7iz+AQHqITB8E4eZ1nKtFg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@fallow-cli/linux-x64-gnu@2.63.0':
+    resolution: {integrity: sha512-itrofEERla6AO2UpgV/YPCnm6mfHbnV6tv+TSpBM+BDuCZM/Q5lIG0fbiVv/FzrFKmfzVPujODfg1Od1QdcJMg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@fallow-cli/linux-x64-musl@2.63.0':
+    resolution: {integrity: sha512-ZnC2yOKQnmild0yZwDxoORQHETPGKeFJMv0Jbwz784SjqmyhO+ZAChHX3N7N34smF5Q8QvW+GvLJsKNvoRQHIQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@fallow-cli/win32-arm64-msvc@2.63.0':
+    resolution: {integrity: sha512-V9fbBcctT6ieG3jf9e6H9xKdbzKx5YG7kJkKFO5M/z6CQMrQL5AcZ+kKmBvL+QrEuDVI669e/3tdKtl9alnEDA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@fallow-cli/win32-x64-msvc@2.63.0':
+    resolution: {integrity: sha512-JChdoy7SwBWmsL+l532j5lceoTQtP0hm1t0u/HqLPY/CAK7vM7Rz9ufzek1RAYpJhSJ+0dcIYLQiyWXLZ9RevQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@grpc/grpc-js@1.14.3':
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
@@ -2899,6 +2942,11 @@ packages:
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
+    hasBin: true
+
+  fallow@2.63.0:
+    resolution: {integrity: sha512-2+6JbFK7xEct35u9t63nDx2RwvIYOh8Y5zfAtxQy4P4Z9f4FbzYDGFkoucXIo6eTPxn8dqo2iLSRSeOZtGs57Q==}
+    engines: {node: '>=16'}
     hasBin: true
 
   fast-deep-equal@3.1.3:
@@ -5559,6 +5607,30 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@fallow-cli/darwin-arm64@2.63.0':
+    optional: true
+
+  '@fallow-cli/darwin-x64@2.63.0':
+    optional: true
+
+  '@fallow-cli/linux-arm64-gnu@2.63.0':
+    optional: true
+
+  '@fallow-cli/linux-arm64-musl@2.63.0':
+    optional: true
+
+  '@fallow-cli/linux-x64-gnu@2.63.0':
+    optional: true
+
+  '@fallow-cli/linux-x64-musl@2.63.0':
+    optional: true
+
+  '@fallow-cli/win32-arm64-msvc@2.63.0':
+    optional: true
+
+  '@fallow-cli/win32-x64-msvc@2.63.0':
+    optional: true
+
   '@grpc/grpc-js@1.14.3':
     dependencies:
       '@grpc/proto-loader': 0.8.0
@@ -6480,14 +6552,6 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 4.0.18
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.2)
-
   '@vitest/mocker@4.0.18(vite@7.3.2(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
@@ -7379,6 +7443,19 @@ snapshots:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:
       - supports-color
+
+  fallow@2.63.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@fallow-cli/darwin-arm64': 2.63.0
+      '@fallow-cli/darwin-x64': 2.63.0
+      '@fallow-cli/linux-arm64-gnu': 2.63.0
+      '@fallow-cli/linux-arm64-musl': 2.63.0
+      '@fallow-cli/linux-x64-gnu': 2.63.0
+      '@fallow-cli/linux-x64-musl': 2.63.0
+      '@fallow-cli/win32-arm64-msvc': 2.63.0
+      '@fallow-cli/win32-x64-msvc': 2.63.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -9570,7 +9647,7 @@ snapshots:
   vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.2(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18


### PR DESCRIPTION
## Problem

`executeLocalJob` in `packages/cli/src/runner/local-job.ts` had a ~190-line closure called `updateStoreFromTimeline`. The closure ran every 100 milliseconds while a job was active. On each tick it read two files — the actions-runner's `timeline.json` and a paused-signal file — folded the records into the shape the live progress display expects, and wrote the result into the in-memory run-state store.

To do its job the closure captured six mutable `let` variables defined just above it: `lastSeenAttempt`, `isPaused`, `pausedAtMs`, `pausedStepName`, `isBooting`, `lastFailedStep`. Every tick mutated some of them; a separate stdin-listener and the code that ran after the polling loop both read them too. The static-analysis tool fallow flagged this closure as the biggest remaining complexity hotspot after the previous round of refactors: a score of 70 on the cognitive-complexity metric (a measure of how hard a human reader finds the code to follow).

The closure being inline made three things harder:

1. It cannot be tested on its own. The only way to exercise it is to start a real Docker container.
2. The mutable state was invisible at a glance — six bare `let` declarations interleaved with other initialisation lines.
3. Reading `executeLocalJob` top-to-bottom required scrolling past 190 lines that had nothing to do with the job-execution lifecycle.

## Solution

Move the closure to module scope and split it into two helpers:

1. `syncTimelineToStore(state, ctx)` — drives one poll tick. Reads the paused-signal file (if `pauseOnFailure` is set) and the timeline JSON, then writes the result into the store. Mutates `state` in place.
2. `buildStepsFromTimeline(steps, state)` — folds the raw timeline records into the `StepState[]` shape the renderer expects. Pulled out of `syncTimelineToStore` because it is the gnarliest part — a 100-line for-loop with its own status-derivation rules.

Two new types make the contract explicit:

- `TimelineSyncState` bundles the six mutable fields. `executeLocalJob` creates one and passes a reference to both the polling loop and the stdin-listener, so they share a single source of truth.
- `TimelineSyncContext` carries the read-only paths and the `store` reference, plus an `onNewPause` callback. The callback wires `setupStdinRetry` in without coupling the helper to terminal handling.

Also drops two lines of dead code (`padW` and `totalSteps`) that the old closure computed but never used.

## Technical Summary

- New `syncTimelineToStore` at module scope. Cognitive 22.
- New `buildStepsFromTimeline` at module scope. Cognitive 45.
- New `TimelineSyncState` and `TimelineSyncContext` types.
- Inside `executeLocalJob`:
  - Six `let` declarations replaced with a single `const timelineState: TimelineSyncState = { … }`.
  - `setupStdinRetry` reads `timelineState.isPaused` instead of the old `let isPaused`.
  - The inline 190-line closure replaced with two calls to `syncTimelineToStore(timelineState, timelineCtx)` (one inside the polling loop, one final tick).
  - The post-polling result-builder reads `timelineState.lastFailedStep` and `timelineState.isBooting` instead of the old free `let`s.
- `executeLocalJob`'s body shrinks from ~715 lines to ~540 lines; its own cognitive score is unchanged at 56 because fallow already treated the inline closure as its own scope. The change is structural: the closure is testable and named, and the mutable state is named and shared explicitly.
- `pnpm check` passes (typecheck, lint, format, compatibility-table, diff-parse).
- Full local smoke suite passes 45 of 45 jobs with zero pauses and zero retries.

Stacked on top of #343. Once #343 (and the chain above it) merges, this can be rebased onto `main` cleanly.