### PR TITLE
chore(fallow): add config to filter false-positive dead-code reports

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.fallow.tools/schemas/fallow.json",
+  "ignorePatterns": [".github/fixtures/**", "experiments/**", "third-party-workflows/**"],
+  "dynamicallyLoaded": ["apps/website/**", "packages/cli/src/hooks/json-loader.ts"]
+}


### PR DESCRIPTION
## Problem

We added the static-analysis tool `fallow` as a development dependency in #337 so the team can find unused code, complexity hotspots, and duplication. Out of the box, fallow flagged 85 issues — but about two thirds were noise, because fallow only sees code that is wired together by static `import` statements. Three patterns in this repository do not look that way to a static scanner:

- The marketing site under `apps/website/**` is a server-rendered React app where the rwsdk framework picks up pages and routes by file-name convention, not by `import`.
- The folders under `experiments/**` and `.github/fixtures/**` are throwaway projects and test fixtures, not part of the published workspace.
- The file `packages/cli/src/hooks/json-loader.ts` is loaded through Node.js's built-in module-loader hook, not a direct `import`.

The result was that a developer looking at the report had to skim past 57 false positives to find the 28 real ones. That is bad for follow-up cleanup work — the next person to run the tool will either give up or start deleting code that is actually live.

## Solution

Add a `.fallowrc.json` configuration file at the repository root that:

1. Ignores the three fixture and experiment trees so they are not scanned at all.
2. Marks the marketing-site directory and the loader-hook file as "dynamically loaded," which tells fallow they are always in use even if no other file imports them.

After this change, `pnpm fallow dead-code` returns 28 issues, all of which point at real code we can act on.

## Technical Summary

- Adds `.fallowrc.json` with two top-level keys: `ignorePatterns` (totally skipped) and `dynamicallyLoaded` (treated as always-used).
- No code or behaviour change; tooling configuration only.
- No published-package changes, so no changeset is required (see `.claude/rules/changeset-required.md`).

Stacked on top of #337 (which adds fallow as the development dependency). Merge order: #337 first, then this.