### PR TITLE
chore: unexport helpers that were never imported externally

### DIFF
--- a/.changeset/trim-dead-exports.md
+++ b/.changeset/trim-dead-exports.md
@@ -1,0 +1,20 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+chore: unexport helpers that were never imported externally
+
+`log-prune.ts` and `generators.ts` had six identifiers marked `export`
+that no other file actually imported:
+
+- `DEFAULT_RETAIN_DAYS`, `DEFAULT_RETAIN_RUNS`, `DEFAULT_THROTTLE_MS`
+  (used only inside `log-prune.ts`)
+- `toContextData`, `toTemplateTokenMapping`
+  (used only inside `generators.ts`)
+- `toContainerTemplateToken`
+  (not used anywhere — wholly dead, removed)
+
+Tightens the public surface so callers can't accidentally rely on
+internal helpers, and gets a step closer to a clean dead-code report.
+No runtime behaviour change.

--- a/packages/cli/src/log-prune.ts
+++ b/packages/cli/src/log-prune.ts
@@ -3,11 +3,11 @@ import path from "node:path";
 import { resolveLogsDir, resolveStateDir } from "./run-result-writer.js";
 
 /** Default: keep runs whose mtime is younger than this many days. */
-export const DEFAULT_RETAIN_DAYS = 7;
+const DEFAULT_RETAIN_DAYS = 7;
 /** Default: keep at most this many runs after age-based filtering. */
-export const DEFAULT_RETAIN_RUNS = 20;
+const DEFAULT_RETAIN_RUNS = 20;
 /** Default: don't run more than once per this many ms unless forced. */
-export const DEFAULT_THROTTLE_MS = 60 * 60 * 1000; // 1 hour
+const DEFAULT_THROTTLE_MS = 60 * 60 * 1000; // 1 hour
 
 export interface PruneOptions {
   logsDir?: string;

--- a/packages/dtu-github-actions/src/server/routes/actions/generators.ts
+++ b/packages/dtu-github-actions/src/server/routes/actions/generators.ts
@@ -20,7 +20,7 @@ import {
 } from "../../../types.js";
 
 // Helper to convert JS objects to ContextData
-export function toContextData(obj: any): any {
+function toContextData(obj: any): any {
   if (typeof obj === "string") {
     return { t: 0, s: obj };
   }
@@ -67,7 +67,7 @@ function toTemplateTokenValue(v: string): any {
   return v;
 }
 
-export function toTemplateTokenMapping(obj: { [key: string]: string }): object {
+function toTemplateTokenMapping(obj: { [key: string]: string }): object {
   const entries = Object.entries(obj);
   if (entries.length === 0) {
     return { type: 2 };
@@ -76,60 +76,6 @@ export function toTemplateTokenMapping(obj: { [key: string]: string }): object {
     type: 2,
     map: entries.map(([k, v]) => ({ Key: k, Value: toTemplateTokenValue(v) })),
   };
-}
-
-/**
- * Convert a container definition { image, env?, ports?, volumes?, options? }
- * into a TemplateToken MappingToken that the runner's EvaluateJobContainer expects.
- *
- * Format:
- *   { type: 2, map: [{ Key: "image", Value: "alpine:3.19" }, ...] }
- *
- * Nested:
- *   env → MappingToken (type 2)
- *   ports/volumes → SequenceToken (type 1) of StringTokens
- *   options → StringToken (bare string)
- */
-export function toContainerTemplateToken(container: {
-  image: string;
-  env?: Record<string, string>;
-  ports?: string[];
-  volumes?: string[];
-  options?: string;
-}): object {
-  const map: { Key: string; Value: any }[] = [];
-
-  map.push({ Key: "image", Value: container.image });
-
-  if (container.env && Object.keys(container.env).length > 0) {
-    map.push({
-      Key: "env",
-      Value: {
-        type: 2,
-        map: Object.entries(container.env).map(([k, v]) => ({ Key: k, Value: v })),
-      },
-    });
-  }
-
-  if (container.ports && container.ports.length > 0) {
-    map.push({
-      Key: "ports",
-      Value: { type: 1, seq: container.ports },
-    });
-  }
-
-  if (container.volumes && container.volumes.length > 0) {
-    map.push({
-      Key: "volumes",
-      Value: { type: 1, seq: container.volumes },
-    });
-  }
-
-  if (container.options) {
-    map.push({ Key: "options", Value: container.options });
-  }
-
-  return { type: 2, map };
 }
 
 export function createJobResponse(


### PR DESCRIPTION
## Problem

Six identifiers in two files were marked `export`, but no file outside their own ever imported them. They were only referenced inside the file that declared them. One of the six (`toContainerTemplateToken`) was not used anywhere at all — leftover utility code from an earlier design.

Exporting an internal helper has two costs. First, it widens the public surface of the package, so a future reader cannot tell which symbols are part of the contract and which are private implementation details. Second, the static-analysis tool `fallow` flags every one of them, drowning out the real dead-code findings.

## Solution

1. In `packages/cli/src/log-prune.ts`, drop the `export` keyword from three module-private constants (`DEFAULT_RETAIN_DAYS`, `DEFAULT_RETAIN_RUNS`, `DEFAULT_THROTTLE_MS`). They are still used inside the file.
2. In `packages/dtu-github-actions/src/server/routes/actions/generators.ts`, drop the `export` keyword from two helpers (`toContextData`, `toTemplateTokenMapping`) that are only called by `createJobResponse` in the same file.
3. In the same file, delete `toContainerTemplateToken` entirely — function plus its block comment. It was not referenced anywhere.

No runtime behaviour change. The fallow unused-exports report drops by six items as a result.

## Technical Summary

- Three constants and two functions: `export` keyword removed; no other change.
- One function (`toContainerTemplateToken`) and its block comment: deleted.
- One patch-level changeset (`.changeset/trim-dead-exports.md`) covering both packages, per the repository's required-changesets rule.

Stacked on top of #337. Once #337 merges, this can be rebased onto `main` cleanly.