### PR TITLE
refactor(local-job): extract pull / seed / wait helpers from executeLocalJob

### DIFF
--- a/.changeset/local-job-extract-helpers.md
+++ b/.changeset/local-job-extract-helpers.md
@@ -1,0 +1,24 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+refactor(local-job): extract three helpers out of `executeLocalJob`
+
+`executeLocalJob` had grown to ~860 lines and scored 73 on the
+cognitive-complexity metric — the highest in the `cli` package after
+the previous round of refactors. Three self-contained blocks of code
+inside it have been moved into module-scope helpers:
+
+- `pullContainerImageWithProgress(docker, image, store, containerName)`
+  — the ~100-line Docker pull with per-layer download / extract
+  progress reporting (direct-container mode).
+- `seedRunnerBinaryToHost(docker, hostRunnerSeedDir)` — the one-time
+  extraction of the actions-runner binary from the seed image
+  (direct-container mode).
+- `waitForContainerExit(container, waitPromise, timeoutMs)` — the
+  promise-race that force-stops the container if the runner does not
+  exit within the timeout.
+
+`executeLocalJob` is now ~715 lines, cognitive 56. No behaviour
+change; the full local smoke suite passes.

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -130,6 +130,190 @@ const SEED_IMAGE = UPSTREAM_RUNNER_IMAGE;
 
 import { writeRunnerCredentials } from "./runner-credentials.js";
 
+const CONTAINER_EXIT_TIMEOUT_MS = 30_000;
+
+/**
+ * Pull a Docker image and report per-layer download / extraction progress to
+ * the RunStateStore. Resolves once the pull completes. Rejects on any error
+ * the daemon surfaces.
+ */
+async function pullContainerImageWithProgress(
+  docker: Docker,
+  image: string,
+  store: RunStateStore | undefined,
+  containerName: string,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    docker.pull(image, (err: Error | null, stream: NodeJS.ReadableStream) => {
+      if (err) {
+        return reject(err);
+      }
+      // Track per-layer progress across download and extraction phases
+      const downloadProgress = new Map<string, { current: number; total: number }>();
+      const extractProgress = new Map<string, { current: number; total: number }>();
+      let lastProgressUpdate = 0;
+      let currentPhase: "downloading" | "extracting" = "downloading";
+
+      const flushProgress = (force = false) => {
+        const map = currentPhase === "downloading" ? downloadProgress : extractProgress;
+        if (map.size === 0) {
+          return;
+        }
+        const now = Date.now();
+        if (!force && now - lastProgressUpdate < 250) {
+          return;
+        }
+        lastProgressUpdate = now;
+        let totalBytes = 0;
+        let currentBytes = 0;
+        for (const layer of map.values()) {
+          totalBytes += layer.total;
+          currentBytes += layer.current;
+        }
+        store?.updateJob(containerName, {
+          pullProgress: { phase: currentPhase, currentBytes, totalBytes },
+        });
+      };
+
+      docker.modem.followProgress(
+        stream,
+        (followErr: Error | null) => {
+          if (followErr) {
+            return reject(followErr);
+          }
+          store?.updateJob(containerName, { pullProgress: undefined });
+          resolve();
+        },
+        (event: {
+          status?: string;
+          id?: string;
+          progressDetail?: { current?: number; total?: number };
+        }) => {
+          if (!event.id) {
+            return;
+          }
+
+          const detail = event.progressDetail;
+          const hasByteCounts =
+            detail &&
+            typeof detail.current === "number" &&
+            typeof detail.total === "number" &&
+            detail.total > 0;
+
+          if (event.status === "Downloading" && hasByteCounts) {
+            downloadProgress.set(event.id, {
+              current: detail.current!,
+              total: detail.total!,
+            });
+          } else if (event.status === "Download complete") {
+            const existing = downloadProgress.get(event.id);
+            if (existing) {
+              existing.current = existing.total;
+            }
+          } else if (event.status === "Extracting" && hasByteCounts) {
+            const phaseChanged = currentPhase !== "extracting";
+            currentPhase = "extracting";
+            extractProgress.set(event.id, {
+              current: detail.current!,
+              total: detail.total!,
+            });
+            // Force update on first extraction event so the phase change is visible immediately
+            if (phaseChanged) {
+              flushProgress(true);
+              return;
+            }
+          } else if (event.status === "Pull complete") {
+            const existing = extractProgress.get(event.id);
+            if (existing) {
+              existing.current = existing.total;
+            }
+          } else {
+            return;
+          }
+
+          flushProgress();
+        },
+      );
+    });
+  });
+}
+
+/**
+ * Extract the actions-runner binary from the SEED_IMAGE to `hostRunnerSeedDir`
+ * once and reuse it on subsequent calls. Direct-container mode injects this
+ * runner into the user's chosen image so we don't have to fork their entrypoint.
+ *
+ * Skipped when the seed dir already has a `.seeded` marker and `run.sh`.
+ */
+async function seedRunnerBinaryToHost(docker: Docker, hostRunnerSeedDir: string): Promise<void> {
+  await fs.promises.mkdir(hostRunnerSeedDir, { recursive: true });
+  const markerFile = path.join(hostRunnerSeedDir, ".seeded");
+  const runShExists = fs.existsSync(path.join(hostRunnerSeedDir, "run.sh"));
+  const needsSeed = !fs.existsSync(markerFile) || !runShExists;
+  if (needsSeed) {
+    if (!runShExists && fs.existsSync(markerFile)) {
+      debugRunner(`Runner seed is incomplete (run.sh missing), re-extracting...`);
+    } else {
+      debugRunner(`Extracting runner binary to host (one-time)...`);
+    }
+    const tmpName = `agent-ci-seed-runner-${Date.now()}`;
+    const seedContainer = await docker.createContainer({
+      Image: SEED_IMAGE,
+      name: tmpName,
+      Cmd: ["true"],
+    });
+    execSync(`docker cp ${tmpName}:/home/runner/. "${hostRunnerSeedDir}/"`, { stdio: "pipe" });
+    await seedContainer.remove();
+    const configShPath = path.join(hostRunnerSeedDir, "config.sh");
+    let configSh = await fs.promises.readFile(configShPath, "utf8");
+    configSh = configSh.replace(
+      /# Check dotnet Core.*?^fi$/ms,
+      "# Dependency checks removed for container injection",
+    );
+    await fs.promises.writeFile(configShPath, configSh);
+    await fs.promises.writeFile(markerFile, new Date().toISOString());
+    ensureRunnerWriteable(hostRunnerSeedDir);
+    debugRunner(`Runner extracted.`);
+  }
+  for (const staleFile of [".runner", ".credentials", ".credentials_rsaparams"]) {
+    try {
+      fs.rmSync(path.join(hostRunnerSeedDir, staleFile));
+    } catch {
+      /* not present */
+    }
+  }
+}
+
+/**
+ * Wait for a container's exit, but bail out after `timeoutMs` and stop the
+ * container if the runner keeps the entrypoint alive past that. Returns the
+ * exit code the daemon reports.
+ */
+async function waitForContainerExit(
+  container: Docker.Container,
+  containerWaitPromise: Promise<{ StatusCode: number }>,
+  timeoutMs: number,
+): Promise<number> {
+  let waitResult: { StatusCode: number };
+  try {
+    waitResult = await Promise.race([
+      containerWaitPromise,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("Container exit timeout")), timeoutMs),
+      ),
+    ]);
+  } catch {
+    debugRunner(`Runner did not exit within ${timeoutMs / 1000}s, force-stopping container…`);
+    try {
+      await container.stop({ t: 5 });
+    } catch {
+      /* already stopped */
+    }
+    waitResult = await container.wait();
+  }
+  return waitResult.StatusCode;
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 export async function executeLocalJob(
@@ -417,144 +601,14 @@ export async function executeLocalJob(
     }
 
     if (useDirectContainer) {
-      await fs.promises.mkdir(hostRunnerSeedDir, { recursive: true });
-      const markerFile = path.join(hostRunnerSeedDir, ".seeded");
-      const runShExists = fs.existsSync(path.join(hostRunnerSeedDir, "run.sh"));
-      const needsSeed = !fs.existsSync(markerFile) || !runShExists;
-      if (needsSeed) {
-        if (!runShExists && fs.existsSync(markerFile)) {
-          debugRunner(`Runner seed is incomplete (run.sh missing), re-extracting...`);
-        } else {
-          debugRunner(`Extracting runner binary to host (one-time)...`);
-        }
-        const tmpName = `agent-ci-seed-runner-${Date.now()}`;
-        const seedContainer = await getDocker().createContainer({
-          Image: SEED_IMAGE,
-          name: tmpName,
-          Cmd: ["true"],
-        });
-        const { execSync } = await import("node:child_process");
-        execSync(`docker cp ${tmpName}:/home/runner/. "${hostRunnerSeedDir}/"`, { stdio: "pipe" });
-        await seedContainer.remove();
-        const configShPath = path.join(hostRunnerSeedDir, "config.sh");
-        let configSh = await fs.promises.readFile(configShPath, "utf8");
-        configSh = configSh.replace(
-          /# Check dotnet Core.*?^fi$/ms,
-          "# Dependency checks removed for container injection",
-        );
-        await fs.promises.writeFile(configShPath, configSh);
-        await fs.promises.writeFile(markerFile, new Date().toISOString());
-        ensureRunnerWriteable(hostRunnerSeedDir);
-        debugRunner(`Runner extracted.`);
-      }
-      for (const staleFile of [".runner", ".credentials", ".credentials_rsaparams"]) {
-        try {
-          fs.rmSync(path.join(hostRunnerSeedDir, staleFile));
-        } catch {
-          /* not present */
-        }
-      }
+      await seedRunnerBinaryToHost(getDocker(), hostRunnerSeedDir);
       execSync(`cp -a "${hostRunnerSeedDir}" "${hostRunnerDir}"`, { stdio: "pipe" });
 
       const resolvedUrl = `${dockerApiUrl}/${githubRepo}`;
       writeRunnerCredentials(hostRunnerDir, containerName, resolvedUrl);
-    }
 
-    if (useDirectContainer) {
       debugRunner(`Pulling ${containerImage}...`);
-      await new Promise<void>((resolve, reject) => {
-        getDocker().pull(containerImage, (err: Error | null, stream: NodeJS.ReadableStream) => {
-          if (err) {
-            return reject(err);
-          }
-          // Track per-layer progress across download and extraction phases
-          const downloadProgress = new Map<string, { current: number; total: number }>();
-          const extractProgress = new Map<string, { current: number; total: number }>();
-          let lastProgressUpdate = 0;
-          let currentPhase: "downloading" | "extracting" = "downloading";
-
-          const flushProgress = (force = false) => {
-            const map = currentPhase === "downloading" ? downloadProgress : extractProgress;
-            if (map.size === 0) {
-              return;
-            }
-            const now = Date.now();
-            if (!force && now - lastProgressUpdate < 250) {
-              return;
-            }
-            lastProgressUpdate = now;
-            let totalBytes = 0;
-            let currentBytes = 0;
-            for (const layer of map.values()) {
-              totalBytes += layer.total;
-              currentBytes += layer.current;
-            }
-            store?.updateJob(containerName, {
-              pullProgress: { phase: currentPhase, currentBytes, totalBytes },
-            });
-          };
-
-          getDocker().modem.followProgress(
-            stream,
-            (err: Error | null) => {
-              if (err) {
-                return reject(err);
-              }
-              store?.updateJob(containerName, { pullProgress: undefined });
-              resolve();
-            },
-            (event: {
-              status?: string;
-              id?: string;
-              progressDetail?: { current?: number; total?: number };
-            }) => {
-              if (!event.id) {
-                return;
-              }
-
-              const detail = event.progressDetail;
-              const hasByteCounts =
-                detail &&
-                typeof detail.current === "number" &&
-                typeof detail.total === "number" &&
-                detail.total > 0;
-
-              if (event.status === "Downloading" && hasByteCounts) {
-                downloadProgress.set(event.id, {
-                  current: detail.current!,
-                  total: detail.total!,
-                });
-              } else if (event.status === "Download complete") {
-                const existing = downloadProgress.get(event.id);
-                if (existing) {
-                  existing.current = existing.total;
-                }
-              } else if (event.status === "Extracting" && hasByteCounts) {
-                const phaseChanged = currentPhase !== "extracting";
-                currentPhase = "extracting";
-                extractProgress.set(event.id, {
-                  current: detail.current!,
-                  total: detail.total!,
-                });
-                // Force update on first extraction event so the phase change is visible immediately
-                if (phaseChanged) {
-                  flushProgress(true);
-                  return;
-                }
-              } else if (event.status === "Pull complete") {
-                const existing = extractProgress.get(event.id);
-                if (existing) {
-                  existing.current = existing.total;
-                }
-              } else {
-                return;
-              }
-
-              flushProgress();
-            },
-          );
-        });
-      });
+      await pullContainerImageWithProgress(getDocker(), containerImage, store, containerName);
     }
 
     const containerEnv = buildContainerEnv({
@@ -897,27 +951,11 @@ export async function executeLocalJob(
     await pollPromise;
 
     // 8. Wait for completion
-    const CONTAINER_EXIT_TIMEOUT_MS = 30_000;
-    let waitResult: { StatusCode: number };
-    try {
-      waitResult = await Promise.race([
-        containerWaitPromise,
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error("Container exit timeout")), CONTAINER_EXIT_TIMEOUT_MS),
-        ),
-      ]);
-    } catch {
-      debugRunner(
-        `Runner did not exit within ${CONTAINER_EXIT_TIMEOUT_MS / 1000}s, force-stopping container…`,
-      );
-      try {
-        await container.stop({ t: 5 });
-      } catch {
-        /* already stopped */
-      }
-      waitResult = await container.wait();
-    }
-    const containerExitCode = waitResult.StatusCode;
+    const containerExitCode = await waitForContainerExit(
+      container,
+      containerWaitPromise,
+      CONTAINER_EXIT_TIMEOUT_MS,
+    );
 
     const jobSucceeded = isJobSuccessful({ lastFailedStep, containerExitCode, isBooting });
 


### PR DESCRIPTION
## Problem

`packages/cli/src/runner/local-job.ts` is where each Docker-backed workflow job actually runs. The function that drives the run, `executeLocalJob`, had grown to roughly 860 lines and scored 73 on the cognitive-complexity metric — the highest single function in the `agent-ci` command-line package after the previous round of refactors in #340.

Three blocks inside it stood out:

1. A ~100-line Docker image pull with detailed per-layer download and extraction progress reporting. Only the direct-container code path uses it.
2. The one-time extraction of the actions-runner binary from the seed image to a host directory (also direct-container only). This includes a fix-up that strips a dotnet check from `config.sh` and resets file permissions.
3. The container-exit wait, which races `container.wait()` against a 30-second timeout and force-stops the container if the runner overruns.

All three are self-contained and orthogonal to the orchestration around them. Keeping them inline made the function harder to read and harder to test.

## Solution

Move each of the three blocks into its own module-scope helper, and call the helper from `executeLocalJob`:

1. `pullContainerImageWithProgress(docker, image, store, containerName)` — wraps the dockerode `pull` plus the per-layer progress tracking. Resolves when the pull completes. Rejects on any error the Docker daemon surfaces.
2. `seedRunnerBinaryToHost(docker, hostRunnerSeedDir)` — extracts the actions-runner binary from the seed image to `hostRunnerSeedDir` the first time it is called and skips the work on subsequent calls.
3. `waitForContainerExit(container, containerWaitPromise, timeoutMs)` — races the supplied wait promise against the timeout, force-stops the container on timeout, and returns the daemon-reported exit code.

`executeLocalJob` still drives the run end-to-end; it now reads top-to-bottom as a sequence of steps that call out to focused helpers.

## Technical Summary

- New module-scope `pullContainerImageWithProgress`, `seedRunnerBinaryToHost`, `waitForContainerExit`.
- New constant `CONTAINER_EXIT_TIMEOUT_MS = 30_000` hoisted out of the wait block.
- Three corresponding inline blocks deleted from `executeLocalJob`.
- File length: `executeLocalJob` 859 → 715 lines; whole file 993 → 1036 lines (the helpers add their own signatures and comment blocks, which more than offsets the body shrinkage at file scope).
- Cognitive complexity score (fallow health): `executeLocalJob` 73 → 56.
- `pnpm check` passes (typecheck, lint, format, compatibility-table, diff-parse).
- Full local smoke suite passes 45 of 45 jobs.

Follow-up: the `updateStoreFromTimeline` closure inside `executeLocalJob` still scores about 70 on the cognitive metric. It captures many mutable local variables, so extracting it cleanly needs a state-object plumbing pass; left as a follow-up so this change stays small and reviewable.

Stacked on top of #337. Once #337 merges, this can be rebased onto `main` cleanly.