### PR TITLE
refactor(local-job): lift the timeline-sync closure to module scope

### DIFF
--- a/.changeset/local-job-timeline-sync.md
+++ b/.changeset/local-job-timeline-sync.md
@@ -1,0 +1,29 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+refactor(local-job): lift the timeline-sync closure to module scope
+
+`executeLocalJob` had a ~190-line `updateStoreFromTimeline` closure
+that read `timeline.json` plus the paused-signal file every 100ms and
+updated the RunStateStore. The closure captured six mutable `let`
+variables defined just above it; fallow's previous report flagged it
+as the biggest remaining complexity hotspot (cognitive 70).
+
+This change pulls the closure to module scope as two helpers:
+
+- `syncTimelineToStore(state, ctx)` — drives one poll tick. Cognitive
+  score 22.
+- `buildStepsFromTimeline(steps, state)` — folds the raw timeline
+  records into the `StepState[]` shape the renderer expects. Cognitive
+  score 45.
+
+Both take an explicit `TimelineSyncState` object that the polling loop
+mutates between ticks, plus a read-only `TimelineSyncContext` with the
+paths, store reference, and `onNewPause` callback.
+
+Also drops `padW` / `totalSteps` from the old closure — they were
+computed but never used (legacy padding logic).
+
+No behaviour change; the full local smoke suite passes 45/45.

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -285,6 +285,236 @@ async function seedRunnerBinaryToHost(docker: Docker, hostRunnerSeedDir: string)
 }
 
 /**
+ * Mutable state tracked across timeline-poll ticks. The store-sync helper
+ * mutates the fields in place; the polling loop and the rest of
+ * `executeLocalJob` read them once the loop finishes.
+ */
+type TimelineSyncState = {
+  lastSeenAttempt: number;
+  isPaused: boolean;
+  pausedAtMs: number | null;
+  pausedStepName: string | null;
+  isBooting: boolean;
+  lastFailedStep: string | null;
+};
+
+/** Read-only inputs the store-sync helper needs but does not mutate. */
+type TimelineSyncContext = {
+  pauseOnFailure: boolean;
+  pausedSignalPath: string;
+  signalsDir: string;
+  timelinePath: string;
+  bootStart: number;
+  containerName: string;
+  store: RunStateStore | undefined;
+  /** Called the first time a pause is detected — sets up the Enter-to-retry stdin listener. */
+  onNewPause: () => void;
+};
+
+/** Result of folding the timeline-records list into a render-ready shape. */
+type BuiltSteps = {
+  newSteps: StepState[];
+  totalDurationMs: number | undefined;
+  jobFinished: boolean;
+};
+
+/**
+ * Fold the raw actions-runner timeline records into the `StepState[]` shape
+ * the renderer expects. Mutates `state.lastFailedStep` when a step result is
+ * "failed". Skips duplicate names; the second occurrence (e.g. for a "Post"
+ * step) triggers a synthetic "Post Setup" row at the end.
+ */
+function buildStepsFromTimeline(steps: any[], state: TimelineSyncState): BuiltSteps {
+  const seenNames = new Set<string>();
+  let hasPostSteps = false;
+  let completeJobRecord: any = null;
+
+  const preCountNames = new Set<string>();
+  for (const r of steps) {
+    if (!preCountNames.has(r.name)) {
+      preCountNames.add(r.name);
+    } else {
+      hasPostSteps = true;
+    }
+  }
+
+  let stepIdx = 0;
+  const newSteps: StepState[] = [];
+
+  for (const r of steps) {
+    if (seenNames.has(r.name)) {
+      continue;
+    }
+    seenNames.add(r.name);
+
+    if (r.name === "Complete job") {
+      completeJobRecord = r;
+      continue;
+    }
+    stepIdx++;
+
+    const durationMs =
+      r.startTime && r.finishTime
+        ? new Date(r.finishTime).getTime() - new Date(r.startTime).getTime()
+        : undefined;
+
+    let status: StepState["status"];
+    if (!r.result && r.state !== "completed") {
+      if (r.startTime) {
+        status = state.isPaused && state.pausedStepName === r.name ? "paused" : "running";
+      } else {
+        status = "pending";
+      }
+    } else {
+      const result = (r.result || "").toLowerCase();
+      if (result === "failed") {
+        state.lastFailedStep = r.name;
+        status = "failed";
+      } else if (result === "skipped") {
+        status = "skipped";
+      } else {
+        status = "completed";
+      }
+    }
+
+    newSteps.push({
+      name: r.name,
+      index: stepIdx,
+      status,
+      startedAt: r.startTime,
+      completedAt: r.finishTime,
+      durationMs,
+    });
+  }
+
+  const jobFinished = !!completeJobRecord?.result;
+
+  if (hasPostSteps && jobFinished) {
+    stepIdx++;
+    newSteps.push({ name: "Post Setup", index: stepIdx, status: "completed" });
+  }
+
+  if (completeJobRecord && jobFinished) {
+    stepIdx++;
+    const durationMs =
+      completeJobRecord.startTime && completeJobRecord.finishTime
+        ? new Date(completeJobRecord.finishTime).getTime() -
+          new Date(completeJobRecord.startTime).getTime()
+        : undefined;
+    newSteps.push({
+      name: "Complete job",
+      index: stepIdx,
+      status: "completed",
+      startedAt: completeJobRecord.startTime,
+      completedAt: completeJobRecord.finishTime,
+      durationMs,
+    });
+  }
+
+  // Total job duration spans first step start to last step end.
+  let totalDurationMs: number | undefined;
+  if (jobFinished) {
+    const allTimes = steps
+      .filter((r) => r.startTime && r.finishTime)
+      .map((r) => ({
+        start: new Date(r.startTime).getTime(),
+        end: new Date(r.finishTime).getTime(),
+      }));
+    if (allTimes.length > 0) {
+      const earliest = Math.min(...allTimes.map((t) => t.start));
+      const latest = Math.max(...allTimes.map((t) => t.end));
+      const ms = latest - earliest;
+      if (!isNaN(ms) && ms >= 0) {
+        totalDurationMs = ms;
+      }
+    }
+  }
+
+  return { newSteps, totalDurationMs, jobFinished };
+}
+
+/**
+ * One poll tick of the actions-runner timeline.json into the RunStateStore.
+ * Reads the paused-signal file (if `pauseOnFailure` is set) and the timeline
+ * JSON; updates the store and the mutable `state` in place. Errors are
+ * swallowed — this is best-effort and runs every 100ms.
+ */
+function syncTimelineToStore(state: TimelineSyncState, ctx: TimelineSyncContext): void {
+  try {
+    // ── Pause-on-failure: check for paused signal ───────────────────────────
+    if (ctx.pauseOnFailure && fs.existsSync(ctx.pausedSignalPath)) {
+      const content = fs.readFileSync(ctx.pausedSignalPath, "utf-8").trim();
+      const lines = content.split("\n");
+      state.pausedStepName = lines[0] || null;
+      const attempt = parseInt(lines[1] || "1", 10);
+      const isNewAttempt = attempt !== state.lastSeenAttempt;
+      if (isNewAttempt) {
+        state.lastSeenAttempt = attempt;
+        state.isPaused = true;
+        state.pausedAtMs = Date.now();
+        ctx.onNewPause();
+      }
+
+      // Read output captured by the wrapper script's tee — written directly
+      // to the signals dir so it's always available when paused.
+      const tailLines = tailLogFile(path.join(ctx.signalsDir, "step-output"), 20);
+
+      ctx.store?.updateJob(ctx.containerName, {
+        status: "paused",
+        pausedAtStep: state.pausedStepName || undefined,
+        ...(isNewAttempt && state.pausedAtMs !== null
+          ? { pausedAtMs: new Date(state.pausedAtMs).toISOString(), attempt: state.lastSeenAttempt }
+          : {}),
+        lastOutputLines: tailLines,
+      });
+    } else if (state.isPaused && !fs.existsSync(ctx.pausedSignalPath)) {
+      // Pause signal removed — job is retrying
+      state.isPaused = false;
+      state.pausedAtMs = null;
+      ctx.store?.updateJob(ctx.containerName, { status: "running", pausedAtMs: undefined });
+    }
+
+    if (!fs.existsSync(ctx.timelinePath)) {
+      return;
+    }
+
+    const records = JSON.parse(fs.readFileSync(ctx.timelinePath, "utf-8")) as any[];
+    const steps = records
+      .filter((r) => r.type === "Task" && r.name)
+      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+
+    if (steps.length === 0) {
+      return;
+    }
+
+    // ── Transition from booting to running on first timeline entry ──────────
+    if (state.isBooting) {
+      state.isBooting = false;
+      debugBoot(`${ctx.containerName} total: ${Date.now() - ctx.bootStart}ms`);
+      ctx.store?.updateJob(ctx.containerName, {
+        status: state.isPaused ? "paused" : "running",
+        bootDurationMs: Date.now() - ctx.bootStart,
+      });
+    }
+
+    const { newSteps, totalDurationMs, jobFinished } = buildStepsFromTimeline(steps, state);
+
+    ctx.store?.updateJob(ctx.containerName, {
+      steps: newSteps,
+      ...(jobFinished
+        ? {
+            status: state.lastFailedStep ? "failed" : "completed",
+            failedStep: state.lastFailedStep || undefined,
+            durationMs: totalDurationMs,
+          }
+        : {}),
+    });
+  } catch {
+    // Best-effort
+  }
+}
+
+/**
  * Wait for a container's exit, but bail out after `timeoutMs` and stop the
  * container if the runner keeps the entrypoint alive past that. Returns the
  * exit code the daemon reports.
@@ -686,16 +916,19 @@ export async function executeLocalJob(
     })) as NodeJS.ReadableStream;
 
     let tailDone = false;
-    let lastFailedStep: string | null = null;
-    let isPaused = false;
-    let pausedStepName: string | null = null;
-    let pausedAtMs: number | null = null;
-    let lastSeenAttempt = 0;
-    let isBooting = true;
     let stdinListening = false;
     const timelinePath = path.join(logDir, "timeline.json");
     const pausedSignalPath = path.join(dirs.signalsDir, "paused");
     const signalsRunDir = path.dirname(dirs.signalsDir);
+
+    const timelineState: TimelineSyncState = {
+      lastSeenAttempt: 0,
+      isPaused: false,
+      pausedAtMs: null,
+      pausedStepName: null,
+      isBooting: true,
+      lastFailedStep: null,
+    };
 
     // Listen for Enter key to trigger retry when paused
     const setupStdinRetry = () => {
@@ -710,7 +943,7 @@ export async function executeLocalJob(
           process.stdin.setRawMode(false);
           process.exit(130);
         }
-        if (key[0] === 13 && isPaused) {
+        if (key[0] === 13 && timelineState.isPaused) {
           syncWorkspaceForRetry(signalsRunDir);
           fs.writeFileSync(path.join(dirs.signalsDir, "retry"), "");
         }
@@ -725,204 +958,24 @@ export async function executeLocalJob(
       }
     };
 
-    // ── Timeline → store updater ──────────────────────────────────────────────
-    // Reads timeline.json and the paused signal, then updates the RunStateStore.
-    // The render loop in cli.ts reads the store and calls renderRunState().
-    const updateStoreFromTimeline = () => {
-      try {
-        // ── Pause-on-failure: check for paused signal ───────────────────────
-        if (pauseOnFailure && fs.existsSync(pausedSignalPath)) {
-          const content = fs.readFileSync(pausedSignalPath, "utf-8").trim();
-          const lines = content.split("\n");
-          pausedStepName = lines[0] || null;
-          const attempt = parseInt(lines[1] || "1", 10);
-          const isNewAttempt = attempt !== lastSeenAttempt;
-          if (isNewAttempt) {
-            lastSeenAttempt = attempt;
-            isPaused = true;
-            pausedAtMs = Date.now();
-            setupStdinRetry();
-          }
-
-          // Read output captured by the wrapper script's tee — written directly
-          // to the signals dir so it's always available when paused.
-          const tailLines = tailLogFile(path.join(dirs.signalsDir, "step-output"), 20);
-
-          store?.updateJob(containerName, {
-            status: "paused",
-            pausedAtStep: pausedStepName || undefined,
-            ...(isNewAttempt && pausedAtMs !== null
-              ? { pausedAtMs: new Date(pausedAtMs).toISOString(), attempt: lastSeenAttempt }
-              : {}),
-            lastOutputLines: tailLines,
-          });
-        } else if (isPaused && !fs.existsSync(pausedSignalPath)) {
-          // Pause signal removed — job is retrying
-          isPaused = false;
-          pausedAtMs = null;
-          store?.updateJob(containerName, { status: "running", pausedAtMs: undefined });
-        }
-
-        if (!fs.existsSync(timelinePath)) {
-          return;
-        }
-
-        const records = JSON.parse(fs.readFileSync(timelinePath, "utf-8")) as any[];
-        const steps = records
-          .filter((r) => r.type === "Task" && r.name)
-          .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
-
-        if (steps.length === 0) {
-          return;
-        }
-
-        // ── Transition from booting to running on first timeline entry ────────
-        if (isBooting) {
-          isBooting = false;
-          bt("total", bootStart);
-          store?.updateJob(containerName, {
-            status: isPaused ? "paused" : "running",
-            bootDurationMs: Date.now() - bootStart,
-          });
-        }
-
-        // ── Build StepState[] from timeline records ───────────────────────────
-        const seenNames = new Set<string>();
-        let hasPostSteps = false;
-        let completeJobRecord: any = null;
-
-        const preCountNames = new Set<string>();
-        for (const r of steps) {
-          if (!preCountNames.has(r.name)) {
-            preCountNames.add(r.name);
-          } else {
-            hasPostSteps = true;
-          }
-        }
-        const hasCompleteJob = preCountNames.has("Complete job");
-        // Total = unique names (minus "Complete job") + "Post Setup" (if any) + "Complete job"
-        const totalSteps =
-          preCountNames.size -
-          (hasCompleteJob ? 1 : 0) +
-          (hasPostSteps ? 1 : 0) +
-          (hasCompleteJob ? 1 : 0);
-        const padW = String(totalSteps).length;
-
-        let stepIdx = 0;
-        const newSteps: StepState[] = [];
-
-        for (const r of steps) {
-          if (seenNames.has(r.name)) {
-            continue;
-          }
-          seenNames.add(r.name);
-
-          if (r.name === "Complete job") {
-            completeJobRecord = r;
-            continue;
-          }
-          stepIdx++;
-
-          const durationMs =
-            r.startTime && r.finishTime
-              ? new Date(r.finishTime).getTime() - new Date(r.startTime).getTime()
-              : undefined;
-
-          let status: StepState["status"];
-          if (!r.result && r.state !== "completed") {
-            if (r.startTime) {
-              status = isPaused && pausedStepName === r.name ? "paused" : "running";
-            } else {
-              status = "pending";
-            }
-          } else {
-            const result = (r.result || "").toLowerCase();
-            if (result === "failed") {
-              lastFailedStep = r.name;
-              status = "failed";
-            } else if (result === "skipped") {
-              status = "skipped";
-            } else {
-              status = "completed";
-            }
-          }
-
-          newSteps.push({
-            name: r.name,
-            index: stepIdx,
-            status,
-            startedAt: r.startTime,
-            completedAt: r.finishTime,
-            durationMs,
-          });
-          void padW; // used for totalSteps calculation above
-        }
-
-        const jobFinished = !!completeJobRecord?.result;
-
-        if (hasPostSteps && jobFinished) {
-          stepIdx++;
-          newSteps.push({ name: "Post Setup", index: stepIdx, status: "completed" });
-        }
-
-        if (completeJobRecord && jobFinished) {
-          stepIdx++;
-          const durationMs =
-            completeJobRecord.startTime && completeJobRecord.finishTime
-              ? new Date(completeJobRecord.finishTime).getTime() -
-                new Date(completeJobRecord.startTime).getTime()
-              : undefined;
-          newSteps.push({
-            name: "Complete job",
-            index: stepIdx,
-            status: "completed",
-            startedAt: completeJobRecord.startTime,
-            completedAt: completeJobRecord.finishTime,
-            durationMs,
-          });
-        }
-
-        // Compute total duration from timeline step times
-        let totalDurationMs: number | undefined;
-        if (jobFinished) {
-          const allTimes = steps
-            .filter((r) => r.startTime && r.finishTime)
-            .map((r) => ({
-              start: new Date(r.startTime).getTime(),
-              end: new Date(r.finishTime).getTime(),
-            }));
-          if (allTimes.length > 0) {
-            const earliest = Math.min(...allTimes.map((t) => t.start));
-            const latest = Math.max(...allTimes.map((t) => t.end));
-            const ms = latest - earliest;
-            if (!isNaN(ms) && ms >= 0) {
-              totalDurationMs = ms;
-            }
-          }
-        }
-
-        store?.updateJob(containerName, {
-          steps: newSteps,
-          ...(jobFinished
-            ? {
-                status: lastFailedStep ? "failed" : "completed",
-                failedStep: lastFailedStep || undefined,
-                durationMs: totalDurationMs,
-              }
-            : {}),
-        });
-      } catch {
-        // Best-effort
-      }
+    const timelineCtx: TimelineSyncContext = {
+      pauseOnFailure,
+      pausedSignalPath,
+      signalsDir: dirs.signalsDir,
+      timelinePath,
+      bootStart,
+      containerName,
+      store,
+      onNewPause: setupStdinRetry,
     };
 
     const pollPromise = (async () => {
       while (!tailDone) {
-        updateStoreFromTimeline();
+        syncTimelineToStore(timelineState, timelineCtx);
         await new Promise((r) => setTimeout(r, 100));
       }
       // Final update
-      updateStoreFromTimeline();
+      syncTimelineToStore(timelineState, timelineCtx);
     })();
 
     // Start waiting for container exit in parallel with log streaming.
@@ -957,7 +1010,11 @@ export async function executeLocalJob(
       CONTAINER_EXIT_TIMEOUT_MS,
     );
 
-    const jobSucceeded = isJobSuccessful({ lastFailedStep, containerExitCode, isBooting });
+    const jobSucceeded = isJobSuccessful({
+      lastFailedStep: timelineState.lastFailedStep,
+      containerExitCode,
+      isBooting: timelineState.isBooting,
+    });
 
     // Update store with final exit code on failure
     if (!jobSucceeded) {
@@ -995,7 +1052,7 @@ export async function executeLocalJob(
       job,
       startTime,
       jobSucceeded,
-      lastFailedStep,
+      lastFailedStep: timelineState.lastFailedStep,
       containerExitCode,
       timelinePath,
       logDir,


### PR DESCRIPTION
## Problem

`executeLocalJob` in `packages/cli/src/runner/local-job.ts` had a ~190-line closure called `updateStoreFromTimeline`. The closure ran every 100 milliseconds while a job was active. On each tick it read two files — the actions-runner's `timeline.json` and a paused-signal file — folded the records into the shape the live progress display expects, and wrote the result into the in-memory run-state store.

To do its job the closure captured six mutable `let` variables defined just above it: `lastSeenAttempt`, `isPaused`, `pausedAtMs`, `pausedStepName`, `isBooting`, `lastFailedStep`. Every tick mutated some of them; a separate stdin-listener and the code that ran after the polling loop both read them too. The static-analysis tool fallow flagged this closure as the biggest remaining complexity hotspot after the previous round of refactors: a score of 70 on the cognitive-complexity metric (a measure of how hard a human reader finds the code to follow).

The closure being inline made three things harder:

1. It cannot be tested on its own. The only way to exercise it is to start a real Docker container.
2. The mutable state was invisible at a glance — six bare `let` declarations interleaved with other initialisation lines.
3. Reading `executeLocalJob` top-to-bottom required scrolling past 190 lines that had nothing to do with the job-execution lifecycle.

## Solution

Move the closure to module scope and split it into two helpers:

1. `syncTimelineToStore(state, ctx)` — drives one poll tick. Reads the paused-signal file (if `pauseOnFailure` is set) and the timeline JSON, then writes the result into the store. Mutates `state` in place.
2. `buildStepsFromTimeline(steps, state)` — folds the raw timeline records into the `StepState[]` shape the renderer expects. Pulled out of `syncTimelineToStore` because it is the gnarliest part — a 100-line for-loop with its own status-derivation rules.

Two new types make the contract explicit:

- `TimelineSyncState` bundles the six mutable fields. `executeLocalJob` creates one and passes a reference to both the polling loop and the stdin-listener, so they share a single source of truth.
- `TimelineSyncContext` carries the read-only paths and the `store` reference, plus an `onNewPause` callback. The callback wires `setupStdinRetry` in without coupling the helper to terminal handling.

Also drops two lines of dead code (`padW` and `totalSteps`) that the old closure computed but never used.

## Technical Summary

- New `syncTimelineToStore` at module scope. Cognitive 22.
- New `buildStepsFromTimeline` at module scope. Cognitive 45.
- New `TimelineSyncState` and `TimelineSyncContext` types.
- Inside `executeLocalJob`:
  - Six `let` declarations replaced with a single `const timelineState: TimelineSyncState = { … }`.
  - `setupStdinRetry` reads `timelineState.isPaused` instead of the old `let isPaused`.
  - The inline 190-line closure replaced with two calls to `syncTimelineToStore(timelineState, timelineCtx)` (one inside the polling loop, one final tick).
  - The post-polling result-builder reads `timelineState.lastFailedStep` and `timelineState.isBooting` instead of the old free `let`s.
- `executeLocalJob`'s body shrinks from ~715 lines to ~540 lines; its own cognitive score is unchanged at 56 because fallow already treated the inline closure as its own scope. The change is structural: the closure is testable and named, and the mutable state is named and shared explicitly.
- `pnpm check` passes (typecheck, lint, format, compatibility-table, diff-parse).
- Full local smoke suite passes 45 of 45 jobs with zero pauses and zero retries.

Stacked on top of #343. Once #343 (and the chain above it) merges, this can be rebased onto `main` cleanly.