### PR TITLE
chore: require Node 24 and drop tsx

### DIFF
--- a/.changeset/node-24-drop-tsx.md
+++ b/.changeset/node-24-drop-tsx.md
@@ -1,0 +1,31 @@
+---
+"@redwoodjs/agent-ci": minor
+"dtu-github-actions": minor
+---
+
+chore: require Node 24 and drop `tsx`
+
+Node 24 ships native TypeScript stripping as a stable feature, so we no
+longer need the `tsx` runtime to execute `.ts` files. Every `tsx foo.ts`
+invocation in package scripts becomes `node foo.ts`. `tsx` is removed
+from `devDependencies` in every workspace.
+
+To make this work with the codebase's existing import convention,
+TypeScript is configured to emit `.js` paths in built output while
+allowing source files to use real `.ts` extensions:
+
+- `allowImportingTsExtensions: true`
+- `rewriteRelativeImportExtensions: true`
+
+All 72 source files have been mechanically updated: every relative
+import that previously said `from "./foo.js"` now says
+`from "./foo.ts"`. The compiled `dist/` output still emits the `.js`
+extension, so consumers see no change.
+
+Breaking change: the published packages now declare
+`engines.node: ">=24"`. Node 22 is no longer supported.
+
+CI: the `tests.yml` workflow bumps from Node 22 to Node 24. Smoke
+workflows that set `node-version: 22` are left alone — they are
+fixtures exercising specific Node versions via `actions/setup-node`,
+not our project's runtime.

--- a/.docs/marketing/demo-recording/package.json
+++ b/.docs/marketing/demo-recording/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "scripts": {
     "test": "node --test value.test.mjs",
-    "agent-ci": "pnpm --dir ../../../packages/dtu-github-actions run build && ../../../node_modules/.bin/tsx ../../../packages/cli/src/cli.ts"
+    "agent-ci": "pnpm --dir ../../../packages/dtu-github-actions run build && node ../../../packages/cli/src/cli.ts"
   }
 }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
       - run: pnpm install
       - run: pnpm check

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "agent-ci-monorepo",
   "private": true,
+  "type": "module",
   "scripts": {
     "test": "pnpm --include-workspace-root=false -r test",
     "check": "npm-run-all --parallel typecheck lint format:check compat:check parse:diff",
@@ -13,11 +14,11 @@
     "format": "oxfmt",
     "format:fix": "oxfmt",
     "format:check": "oxfmt --check",
-    "agent-ci": "cd packages/dtu-github-actions && pnpm run build && cd ../cli && tsx src/cli.ts",
+    "agent-ci": "cd packages/dtu-github-actions && pnpm run build && cd ../cli && node src/cli.ts",
     "agent-ci-dev": "./scripts/agent-ci-dev.sh",
     "demo": "bash .docs/marketing/demo-recording/demo.sh",
-    "parse:diff": "tsx scripts/diff-parse.ts",
-    "ts-runner": "tsx packages/ts-runner/src/cli.ts",
+    "parse:diff": "node scripts/diff-parse.ts",
+    "ts-runner": "node packages/ts-runner/src/cli.ts",
     "start": "./scripts/run.sh",
     "prepare": "husky || true",
     "changeset": "changeset",
@@ -35,8 +36,8 @@
     "npm-run-all2": "8.0.4",
     "oxfmt": "0.33.0",
     "oxlint": "1.48.0",
-    "tsx": "^4.21.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "yaml": "^2.8.2"
   },
   "lint-staged": {
     "*.{js,ts,jsx,tsx,json,css,html}": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "build": "tsgo",
     "typecheck": "tsgo",
-    "agent-ci": "tsx src/cli.ts",
+    "agent-ci": "node src/cli.ts",
     "test": "vitest run"
   },
   "dependencies": {
@@ -50,10 +50,9 @@
   "devDependencies": {
     "@types/dockerode": "^3.3.34",
     "@types/node": "^22.10.2",
-    "tsx": "^4.21.0",
     "vitest": "^4.0.18"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
-import { applyAgentCiEnv } from "./config.js";
+import { applyAgentCiEnv } from "./config.ts";
 
 function resolveRepoRoot() {
   let repoRoot = process.cwd();
@@ -37,13 +37,13 @@ async function main() {
   // don't pay the cost of loading dockerode/grpc-js/protobufjs/ssh2 and the
   // full workflow parser. See issue #334.
   if (command === "run") {
-    const { default: runCmd } = await import("./commands/run.js");
+    const { default: runCmd } = await import("./commands/run.ts");
     await runCmd(args);
   } else if (command === "retry" || command === "abort") {
-    const { default: retryAbort } = await import("./commands/retry-abort.js");
+    const { default: retryAbort } = await import("./commands/retry-abort.ts");
     await retryAbort(command, args);
   } else if (command === "clean") {
-    const { default: clean } = await import("./commands/clean.js");
+    const { default: clean } = await import("./commands/clean.ts");
     clean();
   } else {
     printUsage();

--- a/packages/cli/src/commands/clean.ts
+++ b/packages/cli/src/commands/clean.ts
@@ -1,4 +1,4 @@
-import { pruneLogs } from "../log-prune.js";
+import { pruneLogs } from "../log-prune.ts";
 
 export default function clean(): never {
   const result = pruneLogs({ force: true });

--- a/packages/cli/src/commands/retry-abort.ts
+++ b/packages/cli/src/commands/retry-abort.ts
@@ -1,9 +1,9 @@
 import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { getWorkingDirectory } from "../output/working-directory.js";
-import { syncWorkspaceForRetry } from "../runner/sync.js";
-import { readDetachedMarker, tailRetryUntilOutcome } from "../launcher.js";
+import { getWorkingDirectory } from "../output/working-directory.ts";
+import { syncWorkspaceForRetry } from "../runner/sync.ts";
+import { readDetachedMarker, tailRetryUntilOutcome } from "../launcher.ts";
 
 function findSignalsDir(runnerName: string): string | null {
   const workDir = getWorkingDirectory();

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -3,23 +3,23 @@ import path from "node:path";
 import fs from "node:fs";
 import type Docker from "dockerode";
 
-import { config, loadMachineSecrets, resolveRepoSlug } from "../config.js";
-import { getNextLogNum } from "../output/logger.js";
+import { config, loadMachineSecrets, resolveRepoSlug } from "../config.ts";
+import { getNextLogNum } from "../output/logger.ts";
 import {
   setWorkingDirectory,
   DEFAULT_WORKING_DIR,
   PROJECT_ROOT,
   getWorkingDirectory,
-} from "../output/working-directory.js";
-import { debugCli } from "../output/debug.js";
-import { executeLocalJob, getDocker } from "../runner/local-job.js";
-import { executeMacosVmJob } from "../runner/macos-vm/macos-vm-job.js";
-import { checkMacosVmHost } from "../runner/macos-vm/host-capability.js";
+} from "../output/working-directory.ts";
+import { debugCli } from "../output/debug.ts";
+import { executeLocalJob, getDocker } from "../runner/local-job.ts";
+import { executeMacosVmJob } from "../runner/macos-vm/macos-vm-job.ts";
+import { checkMacosVmHost } from "../runner/macos-vm/host-capability.ts";
 import {
   discoverRunnerImage,
   ensureRunnerImage,
   UPSTREAM_RUNNER_IMAGE,
-} from "../runner/runner-image.js";
+} from "../runner/runner-image.ts";
 import {
   parseWorkflowSteps,
   parseWorkflowServices,
@@ -40,41 +40,41 @@ import {
   parseFailFast,
   parseJobRunsOn,
   expandExpressions,
-} from "../workflow/workflow-parser.js";
+} from "../workflow/workflow-parser.ts";
 import {
   classifyRunsOn,
   isUnsupportedOS,
   formatUnsupportedOSWarning,
   type RunnerOSKind,
-} from "../runner/runs-on-compat.js";
-import { resolveJobOutputs } from "../runner/result-builder.js";
-import { Job } from "../types.js";
-import { createConcurrencyLimiter, getDefaultMaxConcurrentJobs } from "../output/concurrency.js";
-import { isWarmNodeModules, computeLockfileHash } from "../output/cleanup.js";
+} from "../runner/runs-on-compat.ts";
+import { resolveJobOutputs } from "../runner/result-builder.ts";
+import type { Job } from "../types.ts";
+import { createConcurrencyLimiter, getDefaultMaxConcurrentJobs } from "../output/concurrency.ts";
+import { isWarmNodeModules, computeLockfileHash } from "../output/cleanup.ts";
 import {
   pruneOrphanedDockerResources,
   killOrphanedContainers,
   pruneStaleWorkspaces,
-} from "../docker/shutdown.js";
-import { topoSort } from "../workflow/job-scheduler.js";
-import { expandReusableJobs, type ExpandedJobEntry } from "../workflow/reusable-workflow.js";
-import { prefetchRemoteWorkflows } from "../workflow/remote-workflow-fetch.js";
-import { printSummary, type JobResult } from "../output/reporter.js";
-import { computeDirtySha } from "../runner/dirty-sha.js";
-import { RunStateStore } from "../output/run-state.js";
-import { renderRunState } from "../output/state-renderer.js";
-import { isAgentMode, isJsonMode, setJsonMode, setQuietMode } from "../output/agent-mode.js";
-import { createDiffRenderer } from "../output/diff-renderer.js";
-import { createFailedJobResult, wrapJobError, isJobError } from "../runner/job-result.js";
-import { postCommitStatus } from "../commit-status.js";
+} from "../docker/shutdown.ts";
+import { topoSort } from "../workflow/job-scheduler.ts";
+import { expandReusableJobs, type ExpandedJobEntry } from "../workflow/reusable-workflow.ts";
+import { prefetchRemoteWorkflows } from "../workflow/remote-workflow-fetch.ts";
+import { printSummary, type JobResult } from "../output/reporter.ts";
+import { computeDirtySha } from "../runner/dirty-sha.ts";
+import { RunStateStore } from "../output/run-state.ts";
+import { renderRunState } from "../output/state-renderer.ts";
+import { isAgentMode, isJsonMode, setJsonMode, setQuietMode } from "../output/agent-mode.ts";
+import { createDiffRenderer } from "../output/diff-renderer.ts";
+import { createFailedJobResult, wrapJobError, isJobError } from "../runner/job-result.ts";
+import { postCommitStatus } from "../commit-status.ts";
 import {
   classifyJobResources,
   collectJobResourceHints,
   getHostResources,
   type ResourceFidelity,
-} from "../workflow/resource-classifier.js";
-import { writeRunResult } from "../run-result-writer.js";
-import { pruneLogs } from "../log-prune.js";
+} from "../workflow/resource-classifier.ts";
+import { writeRunResult } from "../run-result-writer.ts";
+import { pruneLogs } from "../log-prune.ts";
 import {
   EVENT_SCHEMA_VERSION,
   formatEvent,
@@ -83,7 +83,7 @@ import {
   runDetachedLauncher,
   shouldLaunchDetached,
   type LogEvent,
-} from "../launcher.js";
+} from "../launcher.ts";
 
 type ParsedRunArgs = {
   sha?: string;

--- a/packages/cli/src/commit-status.ts
+++ b/packages/cli/src/commit-status.ts
@@ -1,6 +1,6 @@
 import { execSync } from "child_process";
-import { config } from "./config.js";
-import type { JobResult } from "./output/reporter.js";
+import { config } from "./config.ts";
+import type { JobResult } from "./output/reporter.ts";
 
 /**
  * Post a GitHub commit status via the `gh` CLI.

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -10,7 +10,7 @@ import {
   loadMachineSecrets,
   parseRepoSlug,
   resolveRepoSlug,
-} from "./config.js";
+} from "./config.ts";
 
 describe("parseRepoSlug", () => {
   it.each([

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,7 +1,7 @@
 import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";
-import { PROJECT_ROOT } from "./output/working-directory.js";
+import { PROJECT_ROOT } from "./output/working-directory.ts";
 
 /**
  * Get the URL of the first git remote, preferring 'origin'.

--- a/packages/cli/src/docker/container-config.test.ts
+++ b/packages/cli/src/docker/container-config.test.ts
@@ -9,7 +9,7 @@ afterEach(() => {
 
 describe("buildContainerEnv", () => {
   it("builds the standard env array", async () => {
-    const { buildContainerEnv } = await import("./container-config.js");
+    const { buildContainerEnv } = await import("./container-config.ts");
     const env = buildContainerEnv({
       containerName: "runner-1",
       registrationToken: "tok",
@@ -31,7 +31,7 @@ describe("buildContainerEnv", () => {
   });
 
   it("adds root-mode env vars for direct container injection", async () => {
-    const { buildContainerEnv } = await import("./container-config.js");
+    const { buildContainerEnv } = await import("./container-config.ts");
     const env = buildContainerEnv({
       containerName: "runner-1",
       registrationToken: "tok",
@@ -51,7 +51,7 @@ describe("buildContainerEnv", () => {
 
 describe("buildContainerBinds", () => {
   it("builds standard bind mounts with all PM caches", async () => {
-    const { buildContainerBinds } = await import("./container-config.js");
+    const { buildContainerBinds } = await import("./container-config.ts");
     const binds = buildContainerBinds({
       hostWorkDir: "/tmp/work",
       shimsDir: "/tmp/shims",
@@ -79,7 +79,7 @@ describe("buildContainerBinds", () => {
   });
 
   it("omits PM bind mounts when cache dirs are not provided", async () => {
-    const { buildContainerBinds } = await import("./container-config.js");
+    const { buildContainerBinds } = await import("./container-config.ts");
     const binds = buildContainerBinds({
       hostWorkDir: "/tmp/work",
       shimsDir: "/tmp/shims",
@@ -99,7 +99,7 @@ describe("buildContainerBinds", () => {
   });
 
   it("includes only the npm bind mount when only npmCacheDir is provided", async () => {
-    const { buildContainerBinds } = await import("./container-config.js");
+    const { buildContainerBinds } = await import("./container-config.ts");
     const binds = buildContainerBinds({
       hostWorkDir: "/tmp/work",
       shimsDir: "/tmp/shims",
@@ -119,7 +119,7 @@ describe("buildContainerBinds", () => {
   });
 
   it("uses the given dockerSocketPath as the bind-mount source", async () => {
-    const { buildContainerBinds } = await import("./container-config.js");
+    const { buildContainerBinds } = await import("./container-config.ts");
     const binds = buildContainerBinds({
       hostWorkDir: "/tmp/work",
       shimsDir: "/tmp/shims",
@@ -138,7 +138,7 @@ describe("buildContainerBinds", () => {
   });
 
   it("includes runner bind mount for direct container", async () => {
-    const { buildContainerBinds } = await import("./container-config.js");
+    const { buildContainerBinds } = await import("./container-config.ts");
     const binds = buildContainerBinds({
       hostWorkDir: "/tmp/work",
       shimsDir: "/tmp/shims",
@@ -162,7 +162,7 @@ describe("buildContainerBinds", () => {
 
 describe("buildContainerCmd", () => {
   it("starts with bash -c for standard containers", async () => {
-    const { buildContainerCmd } = await import("./container-config.js");
+    const { buildContainerCmd } = await import("./container-config.ts");
     const cmd = buildContainerCmd({
       svcPortForwardSnippet: "",
       dtuPort: "3000",
@@ -178,7 +178,7 @@ describe("buildContainerCmd", () => {
   });
 
   it("starts with -c for direct containers", async () => {
-    const { buildContainerCmd } = await import("./container-config.js");
+    const { buildContainerCmd } = await import("./container-config.ts");
     const cmd = buildContainerCmd({
       svcPortForwardSnippet: "",
       dtuPort: "3000",
@@ -192,7 +192,7 @@ describe("buildContainerCmd", () => {
   });
 
   it("includes service port forwarding snippet", async () => {
-    const { buildContainerCmd } = await import("./container-config.js");
+    const { buildContainerCmd } = await import("./container-config.ts");
     const cmd = buildContainerCmd({
       svcPortForwardSnippet: "socat TCP-LISTEN:5432,fork TCP:svc-db:5432 & \nsleep 0.3 && ",
       dtuPort: "3000",
@@ -210,7 +210,7 @@ describe("buildContainerCmd", () => {
   // talks to the Docker socket (buildx, compose, docker login, ...) fails
   // with "permission denied".
   it("chmods the docker socket via MAYBE_SUDO so it works on native Linux Docker (#257)", async () => {
-    const { buildContainerCmd } = await import("./container-config.js");
+    const { buildContainerCmd } = await import("./container-config.ts");
     const cmd = buildContainerCmd({
       svcPortForwardSnippet: "",
       dtuPort: "3000",
@@ -228,7 +228,7 @@ describe("buildContainerCmd", () => {
   // through the VM mount layer), so the runner user (uid 1001) hits
   // UnauthorizedAccessException when writing its diag logs and workspace.
   it("chmods /home/runner/_diag and /home/runner/_work via MAYBE_SUDO (#263)", async () => {
-    const { buildContainerCmd } = await import("./container-config.js");
+    const { buildContainerCmd } = await import("./container-config.ts");
     const cmd = buildContainerCmd({
       svcPortForwardSnippet: "",
       dtuPort: "3000",
@@ -245,35 +245,35 @@ describe("buildContainerCmd", () => {
 
 describe("resolveDockerApiUrl", () => {
   it("replaces localhost with the DTU host", async () => {
-    const { resolveDockerApiUrl } = await import("./container-config.js");
+    const { resolveDockerApiUrl } = await import("./container-config.ts");
     expect(resolveDockerApiUrl("http://localhost:3000", "172.17.0.2")).toBe(
       "http://172.17.0.2:3000",
     );
   });
 
   it("replaces 127.0.0.1 with the DTU host", async () => {
-    const { resolveDockerApiUrl } = await import("./container-config.js");
+    const { resolveDockerApiUrl } = await import("./container-config.ts");
     expect(resolveDockerApiUrl("http://127.0.0.1:3000", "host.docker.internal")).toBe(
       "http://host.docker.internal:3000",
     );
   });
 
   it("preserves path and query components", async () => {
-    const { resolveDockerApiUrl } = await import("./container-config.js");
+    const { resolveDockerApiUrl } = await import("./container-config.ts");
     expect(resolveDockerApiUrl("http://localhost:8910/api/v1?foo=bar", "10.0.0.8")).toBe(
       "http://10.0.0.8:8910/api/v1?foo=bar",
     );
   });
 
   it("keeps implicit https default port behavior", async () => {
-    const { resolveDockerApiUrl } = await import("./container-config.js");
+    const { resolveDockerApiUrl } = await import("./container-config.ts");
     expect(resolveDockerApiUrl("https://localhost", "host.docker.internal")).toBe(
       "https://host.docker.internal",
     );
   });
 
   it("does not rewrite non-loopback hosts", async () => {
-    const { resolveDockerApiUrl } = await import("./container-config.js");
+    const { resolveDockerApiUrl } = await import("./container-config.ts");
     expect(
       resolveDockerApiUrl("https://dtu.internal.example.com:8910", "host.docker.internal"),
     ).toBe("https://dtu.internal.example.com:8910");
@@ -303,7 +303,7 @@ describe("resolveDtuHost", () => {
 
   it("uses host alias when available outside Docker", async () => {
     delete process.env.AGENT_CI_DTU_HOST;
-    const { resolveDtuHost } = await import("./container-config.js");
+    const { resolveDtuHost } = await import("./container-config.ts");
     const originalExistsSync = fs.existsSync;
 
     vi.spyOn(fs, "existsSync").mockImplementation((filePath: fs.PathLike) => {
@@ -318,7 +318,7 @@ describe("resolveDtuHost", () => {
 
   it("uses configured bridge gateway outside Docker when provided", async () => {
     delete process.env.AGENT_CI_DTU_HOST;
-    const { resolveDtuHost } = await import("./container-config.js");
+    const { resolveDtuHost } = await import("./container-config.ts");
     const originalExistsSync = fs.existsSync;
 
     vi.spyOn(fs, "existsSync").mockImplementation((filePath: fs.PathLike) => {
@@ -334,7 +334,7 @@ describe("resolveDtuHost", () => {
 
   it("uses host alias outside Docker when no gateway override is configured", async () => {
     delete process.env.AGENT_CI_DTU_HOST;
-    const { resolveDtuHost } = await import("./container-config.js");
+    const { resolveDtuHost } = await import("./container-config.ts");
     const originalExistsSync = fs.existsSync;
 
     vi.spyOn(fs, "existsSync").mockImplementation((filePath: fs.PathLike) => {
@@ -378,7 +378,7 @@ describe("resolveDockerExtraHosts", () => {
     delete process.env.AGENT_CI_DOCKER_DISABLE_DEFAULT_EXTRA_HOSTS;
     delete process.env.AGENT_CI_DOCKER_HOST_GATEWAY;
 
-    const { resolveDockerExtraHosts } = await import("./container-config.js");
+    const { resolveDockerExtraHosts } = await import("./container-config.ts");
     expect(resolveDockerExtraHosts("host.docker.internal")).toEqual([
       "host.docker.internal:host-gateway",
     ]);
@@ -388,7 +388,7 @@ describe("resolveDockerExtraHosts", () => {
     process.env.AGENT_CI_DOCKER_EXTRA_HOSTS = "host.docker.internal:172.17.0.1,api.local:10.0.0.2";
     delete process.env.AGENT_CI_DOCKER_DISABLE_DEFAULT_EXTRA_HOSTS;
 
-    const { resolveDockerExtraHosts } = await import("./container-config.js");
+    const { resolveDockerExtraHosts } = await import("./container-config.ts");
     expect(resolveDockerExtraHosts("host.docker.internal")).toEqual([
       "host.docker.internal:172.17.0.1",
       "api.local:10.0.0.2",
@@ -399,7 +399,7 @@ describe("resolveDockerExtraHosts", () => {
     delete process.env.AGENT_CI_DOCKER_EXTRA_HOSTS;
     process.env.AGENT_CI_DOCKER_DISABLE_DEFAULT_EXTRA_HOSTS = "1";
 
-    const { resolveDockerExtraHosts } = await import("./container-config.js");
+    const { resolveDockerExtraHosts } = await import("./container-config.ts");
     expect(resolveDockerExtraHosts("host.docker.internal")).toBeUndefined();
   });
 
@@ -407,7 +407,7 @@ describe("resolveDockerExtraHosts", () => {
     delete process.env.AGENT_CI_DOCKER_EXTRA_HOSTS;
     delete process.env.AGENT_CI_DOCKER_DISABLE_DEFAULT_EXTRA_HOSTS;
 
-    const { resolveDockerExtraHosts } = await import("./container-config.js");
+    const { resolveDockerExtraHosts } = await import("./container-config.ts");
     expect(resolveDockerExtraHosts("10.10.10.10")).toBeUndefined();
   });
 });
@@ -428,13 +428,13 @@ describe("buildContainerBinds with dockerSocketPath", () => {
   };
 
   it("uses default /var/run/docker.sock when no dockerSocketPath is provided", async () => {
-    const { buildContainerBinds } = await import("./container-config.js");
+    const { buildContainerBinds } = await import("./container-config.ts");
     const binds = buildContainerBinds(baseOpts);
     expect(binds).toContain("/var/run/docker.sock:/var/run/docker.sock");
   });
 
   it("uses custom host socket path from dockerSocketPath", async () => {
-    const { buildContainerBinds } = await import("./container-config.js");
+    const { buildContainerBinds } = await import("./container-config.ts");
     const binds = buildContainerBinds({
       ...baseOpts,
       dockerSocketPath: "/Users/foo/.docker/run/docker.sock",
@@ -463,13 +463,13 @@ describe("buildContainerBinds with signalsDir", () => {
   };
 
   it("includes signals bind-mount when signalsDir is provided", async () => {
-    const { buildContainerBinds } = await import("./container-config.js");
+    const { buildContainerBinds } = await import("./container-config.ts");
     const binds = buildContainerBinds({ ...baseOpts, signalsDir: "/tmp/signals" });
     expect(binds).toContain("/tmp/signals:/tmp/agent-ci-signals");
   });
 
   it("omits signals bind-mount when signalsDir is undefined", async () => {
-    const { buildContainerBinds } = await import("./container-config.js");
+    const { buildContainerBinds } = await import("./container-config.ts");
     const binds = buildContainerBinds(baseOpts);
     expect(binds.some((b) => b.includes("agent-ci-signals"))).toBe(false);
   });

--- a/packages/cli/src/docker/container-config.ts
+++ b/packages/cli/src/docker/container-config.ts
@@ -232,7 +232,7 @@ export function buildContainerCmd(opts: ContainerCmdOpts): string[] {
 
 import fs from "fs";
 import { execSync } from "child_process";
-import { debugRunner } from "../output/debug.js";
+import { debugRunner } from "../output/debug.ts";
 
 const DEFAULT_DTU_HOST_ALIAS = "host.docker.internal";
 const DEFAULT_DOCKER_BRIDGE_GATEWAY = "172.17.0.1";

--- a/packages/cli/src/docker/docker-socket.test.ts
+++ b/packages/cli/src/docker/docker-socket.test.ts
@@ -15,7 +15,7 @@ afterEach(() => {
 
 async function importFresh() {
   vi.resetModules();
-  return import("./docker-socket.js");
+  return import("./docker-socket.ts");
 }
 
 describe("resolveDockerSocket", () => {

--- a/packages/cli/src/docker/docker-socket.ts
+++ b/packages/cli/src/docker/docker-socket.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { execSync } from "child_process";
-import { debugRunner } from "../output/debug.js";
+import { debugRunner } from "../output/debug.ts";
 
 const DEFAULT_SOCKET = "/var/run/docker.sock";
 const DOCS_URL =

--- a/packages/cli/src/docker/image-pull.test.ts
+++ b/packages/cli/src/docker/image-pull.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import Docker from "dockerode";
-import { ensureImagePulled } from "./image-pull.js";
-import { resolveDockerSocket } from "./docker-socket.js";
+import { ensureImagePulled } from "./image-pull.ts";
+import { resolveDockerSocket } from "./docker-socket.ts";
 
 // Integration test: requires a running Docker daemon and network access.
 // Uses hello-world (~13 KB) to keep pull time minimal.

--- a/packages/cli/src/docker/repro-126.test.ts
+++ b/packages/cli/src/docker/repro-126.test.ts
@@ -65,7 +65,7 @@ describe("issue-126 reproduction: resolveDtuHost inside Docker", () => {
     // Simulate agent-ci Docker env: AGENT_CI_DTU_HOST was set but we deleted it
     delete process.env.AGENT_CI_DTU_HOST;
 
-    const { resolveDtuHost } = await import("./container-config.js");
+    const { resolveDtuHost } = await import("./container-config.ts");
 
     const originalExistsSync = fs.existsSync;
     vi.spyOn(fs, "existsSync").mockImplementation((filePath: fs.PathLike) => {

--- a/packages/cli/src/docker/repro-197.test.ts
+++ b/packages/cli/src/docker/repro-197.test.ts
@@ -29,7 +29,7 @@ afterEach(() => {
 
 async function importFreshSocket() {
   vi.resetModules();
-  return import("./docker-socket.js");
+  return import("./docker-socket.ts");
 }
 
 describe("issue-197 reproduction: Docker Desktop bind mount path", () => {
@@ -68,7 +68,7 @@ describe("issue-197 reproduction: Docker Desktop bind mount path", () => {
     vi.spyOn(fs, "accessSync").mockReturnValue(undefined);
 
     const { resolveDockerSocket } = await importFreshSocket();
-    const { buildContainerBinds } = await import("./container-config.js");
+    const { buildContainerBinds } = await import("./container-config.ts");
 
     const socket = resolveDockerSocket();
 

--- a/packages/cli/src/docker/service-containers.test.ts
+++ b/packages/cli/src/docker/service-containers.test.ts
@@ -3,8 +3,8 @@ import {
   startServiceContainers,
   cleanupServiceContainers,
   parseHealthCheck,
-} from "./service-containers.js";
-import type { WorkflowService } from "../workflow/workflow-parser.js";
+} from "./service-containers.ts";
+import type { WorkflowService } from "../workflow/workflow-parser.ts";
 
 // ─── Mock Docker client ───────────────────────────────────────────────────────
 

--- a/packages/cli/src/docker/service-containers.ts
+++ b/packages/cli/src/docker/service-containers.ts
@@ -1,5 +1,5 @@
 import Docker from "dockerode";
-import type { WorkflowService } from "../workflow/workflow-parser.js";
+import type { WorkflowService } from "../workflow/workflow-parser.ts";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/packages/cli/src/docker/shutdown.test.ts
+++ b/packages/cli/src/docker/shutdown.test.ts
@@ -369,7 +369,7 @@ describe.skipIf(!dockerAvailable() || insideDocker())(
     // so exercising the real module resolution path is a feature, not a hack.
     function runKillOrphanedContainers() {
       execSync(
-        `npx tsx -e "import { killOrphanedContainers } from './src/docker/shutdown.ts'; killOrphanedContainers();"`,
+        `node --input-type=module -e "import { killOrphanedContainers } from './src/docker/shutdown.ts'; killOrphanedContainers();"`,
         { stdio: "pipe" },
       );
     }

--- a/packages/cli/src/docker/shutdown.test.ts
+++ b/packages/cli/src/docker/shutdown.test.ts
@@ -82,7 +82,7 @@ describe("Stale workspace pruning", () => {
     const oldTime = new Date(Date.now() - 48 * 60 * 60 * 1000);
     fs.utimesSync(staleDir, oldTime, oldTime);
 
-    const { pruneStaleWorkspaces } = await import("./shutdown.js");
+    const { pruneStaleWorkspaces } = await import("./shutdown.ts");
     const pruned = pruneStaleWorkspaces(tmpDir, 24 * 60 * 60 * 1000);
 
     expect(pruned).toContain("agent-ci-100");
@@ -95,7 +95,7 @@ describe("Stale workspace pruning", () => {
     fs.mkdirSync(path.join(freshDir, "logs"), { recursive: true });
     fs.writeFileSync(path.join(freshDir, "logs", "output.log"), "fresh");
 
-    const { pruneStaleWorkspaces } = await import("./shutdown.js");
+    const { pruneStaleWorkspaces } = await import("./shutdown.ts");
     const pruned = pruneStaleWorkspaces(tmpDir, 24 * 60 * 60 * 1000);
 
     expect(pruned).toEqual([]);
@@ -110,7 +110,7 @@ describe("Stale workspace pruning", () => {
     const oldTime = new Date(Date.now() - 48 * 60 * 60 * 1000);
     fs.utimesSync(otherDir, oldTime, oldTime);
 
-    const { pruneStaleWorkspaces } = await import("./shutdown.js");
+    const { pruneStaleWorkspaces } = await import("./shutdown.ts");
     const pruned = pruneStaleWorkspaces(tmpDir, 24 * 60 * 60 * 1000);
 
     expect(pruned).toEqual([]);
@@ -162,7 +162,7 @@ describe("killOrphanedContainers", () => {
       return true;
     }) as typeof process.kill);
 
-    const { killOrphanedContainers } = await import("./shutdown.js");
+    const { killOrphanedContainers } = await import("./shutdown.ts");
     killOrphanedContainers();
 
     const rmCalls = execSyncMock.mock.calls.filter(([cmd]: string[]) =>
@@ -186,7 +186,7 @@ describe("killOrphanedContainers", () => {
       throw new Error("ESRCH");
     }) as typeof process.kill);
 
-    const { killOrphanedContainers } = await import("./shutdown.js");
+    const { killOrphanedContainers } = await import("./shutdown.ts");
     killOrphanedContainers();
 
     const rmCalls = execSyncMock.mock.calls.filter(([cmd]: string[]) =>
@@ -204,7 +204,7 @@ describe("killOrphanedContainers", () => {
       return "";
     });
 
-    const { killOrphanedContainers } = await import("./shutdown.js");
+    const { killOrphanedContainers } = await import("./shutdown.ts");
     killOrphanedContainers();
 
     const rmCalls = execSyncMock.mock.calls.filter(([cmd]: string[]) =>
@@ -222,7 +222,7 @@ describe("killOrphanedContainers", () => {
       return "";
     });
 
-    const { killOrphanedContainers } = await import("./shutdown.js");
+    const { killOrphanedContainers } = await import("./shutdown.ts");
     killOrphanedContainers();
 
     // Should call killRunnerContainers with the runner name (without -svc-cache-db)
@@ -250,7 +250,7 @@ describe("killOrphanedContainers", () => {
       return true;
     }) as typeof process.kill);
 
-    const { killOrphanedContainers } = await import("./shutdown.js");
+    const { killOrphanedContainers } = await import("./shutdown.ts");
     killOrphanedContainers();
 
     // killRunnerContainers should only be called once for the runner name
@@ -267,7 +267,7 @@ describe("killOrphanedContainers", () => {
       throw new Error("Cannot connect to Docker daemon");
     });
 
-    const { killOrphanedContainers } = await import("./shutdown.js");
+    const { killOrphanedContainers } = await import("./shutdown.ts");
     expect(() => killOrphanedContainers()).not.toThrow();
   });
 });

--- a/packages/cli/src/launcher.test.ts
+++ b/packages/cli/src/launcher.test.ts
@@ -14,7 +14,7 @@ import {
   readDetachedMarker,
   shouldLaunchDetached,
   writeDetachedMarker,
-} from "./launcher.js";
+} from "./launcher.ts";
 
 describe("formatEvent / parseLogEvent — run.paused", () => {
   it("round-trips a paused event", () => {

--- a/packages/cli/src/launcher.ts
+++ b/packages/cli/src/launcher.ts
@@ -20,7 +20,7 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { resolveStateDir } from "./run-result-writer.js";
+import { resolveStateDir } from "./run-result-writer.ts";
 
 export const PAUSED_EXIT_CODE = 77;
 /** Set by the launcher on the worker child. Presence = detached; value = worker log path. */

--- a/packages/cli/src/log-prune.ts
+++ b/packages/cli/src/log-prune.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { resolveLogsDir, resolveStateDir } from "./run-result-writer.js";
+import { resolveLogsDir, resolveStateDir } from "./run-result-writer.ts";
 
 /** Default: keep runs whose mtime is younger than this many days. */
 const DEFAULT_RETAIN_DAYS = 7;

--- a/packages/cli/src/output/agent-mode.test.ts
+++ b/packages/cli/src/output/agent-mode.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { isAgentMode, setQuietMode } from "./agent-mode.js";
+import { isAgentMode, setQuietMode } from "./agent-mode.ts";
 
 describe("isAgentMode", () => {
   const originalEnv = process.env.AI_AGENT;

--- a/packages/cli/src/output/cleanup.test.ts
+++ b/packages/cli/src/output/cleanup.test.ts
@@ -49,7 +49,7 @@ describe("copyWorkspace", () => {
   });
 
   it("copies tracked files", async () => {
-    const { copyWorkspace } = await import("./cleanup.js");
+    const { copyWorkspace } = await import("./cleanup.ts");
     copyWorkspace(repoDir, destDir);
 
     expect(fs.existsSync(path.join(destDir, "README.md"))).toBe(true);
@@ -59,7 +59,7 @@ describe("copyWorkspace", () => {
   });
 
   it("copies untracked-but-not-ignored files", async () => {
-    const { copyWorkspace } = await import("./cleanup.js");
+    const { copyWorkspace } = await import("./cleanup.ts");
     copyWorkspace(repoDir, destDir);
 
     expect(fs.existsSync(path.join(destDir, "newfile.txt"))).toBe(true);
@@ -69,7 +69,7 @@ describe("copyWorkspace", () => {
   });
 
   it("excludes gitignored files", async () => {
-    const { copyWorkspace } = await import("./cleanup.js");
+    const { copyWorkspace } = await import("./cleanup.ts");
     copyWorkspace(repoDir, destDir);
 
     expect(fs.existsSync(path.join(destDir, "node_modules"))).toBe(false);
@@ -78,7 +78,7 @@ describe("copyWorkspace", () => {
   });
 
   it("preserves nested directory structure", async () => {
-    const { copyWorkspace } = await import("./cleanup.js");
+    const { copyWorkspace } = await import("./cleanup.ts");
     copyWorkspace(repoDir, destDir);
 
     expect(fs.readFileSync(path.join(destDir, "src", "index.ts"), "utf-8")).toBe(
@@ -96,7 +96,7 @@ describe("copyWorkspace", () => {
     execSync("git add .", { cwd: repoDir, stdio: "pipe" });
     execSync('git commit -m "add symlink"', { cwd: repoDir, stdio: "pipe" });
 
-    const { copyWorkspace } = await import("./cleanup.js");
+    const { copyWorkspace } = await import("./cleanup.ts");
     copyWorkspace(repoDir, destDir);
 
     const copiedLink = path.join(destDir, "packages", "pkg-a", "types");
@@ -123,7 +123,7 @@ describe("computeLockfileHash", () => {
   });
 
   it("returns a hex string for a repo with a tracked lockfile", async () => {
-    const { computeLockfileHash } = await import("./cleanup.js");
+    const { computeLockfileHash } = await import("./cleanup.ts");
     fs.writeFileSync(path.join(repoDir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
     execSync("git add .", { cwd: repoDir, stdio: "pipe" });
     execSync('git commit -m "init"', { cwd: repoDir, stdio: "pipe" });
@@ -133,7 +133,7 @@ describe("computeLockfileHash", () => {
   });
 
   it("returns the same hash for the same lockfile content", async () => {
-    const { computeLockfileHash } = await import("./cleanup.js");
+    const { computeLockfileHash } = await import("./cleanup.ts");
     fs.writeFileSync(path.join(repoDir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
     execSync("git add .", { cwd: repoDir, stdio: "pipe" });
     execSync('git commit -m "init"', { cwd: repoDir, stdio: "pipe" });
@@ -142,7 +142,7 @@ describe("computeLockfileHash", () => {
   });
 
   it("returns a different hash when lockfile content changes", async () => {
-    const { computeLockfileHash } = await import("./cleanup.js");
+    const { computeLockfileHash } = await import("./cleanup.ts");
     fs.writeFileSync(path.join(repoDir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
     execSync("git add .", { cwd: repoDir, stdio: "pipe" });
     execSync('git commit -m "init"', { cwd: repoDir, stdio: "pipe" });
@@ -157,7 +157,7 @@ describe("computeLockfileHash", () => {
   });
 
   it("returns 'no-lockfile' when no lockfile exists", async () => {
-    const { computeLockfileHash } = await import("./cleanup.js");
+    const { computeLockfileHash } = await import("./cleanup.ts");
     // Empty repo, no lockfile
     fs.writeFileSync(path.join(repoDir, "README.md"), "hi");
     execSync("git add .", { cwd: repoDir, stdio: "pipe" });
@@ -167,7 +167,7 @@ describe("computeLockfileHash", () => {
   });
 
   it("detects package-lock.json (npm)", async () => {
-    const { computeLockfileHash } = await import("./cleanup.js");
+    const { computeLockfileHash } = await import("./cleanup.ts");
     fs.writeFileSync(path.join(repoDir, "package-lock.json"), '{"lockfileVersion": 3}');
     execSync("git add .", { cwd: repoDir, stdio: "pipe" });
     execSync('git commit -m "init"', { cwd: repoDir, stdio: "pipe" });
@@ -177,7 +177,7 @@ describe("computeLockfileHash", () => {
   });
 
   it("detects yarn.lock", async () => {
-    const { computeLockfileHash } = await import("./cleanup.js");
+    const { computeLockfileHash } = await import("./cleanup.ts");
     fs.writeFileSync(path.join(repoDir, "yarn.lock"), "# yarn lockfile v1");
     execSync("git add .", { cwd: repoDir, stdio: "pipe" });
     execSync('git commit -m "init"', { cwd: repoDir, stdio: "pipe" });
@@ -187,7 +187,7 @@ describe("computeLockfileHash", () => {
   });
 
   it("detects bun.lock", async () => {
-    const { computeLockfileHash } = await import("./cleanup.js");
+    const { computeLockfileHash } = await import("./cleanup.ts");
     fs.writeFileSync(path.join(repoDir, "bun.lock"), '{"lockfileVersion": 0}');
     execSync("git add .", { cwd: repoDir, stdio: "pipe" });
     execSync('git commit -m "init"', { cwd: repoDir, stdio: "pipe" });
@@ -211,42 +211,42 @@ describe("detectPackageManager", () => {
   });
 
   it("detects pnpm from pnpm-lock.yaml", async () => {
-    const { detectPackageManager } = await import("./cleanup.js");
+    const { detectPackageManager } = await import("./cleanup.ts");
     fs.writeFileSync(path.join(repoDir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
     expect(detectPackageManager(repoDir)).toBe("pnpm");
   });
 
   it("detects npm from package-lock.json", async () => {
-    const { detectPackageManager } = await import("./cleanup.js");
+    const { detectPackageManager } = await import("./cleanup.ts");
     fs.writeFileSync(path.join(repoDir, "package-lock.json"), '{"lockfileVersion": 3}');
     expect(detectPackageManager(repoDir)).toBe("npm");
   });
 
   it("detects yarn from yarn.lock", async () => {
-    const { detectPackageManager } = await import("./cleanup.js");
+    const { detectPackageManager } = await import("./cleanup.ts");
     fs.writeFileSync(path.join(repoDir, "yarn.lock"), "# yarn lockfile v1");
     expect(detectPackageManager(repoDir)).toBe("yarn");
   });
 
   it("detects bun from bun.lock", async () => {
-    const { detectPackageManager } = await import("./cleanup.js");
+    const { detectPackageManager } = await import("./cleanup.ts");
     fs.writeFileSync(path.join(repoDir, "bun.lock"), '{"lockfileVersion": 0}');
     expect(detectPackageManager(repoDir)).toBe("bun");
   });
 
   it("detects bun from bun.lockb", async () => {
-    const { detectPackageManager } = await import("./cleanup.js");
+    const { detectPackageManager } = await import("./cleanup.ts");
     fs.writeFileSync(path.join(repoDir, "bun.lockb"), Buffer.from([0x00]));
     expect(detectPackageManager(repoDir)).toBe("bun");
   });
 
   it("returns null when no lockfile exists", async () => {
-    const { detectPackageManager } = await import("./cleanup.js");
+    const { detectPackageManager } = await import("./cleanup.ts");
     expect(detectPackageManager(repoDir)).toBeNull();
   });
 
   it("prefers pnpm over npm when both lockfiles exist", async () => {
-    const { detectPackageManager } = await import("./cleanup.js");
+    const { detectPackageManager } = await import("./cleanup.ts");
     fs.writeFileSync(path.join(repoDir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
     fs.writeFileSync(path.join(repoDir, "package-lock.json"), '{"lockfileVersion": 3}');
     expect(detectPackageManager(repoDir)).toBe("pnpm");
@@ -267,19 +267,19 @@ describe("isWarmNodeModules", () => {
   });
 
   it("returns false for a non-existent directory", async () => {
-    const { isWarmNodeModules } = await import("./cleanup.js");
+    const { isWarmNodeModules } = await import("./cleanup.ts");
     expect(isWarmNodeModules(path.join(tmpDir, "does-not-exist"))).toBe(false);
   });
 
   it("returns false for an empty directory", async () => {
-    const { isWarmNodeModules } = await import("./cleanup.js");
+    const { isWarmNodeModules } = await import("./cleanup.ts");
     const emptyDir = path.join(tmpDir, "empty");
     fs.mkdirSync(emptyDir);
     expect(isWarmNodeModules(emptyDir)).toBe(false);
   });
 
   it("returns false when directory has files but no .modules.yaml (corrupted)", async () => {
-    const { isWarmNodeModules } = await import("./cleanup.js");
+    const { isWarmNodeModules } = await import("./cleanup.ts");
     const warmDir = path.join(tmpDir, "warm");
     fs.mkdirSync(warmDir);
     fs.writeFileSync(path.join(warmDir, "some-package"), "content");
@@ -287,7 +287,7 @@ describe("isWarmNodeModules", () => {
   });
 
   it("returns true when directory has .modules.yaml (pnpm)", async () => {
-    const { isWarmNodeModules } = await import("./cleanup.js");
+    const { isWarmNodeModules } = await import("./cleanup.ts");
     const warmDir = path.join(tmpDir, "warm");
     fs.mkdirSync(warmDir);
     fs.writeFileSync(path.join(warmDir, ".modules.yaml"), "hoistedDependencies: {}");
@@ -296,7 +296,7 @@ describe("isWarmNodeModules", () => {
   });
 
   it("returns true when directory has .package-lock.json (npm)", async () => {
-    const { isWarmNodeModules } = await import("./cleanup.js");
+    const { isWarmNodeModules } = await import("./cleanup.ts");
     const warmDir = path.join(tmpDir, "warm-npm");
     fs.mkdirSync(warmDir);
     fs.writeFileSync(path.join(warmDir, ".package-lock.json"), "{}");
@@ -305,7 +305,7 @@ describe("isWarmNodeModules", () => {
   });
 
   it("returns true when directory has .yarn-integrity (yarn)", async () => {
-    const { isWarmNodeModules } = await import("./cleanup.js");
+    const { isWarmNodeModules } = await import("./cleanup.ts");
     const warmDir = path.join(tmpDir, "warm-yarn");
     fs.mkdirSync(warmDir);
     fs.writeFileSync(path.join(warmDir, ".yarn-integrity"), "{}");
@@ -314,7 +314,7 @@ describe("isWarmNodeModules", () => {
   });
 
   it("returns true when directory has .cache (bun)", async () => {
-    const { isWarmNodeModules } = await import("./cleanup.js");
+    const { isWarmNodeModules } = await import("./cleanup.ts");
     const warmDir = path.join(tmpDir, "warm-bun");
     fs.mkdirSync(warmDir);
     fs.mkdirSync(path.join(warmDir, ".cache"));
@@ -337,19 +337,19 @@ describe("repairWarmCache", () => {
   });
 
   it("returns 'cold' for a non-existent directory", async () => {
-    const { repairWarmCache } = await import("./cleanup.js");
+    const { repairWarmCache } = await import("./cleanup.ts");
     expect(repairWarmCache(path.join(tmpDir, "nope"))).toBe("cold");
   });
 
   it("returns 'cold' for an empty directory", async () => {
-    const { repairWarmCache } = await import("./cleanup.js");
+    const { repairWarmCache } = await import("./cleanup.ts");
     const emptyDir = path.join(tmpDir, "empty");
     fs.mkdirSync(emptyDir);
     expect(repairWarmCache(emptyDir)).toBe("cold");
   });
 
   it("returns 'warm' when .modules.yaml exists (pnpm)", async () => {
-    const { repairWarmCache } = await import("./cleanup.js");
+    const { repairWarmCache } = await import("./cleanup.ts");
     const warmDir = path.join(tmpDir, "warm");
     fs.mkdirSync(warmDir);
     fs.writeFileSync(path.join(warmDir, ".modules.yaml"), "ok");
@@ -357,7 +357,7 @@ describe("repairWarmCache", () => {
   });
 
   it("returns 'warm' when .package-lock.json exists (npm)", async () => {
-    const { repairWarmCache } = await import("./cleanup.js");
+    const { repairWarmCache } = await import("./cleanup.ts");
     const warmDir = path.join(tmpDir, "warm-npm");
     fs.mkdirSync(warmDir);
     fs.writeFileSync(path.join(warmDir, ".package-lock.json"), "{}");
@@ -365,7 +365,7 @@ describe("repairWarmCache", () => {
   });
 
   it("returns 'repaired' and nukes a corrupted cache (files but no sentinel)", async () => {
-    const { repairWarmCache } = await import("./cleanup.js");
+    const { repairWarmCache } = await import("./cleanup.ts");
     const brokenDir = path.join(tmpDir, "broken");
     fs.mkdirSync(path.join(brokenDir, ".pnpm", "yaml@2.8.2"), { recursive: true });
     fs.writeFileSync(path.join(brokenDir, ".pnpm", "yaml@2.8.2", "Pair.js"), "broken");

--- a/packages/cli/src/output/concurrency.test.ts
+++ b/packages/cli/src/output/concurrency.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createConcurrencyLimiter, getDefaultMaxConcurrentJobs } from "./concurrency.js";
+import { createConcurrencyLimiter, getDefaultMaxConcurrentJobs } from "./concurrency.ts";
 
 describe("createConcurrencyLimiter", () => {
   it("limits concurrent execution to max", async () => {

--- a/packages/cli/src/output/logger.test.ts
+++ b/packages/cli/src/output/logger.test.ts
@@ -20,8 +20,8 @@ describe("Logger utilities", () => {
 
   describe("ensureLogDirs", () => {
     it("creates the runs/ directory", async () => {
-      const { setWorkingDirectory } = await import("./working-directory.js");
-      const { ensureLogDirs } = await import("./logger.js");
+      const { setWorkingDirectory } = await import("./working-directory.ts");
+      const { ensureLogDirs } = await import("./logger.ts");
       setWorkingDirectory(tmpDir);
       ensureLogDirs();
       expect(fs.existsSync(path.join(tmpDir, "runs"))).toBe(true);
@@ -30,15 +30,15 @@ describe("Logger utilities", () => {
 
   describe("getNextLogNum", () => {
     it("returns 1 when runs/ dir is empty or absent", async () => {
-      const { setWorkingDirectory } = await import("./working-directory.js");
-      const { getNextLogNum } = await import("./logger.js");
+      const { setWorkingDirectory } = await import("./working-directory.ts");
+      const { getNextLogNum } = await import("./logger.ts");
       setWorkingDirectory(tmpDir);
       expect(getNextLogNum("agent-ci")).toBe(1);
     });
 
     it("returns next number after existing agent-ci-* entries", async () => {
-      const { setWorkingDirectory } = await import("./working-directory.js");
-      const { getNextLogNum } = await import("./logger.js");
+      const { setWorkingDirectory } = await import("./working-directory.ts");
+      const { getNextLogNum } = await import("./logger.ts");
       setWorkingDirectory(tmpDir);
       fs.mkdirSync(path.join(tmpDir, "runs", "agent-ci-1"), { recursive: true });
       fs.mkdirSync(path.join(tmpDir, "runs", "agent-ci-2"), { recursive: true });
@@ -46,8 +46,8 @@ describe("Logger utilities", () => {
     });
 
     it("counts only the base run number from multi-job names", async () => {
-      const { setWorkingDirectory } = await import("./working-directory.js");
-      const { getNextLogNum } = await import("./logger.js");
+      const { setWorkingDirectory } = await import("./working-directory.ts");
+      const { getNextLogNum } = await import("./logger.ts");
       setWorkingDirectory(tmpDir);
       // Multi-job run: agent-ci-15 with -j1-m2 suffix — base is 15
       fs.mkdirSync(path.join(tmpDir, "runs", "agent-ci-redwoodjssdk-14"), { recursive: true });
@@ -61,9 +61,9 @@ describe("Logger utilities", () => {
 
   describe("createLogContext", () => {
     it("creates runDir under workingDir and logDir under logsDir", async () => {
-      const { setWorkingDirectory } = await import("./working-directory.js");
-      const { setLogsDirectory } = await import("./logs-directory.js");
-      const { createLogContext } = await import("./logger.js");
+      const { setWorkingDirectory } = await import("./working-directory.ts");
+      const { setLogsDirectory } = await import("./logs-directory.ts");
+      const { createLogContext } = await import("./logger.ts");
       setWorkingDirectory(tmpDir);
       setLogsDirectory(logsDir);
 
@@ -78,9 +78,9 @@ describe("Logger utilities", () => {
     });
 
     it("uses preferredName when provided", async () => {
-      const { setWorkingDirectory } = await import("./working-directory.js");
-      const { setLogsDirectory } = await import("./logs-directory.js");
-      const { createLogContext } = await import("./logger.js");
+      const { setWorkingDirectory } = await import("./working-directory.ts");
+      const { setLogsDirectory } = await import("./logs-directory.ts");
+      const { createLogContext } = await import("./logger.ts");
       setWorkingDirectory(tmpDir);
       setLogsDirectory(logsDir);
 
@@ -91,9 +91,9 @@ describe("Logger utilities", () => {
     });
 
     it("auto-increments when no preferredName given", async () => {
-      const { setWorkingDirectory } = await import("./working-directory.js");
-      const { setLogsDirectory } = await import("./logs-directory.js");
-      const { createLogContext } = await import("./logger.js");
+      const { setWorkingDirectory } = await import("./working-directory.ts");
+      const { setLogsDirectory } = await import("./logs-directory.ts");
+      const { createLogContext } = await import("./logger.ts");
       setWorkingDirectory(tmpDir);
       setLogsDirectory(logsDir);
 
@@ -103,9 +103,9 @@ describe("Logger utilities", () => {
     });
 
     it("skips over a directory that already exists (race condition)", async () => {
-      const { setWorkingDirectory } = await import("./working-directory.js");
-      const { setLogsDirectory } = await import("./logs-directory.js");
-      const { createLogContext } = await import("./logger.js");
+      const { setWorkingDirectory } = await import("./working-directory.ts");
+      const { setLogsDirectory } = await import("./logs-directory.ts");
+      const { createLogContext } = await import("./logger.ts");
       setWorkingDirectory(tmpDir);
       setLogsDirectory(logsDir);
 
@@ -120,9 +120,9 @@ describe("Logger utilities", () => {
     });
 
     it("handles multiple consecutive collisions", async () => {
-      const { setWorkingDirectory } = await import("./working-directory.js");
-      const { setLogsDirectory } = await import("./logs-directory.js");
-      const { createLogContext } = await import("./logger.js");
+      const { setWorkingDirectory } = await import("./working-directory.ts");
+      const { setLogsDirectory } = await import("./logs-directory.ts");
+      const { createLogContext } = await import("./logger.ts");
       setWorkingDirectory(tmpDir);
       setLogsDirectory(logsDir);
 
@@ -138,9 +138,9 @@ describe("Logger utilities", () => {
     });
 
     it("concurrent calls each get a unique directory", async () => {
-      const { setWorkingDirectory } = await import("./working-directory.js");
-      const { setLogsDirectory } = await import("./logs-directory.js");
-      const { createLogContext } = await import("./logger.js");
+      const { setWorkingDirectory } = await import("./working-directory.ts");
+      const { setLogsDirectory } = await import("./logs-directory.ts");
+      const { createLogContext } = await import("./logger.ts");
       setWorkingDirectory(tmpDir);
       setLogsDirectory(logsDir);
 

--- a/packages/cli/src/output/logger.ts
+++ b/packages/cli/src/output/logger.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import fs from "fs";
-import { getWorkingDirectory } from "./working-directory.js";
-import { getLogsDirectory } from "./logs-directory.js";
+import { getWorkingDirectory } from "./working-directory.ts";
+import { getLogsDirectory } from "./logs-directory.ts";
 
 /** Root of all run directories: `<workingDir>/runs/` */
 function getRunsDir(): string {

--- a/packages/cli/src/output/logs-directory.ts
+++ b/packages/cli/src/output/logs-directory.ts
@@ -1,4 +1,4 @@
-import { resolveLogsDir } from "../run-result-writer.js";
+import { resolveLogsDir } from "../run-result-writer.ts";
 
 let override: string | null = null;
 

--- a/packages/cli/src/output/reporter.test.ts
+++ b/packages/cli/src/output/reporter.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { printSummary, type JobResult } from "./reporter.js";
+import { printSummary, type JobResult } from "./reporter.ts";
 
 function makeResult(overrides: Partial<JobResult> = {}): JobResult {
   return {

--- a/packages/cli/src/output/reporter.ts
+++ b/packages/cli/src/output/reporter.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import { isJsonMode } from "./agent-mode.js";
+import { isJsonMode } from "./agent-mode.ts";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/packages/cli/src/output/run-state.test.ts
+++ b/packages/cli/src/output/run-state.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { RunStateStore, type RunState } from "./run-state.js";
+import { RunStateStore, type RunState } from "./run-state.ts";
 
 let tmpDir: string;
 

--- a/packages/cli/src/output/run-state.ts
+++ b/packages/cli/src/output/run-state.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import fsp from "fs/promises";
 import path from "path";
-import type { ResourceFidelity } from "../workflow/resource-classifier.js";
+import type { ResourceFidelity } from "../workflow/resource-classifier.ts";
 
 // ─── Status types ─────────────────────────────────────────────────────────────
 

--- a/packages/cli/src/output/state-renderer.test.ts
+++ b/packages/cli/src/output/state-renderer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { renderRunState } from "./state-renderer.js";
-import type { RunState } from "./run-state.js";
+import { renderRunState } from "./state-renderer.ts";
+import type { RunState } from "./run-state.ts";
 
 // Freeze time so spinner frames and elapsed times are deterministic.
 // Date.now() → 0 → Math.floor(0/80) % 10 → frame index 0 → "⠋"

--- a/packages/cli/src/output/state-renderer.ts
+++ b/packages/cli/src/output/state-renderer.ts
@@ -4,8 +4,8 @@
 // logUpdate. No side effects, no I/O — fully testable in isolation.
 
 import path from "path";
-import { renderTree, type TreeNode } from "./tree-renderer.js";
-import type { RunState, JobState, StepState } from "./run-state.js";
+import { renderTree, type TreeNode } from "./tree-renderer.ts";
+import type { RunState, JobState, StepState } from "./run-state.ts";
 
 // ─── ANSI helpers ─────────────────────────────────────────────────────────────
 

--- a/packages/cli/src/output/tree-renderer.test.ts
+++ b/packages/cli/src/output/tree-renderer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { renderTree, type TreeNode } from "./tree-renderer.js";
+import { renderTree, type TreeNode } from "./tree-renderer.ts";
 
 describe("renderTree", () => {
   it("renders a single root node", () => {

--- a/packages/cli/src/output/working-directory.test.ts
+++ b/packages/cli/src/output/working-directory.test.ts
@@ -11,7 +11,7 @@ afterEach(() => {
 // Fresh import each test so module-level DEFAULT_WORKING_DIR is recomputed
 async function importFresh() {
   vi.resetModules();
-  return import("./working-directory.js");
+  return import("./working-directory.ts");
 }
 
 describe("DEFAULT_WORKING_DIR", () => {

--- a/packages/cli/src/run-result-writer.test.ts
+++ b/packages/cli/src/run-result-writer.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { JobResult } from "./output/reporter.js";
+import type { JobResult } from "./output/reporter.ts";
 import {
   buildRunResultJson,
   resolveRunResultPath,
@@ -10,7 +10,7 @@ import {
   RUN_RESULT_SCHEMA_VERSION,
   worktreePathHash,
   writeRunResult,
-} from "./run-result-writer.js";
+} from "./run-result-writer.ts";
 
 function job(overrides: Partial<JobResult> = {}): JobResult {
   return {

--- a/packages/cli/src/run-result-writer.ts
+++ b/packages/cli/src/run-result-writer.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { JobResult } from "./output/reporter.js";
+import type { JobResult } from "./output/reporter.ts";
 
 export const RUN_RESULT_SCHEMA_VERSION = 1;
 

--- a/packages/cli/src/runner/directory-setup.test.ts
+++ b/packages/cli/src/runner/directory-setup.test.ts
@@ -18,7 +18,7 @@ describe("ensureWorldWritable", () => {
   });
 
   it("sets all directories to 0o777", async () => {
-    const { ensureWorldWritable } = await import("./directory-setup.js");
+    const { ensureWorldWritable } = await import("./directory-setup.ts");
     const dir1 = path.join(tmpDir, "a");
     const dir2 = path.join(tmpDir, "b");
     fs.mkdirSync(dir1);
@@ -35,7 +35,7 @@ describe("ensureWorldWritable", () => {
   });
 
   it("does not throw on non-existent directories", async () => {
-    const { ensureWorldWritable } = await import("./directory-setup.js");
+    const { ensureWorldWritable } = await import("./directory-setup.ts");
     expect(() => ensureWorldWritable(["/nonexistent/path"])).not.toThrow();
   });
 });
@@ -81,7 +81,7 @@ describe("createRunDirectories — PM-scoped caching", () => {
 
   it("npm: only creates npm cache dir, not pnpm or bun", async () => {
     makeFixture("package-lock.json", '{"lockfileVersion":3}');
-    const { createRunDirectories } = await import("./directory-setup.js");
+    const { createRunDirectories } = await import("./directory-setup.ts");
 
     const dirs = createRunDirectories({
       runDir,
@@ -97,7 +97,7 @@ describe("createRunDirectories — PM-scoped caching", () => {
 
   it("pnpm: only creates pnpm cache dir, not npm or bun", async () => {
     makeFixture("pnpm-lock.yaml", "lockfileVersion: '9.0'\n");
-    const { createRunDirectories } = await import("./directory-setup.js");
+    const { createRunDirectories } = await import("./directory-setup.ts");
 
     const dirs = createRunDirectories({
       runDir,
@@ -113,7 +113,7 @@ describe("createRunDirectories — PM-scoped caching", () => {
 
   it("yarn: creates no PM-specific cache dirs (no dedicated mount)", async () => {
     makeFixture("yarn.lock", "# yarn lockfile v1\n");
-    const { createRunDirectories } = await import("./directory-setup.js");
+    const { createRunDirectories } = await import("./directory-setup.ts");
 
     const dirs = createRunDirectories({
       runDir,
@@ -129,7 +129,7 @@ describe("createRunDirectories — PM-scoped caching", () => {
 
   it("bun: only creates bun cache dir, not pnpm or npm", async () => {
     makeFixture("bun.lock", '{"lockfileVersion":0}');
-    const { createRunDirectories } = await import("./directory-setup.js");
+    const { createRunDirectories } = await import("./directory-setup.ts");
 
     const dirs = createRunDirectories({
       runDir,
@@ -159,7 +159,7 @@ describe("createRunDirectories — PM-scoped caching", () => {
     execSync("git add -A", { cwd: repoDir, stdio: "pipe" });
     execSync('git commit -m "init"', { cwd: repoDir, stdio: "pipe" });
 
-    const { createRunDirectories } = await import("./directory-setup.js");
+    const { createRunDirectories } = await import("./directory-setup.ts");
 
     const dirs = createRunDirectories({
       runDir,
@@ -178,7 +178,7 @@ describe("createRunDirectories — PM-scoped caching", () => {
 
 describe("buildContainerBinds — PM-scoped mounts", () => {
   it("npm project: only mounts .npm, no .pnpm-store or .bun", async () => {
-    const { buildContainerBinds } = await import("../docker/container-config.js");
+    const { buildContainerBinds } = await import("../docker/container-config.ts");
 
     const binds = buildContainerBinds({
       hostWorkDir: "/tmp/work",
@@ -200,7 +200,7 @@ describe("buildContainerBinds — PM-scoped mounts", () => {
   });
 
   it("pnpm project: only mounts .pnpm-store, no .npm or .bun", async () => {
-    const { buildContainerBinds } = await import("../docker/container-config.js");
+    const { buildContainerBinds } = await import("../docker/container-config.ts");
 
     const binds = buildContainerBinds({
       hostWorkDir: "/tmp/work",
@@ -222,7 +222,7 @@ describe("buildContainerBinds — PM-scoped mounts", () => {
   });
 
   it("bun project: only mounts .bun, no .pnpm-store or .npm", async () => {
-    const { buildContainerBinds } = await import("../docker/container-config.js");
+    const { buildContainerBinds } = await import("../docker/container-config.ts");
 
     const binds = buildContainerBinds({
       hostWorkDir: "/tmp/work",
@@ -244,7 +244,7 @@ describe("buildContainerBinds — PM-scoped mounts", () => {
   });
 
   it("yarn project: no PM-specific mounts at all", async () => {
-    const { buildContainerBinds } = await import("../docker/container-config.js");
+    const { buildContainerBinds } = await import("../docker/container-config.ts");
 
     const binds = buildContainerBinds({
       hostWorkDir: "/tmp/work",

--- a/packages/cli/src/runner/directory-setup.ts
+++ b/packages/cli/src/runner/directory-setup.ts
@@ -1,10 +1,10 @@
 import path from "path";
 import fs from "fs";
-import { getWorkingDirectory } from "../output/working-directory.js";
-import { computeLockfileHash, detectPackageManager, repairWarmCache } from "../output/cleanup.js";
-import type { PackageManager } from "../output/cleanup.js";
-import { findRepoRoot } from "./metadata.js";
-import { debugRunner } from "../output/debug.js";
+import { getWorkingDirectory } from "../output/working-directory.ts";
+import { computeLockfileHash, detectPackageManager, repairWarmCache } from "../output/cleanup.ts";
+import type { PackageManager } from "../output/cleanup.ts";
+import { findRepoRoot } from "./metadata.ts";
+import { debugRunner } from "../output/debug.ts";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/packages/cli/src/runner/dirty-sha.test.ts
+++ b/packages/cli/src/runner/dirty-sha.test.ts
@@ -3,7 +3,7 @@ import { execSync } from "child_process";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { computeDirtySha } from "./dirty-sha.js";
+import { computeDirtySha } from "./dirty-sha.ts";
 
 describe("computeDirtySha", () => {
   let repoDir: string;

--- a/packages/cli/src/runner/git-shim.test.ts
+++ b/packages/cli/src/runner/git-shim.test.ts
@@ -17,7 +17,7 @@ describe("writeGitShim", () => {
   });
 
   it("creates an executable git shim with the correct SHA", async () => {
-    const { writeGitShim } = await import("./git-shim.js");
+    const { writeGitShim } = await import("./git-shim.ts");
     const sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
     writeGitShim(tmpDir, sha);
 
@@ -36,7 +36,7 @@ describe("writeGitShim", () => {
   });
 
   it("includes all required interception clauses", async () => {
-    const { writeGitShim } = await import("./git-shim.js");
+    const { writeGitShim } = await import("./git-shim.ts");
     writeGitShim(tmpDir, "abc");
 
     const content = fs.readFileSync(path.join(tmpDir, "git"), "utf-8");

--- a/packages/cli/src/runner/job-result.test.ts
+++ b/packages/cli/src/runner/job-result.test.ts
@@ -5,7 +5,7 @@ import {
   isJobError,
   getErrorMessage,
   type JobError,
-} from "./job-result.js";
+} from "./job-result.ts";
 
 describe("getErrorMessage", () => {
   it("extracts message from Error object", () => {

--- a/packages/cli/src/runner/job-result.ts
+++ b/packages/cli/src/runner/job-result.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import type { JobResult } from "../output/reporter.js";
+import type { JobResult } from "../output/reporter.ts";
 
 export interface JobError {
   taskName: string;

--- a/packages/cli/src/runner/local-job-ssh.test.ts
+++ b/packages/cli/src/runner/local-job-ssh.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import Docker from "dockerode";
-import type { DockerSocket } from "../docker/docker-socket.js";
+import type { DockerSocket } from "../docker/docker-socket.ts";
 
 // End-to-end reproduction for #322: when AGENT_CI_DOCKER_HOST is an ssh:// URI,
 // the Docker client must be wired so docker-modem ends up with the parsed
@@ -11,7 +11,7 @@ import type { DockerSocket } from "../docker/docker-socket.js";
 // the literal URI and fail with `getaddrinfo ENOTFOUND`.
 describe("getDocker SSH wiring (#322)", () => {
   it("constructs a Docker client whose modem has the parsed hostname, not the URI", async () => {
-    const mod = await import("./local-job.js");
+    const mod = await import("./local-job.ts");
     const socket: DockerSocket = {
       socketPath: "",
       uri: "ssh://user@remote-host",

--- a/packages/cli/src/runner/local-job.test.ts
+++ b/packages/cli/src/runner/local-job.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { DockerSocket } from "../docker/docker-socket.js";
+import type { DockerSocket } from "../docker/docker-socket.ts";
 
 const dockerCtor = vi.fn();
 
@@ -17,7 +17,7 @@ afterEach(() => {
 
 describe("getDocker client construction", () => {
   it("uses socketPath for unix sockets", async () => {
-    const mod = await import("./local-job.js");
+    const mod = await import("./local-job.ts");
     const socket: DockerSocket = {
       socketPath: "/tmp/docker.sock",
       uri: "unix:///tmp/docker.sock",
@@ -30,7 +30,7 @@ describe("getDocker client construction", () => {
   });
 
   it("parses ssh URIs into host/username/port (#322)", async () => {
-    const mod = await import("./local-job.js");
+    const mod = await import("./local-job.ts");
     const socket: DockerSocket = {
       socketPath: "",
       uri: "ssh://user@remote-host",
@@ -51,7 +51,7 @@ describe("getDocker client construction", () => {
   });
 
   it("parses ssh URIs with explicit port", async () => {
-    const mod = await import("./local-job.js");
+    const mod = await import("./local-job.ts");
     const socket: DockerSocket = {
       socketPath: "",
       uri: "ssh://deploy@remote-host:2222",
@@ -70,7 +70,7 @@ describe("getDocker client construction", () => {
   });
 
   it("parses ssh URIs without an explicit username", async () => {
-    const mod = await import("./local-job.js");
+    const mod = await import("./local-job.ts");
     const socket: DockerSocket = {
       socketPath: "",
       uri: "ssh://remote-host",
@@ -89,7 +89,7 @@ describe("getDocker client construction", () => {
   });
 
   it("falls back to dockerode environment parsing for tcp URIs", async () => {
-    const mod = await import("./local-job.js");
+    const mod = await import("./local-job.ts");
     const socket: DockerSocket = {
       socketPath: "",
       uri: "tcp://192.168.110.1:2375",

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -5,27 +5,27 @@ import fsp from "fs/promises";
 import { exec, execSync } from "child_process";
 import { promisify } from "util";
 import { createInterface } from "readline";
-import { config } from "../config.js";
-import { Job } from "../types.js";
-import { createLogContext } from "../output/logger.js";
-import { getWorkingDirectory } from "../output/working-directory.js";
+import { config } from "../config.ts";
+import type { Job } from "../types.ts";
+import { createLogContext } from "../output/logger.ts";
+import { getWorkingDirectory } from "../output/working-directory.ts";
 
-import { debugRunner, debugBoot } from "../output/debug.js";
+import { debugRunner, debugBoot } from "../output/debug.ts";
 import {
   startServiceContainers,
   cleanupServiceContainers,
   type ServiceContext,
-} from "../docker/service-containers.js";
-import { killRunnerContainers } from "../docker/shutdown.js";
+} from "../docker/service-containers.ts";
+import { killRunnerContainers } from "../docker/shutdown.ts";
 import { startEphemeralDtu } from "dtu-github-actions/ephemeral";
-import { type JobResult, tailLogFile } from "../output/reporter.js";
-import { RunStateStore, type StepState } from "../output/run-state.js";
+import { type JobResult, tailLogFile } from "../output/reporter.ts";
+import { RunStateStore, type StepState } from "../output/run-state.ts";
 
-import { writeJobMetadata } from "./metadata.js";
-import { writeGitShim } from "./git-shim.js";
-import { prepareWorkspace } from "./workspace.js";
-import { createRunDirectories } from "./directory-setup.js";
-import { writeDetachedMarker } from "../launcher.js";
+import { writeJobMetadata } from "./metadata.ts";
+import { writeGitShim } from "./git-shim.ts";
+import { prepareWorkspace } from "./workspace.ts";
+import { createRunDirectories } from "./directory-setup.ts";
+import { writeDetachedMarker } from "../launcher.ts";
 import {
   buildContainerEnv,
   buildContainerBinds,
@@ -34,18 +34,18 @@ import {
   resolveDtuHost,
   resolveDockerApiUrl,
   resolveDockerExtraHosts,
-} from "../docker/container-config.js";
-import { buildJobResult, isJobSuccessful } from "./result-builder.js";
-import { ensureImagePulled } from "../docker/image-pull.js";
-import { wrapJobSteps, appendOutputCaptureStep } from "./step-wrapper.js";
-import { syncWorkspaceForRetry } from "./sync.js";
+} from "../docker/container-config.ts";
+import { buildJobResult, isJobSuccessful } from "./result-builder.ts";
+import { ensureImagePulled } from "../docker/image-pull.ts";
+import { wrapJobSteps, appendOutputCaptureStep } from "./step-wrapper.ts";
+import { syncWorkspaceForRetry } from "./sync.ts";
 import {
   discoverRunnerImage,
   ensureRunnerImage,
   UPSTREAM_RUNNER_IMAGE,
   type ResolvedRunnerImage,
-} from "./runner-image.js";
-import { findRepoRoot } from "./metadata.js";
+} from "./runner-image.ts";
+import { findRepoRoot } from "./metadata.ts";
 
 // Fix permissions after extracting runner from container.
 // docker cp and cp -a copy files with restrictive permissions (often root-owned),
@@ -76,7 +76,7 @@ function ensureRunnerWriteable(rootDir: string): void {
 
 // ─── Docker setup ─────────────────────────────────────────────────────────────
 
-import { resolveDockerSocket, type DockerSocket } from "../docker/docker-socket.js";
+import { resolveDockerSocket, type DockerSocket } from "../docker/docker-socket.ts";
 
 let _resolvedSocket: DockerSocket | null = null;
 let _docker: Docker | null = null;
@@ -128,7 +128,7 @@ export function __test_createDockerClient(socket: DockerSocket): Docker {
 // discoverRunnerImage() and may be a user-provided Dockerfile build.
 const SEED_IMAGE = UPSTREAM_RUNNER_IMAGE;
 
-import { writeRunnerCredentials } from "./runner-credentials.js";
+import { writeRunnerCredentials } from "./runner-credentials.ts";
 
 const CONTAINER_EXIT_TIMEOUT_MS = 30_000;
 

--- a/packages/cli/src/runner/macos-vm/host-capability.test.ts
+++ b/packages/cli/src/runner/macos-vm/host-capability.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { checkMacosVmHost } from "./host-capability.js";
+import { checkMacosVmHost } from "./host-capability.ts";
 
 const ok = {
   platform: "darwin",

--- a/packages/cli/src/runner/macos-vm/image-mapping.test.ts
+++ b/packages/cli/src/runner/macos-vm/image-mapping.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { resolveMacosVmImage, DEFAULT_MACOS_IMAGE } from "./image-mapping.js";
+import { resolveMacosVmImage, DEFAULT_MACOS_IMAGE } from "./image-mapping.ts";
 
 const ORIG = process.env.AGENT_CI_MACOS_VM_IMAGE;
 

--- a/packages/cli/src/runner/macos-vm/macos-vm-job.ts
+++ b/packages/cli/src/runner/macos-vm/macos-vm-job.ts
@@ -5,20 +5,20 @@ import path from "node:path";
 import type { ChildProcess } from "node:child_process";
 import { startEphemeralDtu } from "dtu-github-actions/ephemeral";
 
-import { Job } from "../../types.js";
-import { getWorkingDirectory } from "../../output/working-directory.js";
-import { createLogContext } from "../../output/logger.js";
-import { debugRunner, debugBoot } from "../../output/debug.js";
-import { type JobResult } from "../../output/reporter.js";
-import { buildJobResult, isJobSuccessful } from "../result-builder.js";
-import { writeJobMetadata } from "../metadata.js";
-import { appendOutputCaptureStep } from "../step-wrapper.js";
-import { writeRunnerCredentials } from "../runner-credentials.js";
-import { classifyRunsOn } from "../runs-on-compat.js";
-import { parseJobRunsOn } from "../../workflow/workflow-parser.js";
+import type { Job } from "../../types.ts";
+import { getWorkingDirectory } from "../../output/working-directory.ts";
+import { createLogContext } from "../../output/logger.ts";
+import { debugRunner, debugBoot } from "../../output/debug.ts";
+import { type JobResult } from "../../output/reporter.ts";
+import { buildJobResult, isJobSuccessful } from "../result-builder.ts";
+import { writeJobMetadata } from "../metadata.ts";
+import { appendOutputCaptureStep } from "../step-wrapper.ts";
+import { writeRunnerCredentials } from "../runner-credentials.ts";
+import { classifyRunsOn } from "../runs-on-compat.ts";
+import { parseJobRunsOn } from "../../workflow/workflow-parser.ts";
 
-import { checkMacosVmHost } from "./host-capability.js";
-import { createSemaphore } from "./semaphore.js";
+import { checkMacosVmHost } from "./host-capability.ts";
+import { createSemaphore } from "./semaphore.ts";
 import {
   listImages,
   pullImage,
@@ -32,9 +32,9 @@ import {
   stop as vmStop,
   destroy as vmDestroy,
   type SshCreds,
-} from "./tart.js";
-import { ensureMacosRunnerBinary } from "./runner-binary.js";
-import { resolveMacosVmImage } from "./image-mapping.js";
+} from "./tart.ts";
+import { ensureMacosRunnerBinary } from "./runner-binary.ts";
+import { resolveMacosVmImage } from "./image-mapping.ts";
 
 // ─── Tunables (env-overridable) ───────────────────────────────────────────────
 

--- a/packages/cli/src/runner/macos-vm/repro-329.test.ts
+++ b/packages/cli/src/runner/macos-vm/repro-329.test.ts
@@ -46,7 +46,7 @@ describe("issue-329 reproduction: getIp swallows runCommand rejection", () => {
     const child = makeFakeChild();
     vi.mocked(childProcess.spawn).mockReturnValue(child as never);
 
-    const { getIp } = await import("./tart.js");
+    const { getIp } = await import("./tart.ts");
     const promise = getIp("agent-ci-macos-cold-boot");
 
     // Same code path runCommand hits when its timer fires and the SIGKILL
@@ -60,7 +60,7 @@ describe("issue-329 reproduction: getIp swallows runCommand rejection", () => {
     const child = makeFakeChild();
     vi.mocked(childProcess.spawn).mockReturnValue(child as never);
 
-    const { getIp } = await import("./tart.js");
+    const { getIp } = await import("./tart.ts");
     const promise = getIp("vm-not-yet-leased");
 
     queueMicrotask(() => child.emit("close", 1));
@@ -72,7 +72,7 @@ describe("issue-329 reproduction: getIp swallows runCommand rejection", () => {
     const child = makeFakeChild();
     vi.mocked(childProcess.spawn).mockReturnValue(child as never);
 
-    const { getIp } = await import("./tart.js");
+    const { getIp } = await import("./tart.ts");
     const promise = getIp("vm-ready");
 
     queueMicrotask(() => {

--- a/packages/cli/src/runner/macos-vm/runner-binary.test.ts
+++ b/packages/cli/src/runner/macos-vm/runner-binary.test.ts
@@ -3,7 +3,7 @@ import {
   DEFAULT_MACOS_RUNNER_VERSION,
   macosRunnerTarballUrl,
   resolveMacosRunnerVersion,
-} from "./runner-binary.js";
+} from "./runner-binary.ts";
 
 describe("macosRunnerTarballUrl", () => {
   it("builds the GitHub release URL for the given version", () => {

--- a/packages/cli/src/runner/macos-vm/semaphore.test.ts
+++ b/packages/cli/src/runner/macos-vm/semaphore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createSemaphore } from "./semaphore.js";
+import { createSemaphore } from "./semaphore.ts";
 
 describe("createSemaphore", () => {
   it("allows up to `limit` concurrent holders", async () => {

--- a/packages/cli/src/runner/macos-vm/tart.test.ts
+++ b/packages/cli/src/runner/macos-vm/tart.test.ts
@@ -9,7 +9,7 @@ import {
   tartListArgs,
   sshArgs,
   rsyncArgs,
-} from "./tart.js";
+} from "./tart.ts";
 
 describe("tart argv builders", () => {
   it("tartPullArgs", () => {

--- a/packages/cli/src/runner/metadata.test.ts
+++ b/packages/cli/src/runner/metadata.test.ts
@@ -17,7 +17,7 @@ describe("findRepoRoot", () => {
   });
 
   it("finds the .git root from a deeply nested path", async () => {
-    const { findRepoRoot } = await import("./metadata.js");
+    const { findRepoRoot } = await import("./metadata.ts");
     // Create .git at root level
     fs.mkdirSync(path.join(tmpDir, ".git"));
     // Create a deeply nested file
@@ -29,7 +29,7 @@ describe("findRepoRoot", () => {
   });
 
   it("returns undefined when no .git exists", async () => {
-    const { findRepoRoot } = await import("./metadata.js");
+    const { findRepoRoot } = await import("./metadata.ts");
     const file = path.join(tmpDir, "file.txt");
     fs.writeFileSync(file, "test");
 
@@ -41,7 +41,7 @@ describe("findRepoRoot", () => {
 
 describe("deriveWorkflowRunId", () => {
   it("strips job/matrix/retry suffixes", async () => {
-    const { deriveWorkflowRunId } = await import("./metadata.js");
+    const { deriveWorkflowRunId } = await import("./metadata.ts");
 
     expect(deriveWorkflowRunId("agent-ci-redwoodjssdk-14-j1-m2-r2")).toBe(
       "agent-ci-redwoodjssdk-14",
@@ -51,7 +51,7 @@ describe("deriveWorkflowRunId", () => {
   });
 
   it("handles names without suffixes", async () => {
-    const { deriveWorkflowRunId } = await import("./metadata.js");
+    const { deriveWorkflowRunId } = await import("./metadata.ts");
 
     expect(deriveWorkflowRunId("simple-runner")).toBe("simple-runner");
   });
@@ -76,7 +76,7 @@ describe("writeJobMetadata", () => {
   });
 
   it("writes metadata.json with expected fields", async () => {
-    const { writeJobMetadata } = await import("./metadata.js");
+    const { writeJobMetadata } = await import("./metadata.ts");
     const logDir = path.join(tmpDir, "logs");
     fs.mkdirSync(logDir, { recursive: true });
     const workflowPath = path.join(repoDir, ".github", "workflows", "ci.yml");
@@ -106,7 +106,7 @@ describe("writeJobMetadata", () => {
   });
 
   it("preserves orchestrator-written fields on merge", async () => {
-    const { writeJobMetadata } = await import("./metadata.js");
+    const { writeJobMetadata } = await import("./metadata.ts");
     const logDir = path.join(tmpDir, "logs");
     fs.mkdirSync(logDir, { recursive: true });
     const workflowPath = path.join(repoDir, ".github", "workflows", "ci.yml");
@@ -144,7 +144,7 @@ describe("writeJobMetadata", () => {
   });
 
   it("does nothing when workflowPath is not set", async () => {
-    const { writeJobMetadata } = await import("./metadata.js");
+    const { writeJobMetadata } = await import("./metadata.ts");
     const logDir = path.join(tmpDir, "logs");
     fs.mkdirSync(logDir, { recursive: true });
 

--- a/packages/cli/src/runner/metadata.ts
+++ b/packages/cli/src/runner/metadata.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import fs from "fs";
-import { Job } from "../types.js";
+import type { Job } from "../types.ts";
 
 // ─── Repo root detection ──────────────────────────────────────────────────────
 

--- a/packages/cli/src/runner/result-builder.test.ts
+++ b/packages/cli/src/runner/result-builder.test.ts
@@ -17,7 +17,7 @@ describe("parseTimelineSteps", () => {
   });
 
   it("parses succeeded, failed, and skipped steps", async () => {
-    const { parseTimelineSteps } = await import("./result-builder.js");
+    const { parseTimelineSteps } = await import("./result-builder.ts");
     const timelinePath = path.join(tmpDir, "timeline.json");
     fs.writeFileSync(
       timelinePath,
@@ -39,12 +39,12 @@ describe("parseTimelineSteps", () => {
   });
 
   it("returns empty array when file does not exist", async () => {
-    const { parseTimelineSteps } = await import("./result-builder.js");
+    const { parseTimelineSteps } = await import("./result-builder.ts");
     expect(parseTimelineSteps(path.join(tmpDir, "nope.json"))).toEqual([]);
   });
 
   it("filters out non-Task records", async () => {
-    const { parseTimelineSteps } = await import("./result-builder.js");
+    const { parseTimelineSteps } = await import("./result-builder.ts");
     const timelinePath = path.join(tmpDir, "timeline.json");
     fs.writeFileSync(
       timelinePath,
@@ -60,7 +60,7 @@ describe("parseTimelineSteps", () => {
   });
 
   it("attaches per-step logPath when logDir is given and the file exists", async () => {
-    const { parseTimelineSteps } = await import("./result-builder.js");
+    const { parseTimelineSteps } = await import("./result-builder.ts");
     const stepsDir = path.join(tmpDir, "steps");
     fs.mkdirSync(stepsDir, { recursive: true });
     // Sanitized name match
@@ -85,7 +85,7 @@ describe("parseTimelineSteps", () => {
   });
 
   it("leaves logPath undefined when logDir is omitted", async () => {
-    const { parseTimelineSteps } = await import("./result-builder.js");
+    const { parseTimelineSteps } = await import("./result-builder.ts");
     const timelinePath = path.join(tmpDir, "timeline.json");
     fs.writeFileSync(
       timelinePath,
@@ -100,22 +100,22 @@ describe("parseTimelineSteps", () => {
 
 describe("sanitizeStepName", () => {
   it("replaces special characters with hyphens", async () => {
-    const { sanitizeStepName } = await import("./result-builder.js");
+    const { sanitizeStepName } = await import("./result-builder.ts");
     expect(sanitizeStepName("Run npm test (shard 1/3)")).toBe("Run-npm-test-shard-1-3");
   });
 
   it("collapses multiple hyphens", async () => {
-    const { sanitizeStepName } = await import("./result-builder.js");
+    const { sanitizeStepName } = await import("./result-builder.ts");
     expect(sanitizeStepName("a   b---c")).toBe("a-b-c");
   });
 
   it("strips leading and trailing hyphens", async () => {
-    const { sanitizeStepName } = await import("./result-builder.js");
+    const { sanitizeStepName } = await import("./result-builder.ts");
     expect(sanitizeStepName("--test--")).toBe("test");
   });
 
   it("truncates to 80 characters", async () => {
-    const { sanitizeStepName } = await import("./result-builder.js");
+    const { sanitizeStepName } = await import("./result-builder.ts");
     const long = "a".repeat(100);
     expect(sanitizeStepName(long).length).toBe(80);
   });
@@ -135,7 +135,7 @@ describe("extractFailureDetails", () => {
   });
 
   it("extracts exit code from the issues array", async () => {
-    const { extractFailureDetails } = await import("./result-builder.js");
+    const { extractFailureDetails } = await import("./result-builder.ts");
     const timelinePath = path.join(tmpDir, "timeline.json");
     fs.writeFileSync(
       timelinePath,
@@ -154,7 +154,7 @@ describe("extractFailureDetails", () => {
   });
 
   it("finds the step log file via sanitized name", async () => {
-    const { extractFailureDetails } = await import("./result-builder.js");
+    const { extractFailureDetails } = await import("./result-builder.ts");
     const stepsDir = path.join(tmpDir, "steps");
     fs.mkdirSync(stepsDir, { recursive: true });
     fs.writeFileSync(path.join(stepsDir, "Run-tests.log"), "error line 1\nerror line 2\n");
@@ -178,7 +178,7 @@ describe("extractFailureDetails", () => {
   });
 
   it("returns empty object when no matching record exists", async () => {
-    const { extractFailureDetails } = await import("./result-builder.js");
+    const { extractFailureDetails } = await import("./result-builder.ts");
     const timelinePath = path.join(tmpDir, "timeline.json");
     fs.writeFileSync(timelinePath, JSON.stringify([]));
 
@@ -191,28 +191,28 @@ describe("extractFailureDetails", () => {
 
 describe("isJobSuccessful", () => {
   it("succeeds when no failed step, exit code 0, and not booting", async () => {
-    const { isJobSuccessful } = await import("./result-builder.js");
+    const { isJobSuccessful } = await import("./result-builder.ts");
     expect(isJobSuccessful({ lastFailedStep: null, containerExitCode: 0, isBooting: false })).toBe(
       true,
     );
   });
 
   it("fails when a step failed", async () => {
-    const { isJobSuccessful } = await import("./result-builder.js");
+    const { isJobSuccessful } = await import("./result-builder.ts");
     expect(
       isJobSuccessful({ lastFailedStep: "Build", containerExitCode: 0, isBooting: false }),
     ).toBe(false);
   });
 
   it("fails when container exit code is non-zero", async () => {
-    const { isJobSuccessful } = await import("./result-builder.js");
+    const { isJobSuccessful } = await import("./result-builder.ts");
     expect(isJobSuccessful({ lastFailedStep: null, containerExitCode: 1, isBooting: false })).toBe(
       false,
     );
   });
 
   it("fails when runner never contacted DTU (isBooting=true)", async () => {
-    const { isJobSuccessful } = await import("./result-builder.js");
+    const { isJobSuccessful } = await import("./result-builder.ts");
     // This is the bug from #102: container exits 0 with no failed steps,
     // but the runner never sent any timeline entries (isBooting stayed true).
     expect(isJobSuccessful({ lastFailedStep: null, containerExitCode: 0, isBooting: true })).toBe(
@@ -235,7 +235,7 @@ describe("buildJobResult", () => {
   });
 
   it("builds a successful result", async () => {
-    const { buildJobResult } = await import("./result-builder.js");
+    const { buildJobResult } = await import("./result-builder.ts");
     const timelinePath = path.join(tmpDir, "timeline.json");
     fs.writeFileSync(
       timelinePath,
@@ -262,7 +262,7 @@ describe("buildJobResult", () => {
   });
 
   it("builds a failed result with failure details", async () => {
-    const { buildJobResult } = await import("./result-builder.js");
+    const { buildJobResult } = await import("./result-builder.ts");
     const timelinePath = path.join(tmpDir, "timeline.json");
     const stepsDir = path.join(tmpDir, "steps");
     fs.mkdirSync(stepsDir, { recursive: true });
@@ -313,7 +313,7 @@ describe("extractStepOutputs", () => {
   });
 
   it("extracts simple key=value outputs from set_output files", async () => {
-    const { extractStepOutputs } = await import("./result-builder.js");
+    const { extractStepOutputs } = await import("./result-builder.ts");
     // Simulate the runner's file_commands directory structure
     const fileCommandsDir = path.join(tmpDir, "_runner_file_commands");
     fs.mkdirSync(fileCommandsDir, { recursive: true });
@@ -330,7 +330,7 @@ describe("extractStepOutputs", () => {
   });
 
   it("extracts multiline (heredoc) values", async () => {
-    const { extractStepOutputs } = await import("./result-builder.js");
+    const { extractStepOutputs } = await import("./result-builder.ts");
     const fileCommandsDir = path.join(tmpDir, "_runner_file_commands");
     fs.mkdirSync(fileCommandsDir, { recursive: true });
     fs.writeFileSync(
@@ -345,7 +345,7 @@ describe("extractStepOutputs", () => {
   });
 
   it("merges outputs from multiple set_output files", async () => {
-    const { extractStepOutputs } = await import("./result-builder.js");
+    const { extractStepOutputs } = await import("./result-builder.ts");
     const fileCommandsDir = path.join(tmpDir, "_runner_file_commands");
     fs.mkdirSync(fileCommandsDir, { recursive: true });
     fs.writeFileSync(path.join(fileCommandsDir, "set_output_aaa"), "key1=val1\n");
@@ -357,13 +357,13 @@ describe("extractStepOutputs", () => {
   });
 
   it("returns empty object when no _runner_file_commands directory exists", async () => {
-    const { extractStepOutputs } = await import("./result-builder.js");
+    const { extractStepOutputs } = await import("./result-builder.ts");
     const outputs = extractStepOutputs(tmpDir);
     expect(outputs).toEqual({});
   });
 
   it("returns empty object when directory has no set_output files", async () => {
-    const { extractStepOutputs } = await import("./result-builder.js");
+    const { extractStepOutputs } = await import("./result-builder.ts");
     const fileCommandsDir = path.join(tmpDir, "_runner_file_commands");
     fs.mkdirSync(fileCommandsDir, { recursive: true });
     fs.writeFileSync(path.join(fileCommandsDir, "add_path_xyz"), "/usr/local/bin\n");
@@ -373,7 +373,7 @@ describe("extractStepOutputs", () => {
   });
 
   it("later files override earlier ones for the same key", async () => {
-    const { extractStepOutputs } = await import("./result-builder.js");
+    const { extractStepOutputs } = await import("./result-builder.ts");
     const fileCommandsDir = path.join(tmpDir, "_runner_file_commands");
     fs.mkdirSync(fileCommandsDir, { recursive: true });
     fs.writeFileSync(path.join(fileCommandsDir, "set_output_aaa"), "key=first\n");
@@ -384,7 +384,7 @@ describe("extractStepOutputs", () => {
   });
 
   it("handles multiline heredoc with multiple lines", async () => {
-    const { extractStepOutputs } = await import("./result-builder.js");
+    const { extractStepOutputs } = await import("./result-builder.ts");
     const fileCommandsDir = path.join(tmpDir, "_runner_file_commands");
     fs.mkdirSync(fileCommandsDir, { recursive: true });
     fs.writeFileSync(
@@ -401,7 +401,7 @@ describe("extractStepOutputs", () => {
 
 describe("resolveJobOutputs", () => {
   it("resolves step output references in job output templates", async () => {
-    const { resolveJobOutputs } = await import("./result-builder.js");
+    const { resolveJobOutputs } = await import("./result-builder.ts");
     const outputDefs = {
       skip: "${{ steps.check.outputs.skip }}",
       count: "${{ steps.counter.outputs.shard_count }}",
@@ -419,7 +419,7 @@ describe("resolveJobOutputs", () => {
   });
 
   it("returns empty string for unresolved step outputs", async () => {
-    const { resolveJobOutputs } = await import("./result-builder.js");
+    const { resolveJobOutputs } = await import("./result-builder.ts");
     const outputDefs = {
       missing: "${{ steps.none.outputs.doesnt_exist }}",
     };
@@ -430,7 +430,7 @@ describe("resolveJobOutputs", () => {
   });
 
   it("passes through literal values unchanged", async () => {
-    const { resolveJobOutputs } = await import("./result-builder.js");
+    const { resolveJobOutputs } = await import("./result-builder.ts");
     const outputDefs = {
       version: "1.2.3",
     };
@@ -441,13 +441,13 @@ describe("resolveJobOutputs", () => {
   });
 
   it("returns empty object when no output definitions", async () => {
-    const { resolveJobOutputs } = await import("./result-builder.js");
+    const { resolveJobOutputs } = await import("./result-builder.ts");
     const resolved = resolveJobOutputs({}, { some: "output" });
     expect(resolved).toEqual({});
   });
 
   it("handles JSON values in step outputs", async () => {
-    const { resolveJobOutputs } = await import("./result-builder.js");
+    const { resolveJobOutputs } = await import("./result-builder.ts");
     const outputDefs = {
       matrix: "${{ steps.plan.outputs.matrix }}",
     };
@@ -462,7 +462,7 @@ describe("resolveJobOutputs", () => {
   });
 
   it("handles templates with surrounding text", async () => {
-    const { resolveJobOutputs } = await import("./result-builder.js");
+    const { resolveJobOutputs } = await import("./result-builder.ts");
     const outputDefs = {
       label: "shard-${{ steps.plan.outputs.index }}",
     };

--- a/packages/cli/src/runner/result-builder.ts
+++ b/packages/cli/src/runner/result-builder.ts
@@ -1,11 +1,11 @@
 import path from "path";
 import fs from "fs";
-import { type JobResult, type StepResult, tailLogFile } from "../output/reporter.js";
+import { type JobResult, type StepResult, tailLogFile } from "../output/reporter.ts";
 import {
   detectMissingToolHint,
   detectToolcacheHint,
   type ResolvedRunnerImage,
-} from "./runner-image.js";
+} from "./runner-image.ts";
 
 // ─── Timeline parsing ─────────────────────────────────────────────────────────
 

--- a/packages/cli/src/runner/runner-image.test.ts
+++ b/packages/cli/src/runner/runner-image.test.ts
@@ -8,7 +8,7 @@ import {
   detectToolcacheHint,
   UPSTREAM_RUNNER_IMAGE,
   type ResolvedRunnerImage,
-} from "./runner-image.js";
+} from "./runner-image.ts";
 
 describe("discoverRunnerImage", () => {
   let repoDir: string;

--- a/packages/cli/src/runner/runner-image.ts
+++ b/packages/cli/src/runner/runner-image.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import crypto from "node:crypto";
 import type Docker from "dockerode";
-import { ensureImagePulled } from "../docker/image-pull.js";
-import { debugRunner } from "../output/debug.js";
+import { ensureImagePulled } from "../docker/image-pull.ts";
+import { debugRunner } from "../output/debug.ts";
 
 export const UPSTREAM_RUNNER_IMAGE = "ghcr.io/actions/actions-runner:latest";
 

--- a/packages/cli/src/runner/runs-on-compat.test.ts
+++ b/packages/cli/src/runner/runs-on-compat.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { classifyRunsOn, isUnsupportedOS, formatUnsupportedOSWarning } from "./runs-on-compat.js";
+import { classifyRunsOn, isUnsupportedOS, formatUnsupportedOSWarning } from "./runs-on-compat.ts";
 
 describe("classifyRunsOn", () => {
   it("treats ubuntu-* as linux", () => {

--- a/packages/cli/src/runner/step-wrapper.test.ts
+++ b/packages/cli/src/runner/step-wrapper.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { wrapStepScript, wrapJobSteps } from "./step-wrapper.js";
+import { wrapStepScript, wrapJobSteps } from "./step-wrapper.ts";
 
 // ── wrapStepScript ────────────────────────────────────────────────────────────
 

--- a/packages/cli/src/runner/workspace.ts
+++ b/packages/cli/src/runner/workspace.ts
@@ -1,7 +1,7 @@
 import { exec, execSync } from "child_process";
 import { promisify } from "util";
-import { copyWorkspace } from "../output/cleanup.js";
-import { findRepoRoot } from "./metadata.js";
+import { copyWorkspace } from "../output/cleanup.ts";
+import { findRepoRoot } from "./metadata.ts";
 
 const execAsync = promisify(exec);
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,4 +1,4 @@
-import type { WorkflowService, WorkflowContainer } from "./workflow/workflow-parser.js";
+import type { WorkflowService, WorkflowContainer } from "./workflow/workflow-parser.ts";
 
 export interface Job {
   deliveryId: string;

--- a/packages/cli/src/workflow/job-scheduler.test.ts
+++ b/packages/cli/src/workflow/job-scheduler.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { parseJobDependencies, topoSort } from "./job-scheduler.js";
+import { parseJobDependencies, topoSort } from "./job-scheduler.ts";
 
 describe("parseJobDependencies", () => {
   let tmpDir: string;

--- a/packages/cli/src/workflow/matrix-collapse.test.ts
+++ b/packages/cli/src/workflow/matrix-collapse.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { collapseMatrixToSingle, expandMatrixCombinations } from "./workflow-parser.js";
+import { collapseMatrixToSingle, expandMatrixCombinations } from "./workflow-parser.ts";
 
 // ─── collapseMatrixToSingle ───────────────────────────────────────────────────
 //

--- a/packages/cli/src/workflow/remote-workflow-fetch.test.ts
+++ b/packages/cli/src/workflow/remote-workflow-fetch.test.ts
@@ -7,7 +7,7 @@ import {
   isShaRef,
   remoteCachePath,
   prefetchRemoteWorkflows,
-} from "./remote-workflow-fetch.js";
+} from "./remote-workflow-fetch.ts";
 
 describe("parseRemoteRef", () => {
   it("parses owner/repo/path@ref", () => {

--- a/packages/cli/src/workflow/resource-classifier.test.ts
+++ b/packages/cli/src/workflow/resource-classifier.test.ts
@@ -5,7 +5,7 @@ import {
   type HostResources,
   parseRunnerSpecs,
   parseRequestedCpuCount,
-} from "./resource-classifier.js";
+} from "./resource-classifier.ts";
 
 describe("parseRequestedCpuCount", () => {
   it("parses explicit larger-runner labels ending in -cores", () => {

--- a/packages/cli/src/workflow/reusable-workflow.test.ts
+++ b/packages/cli/src/workflow/reusable-workflow.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { expandReusableJobs } from "./reusable-workflow.js";
+import { expandReusableJobs } from "./reusable-workflow.ts";
 
 describe("expandReusableJobs", () => {
   let tmpDir: string;

--- a/packages/cli/src/workflow/workflow-parser.test.ts
+++ b/packages/cli/src/workflow/workflow-parser.test.ts
@@ -6,7 +6,7 @@ import {
   parseJobRunsOnLabels,
   parseMergedJobEnv,
   parseWorkflowServices,
-} from "./workflow-parser.js";
+} from "./workflow-parser.ts";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -263,7 +263,7 @@ describe("workflow resource hint accessors", () => {
 
 // ─── expandExpressions ────────────────────────────────────────────────────────
 
-import { expandExpressions } from "./workflow-parser.js";
+import { expandExpressions } from "./workflow-parser.ts";
 
 describe("expandExpressions", () => {
   let tmpDir: string;
@@ -548,7 +548,7 @@ describe("expandExpressions with matrixContext", () => {
 
 // ─── expandMatrixCombinations ─────────────────────────────────────────────────
 
-import { expandMatrixCombinations } from "./workflow-parser.js";
+import { expandMatrixCombinations } from "./workflow-parser.ts";
 
 describe("expandMatrixCombinations", () => {
   it("returns [{}] for an empty matrix", () => {
@@ -689,7 +689,7 @@ OTHER_TOKEN=tok-456
 
 // ─── extractSecretRefs & validateSecrets ──────────────────────────────────────
 
-import { extractSecretRefs, validateSecrets } from "./workflow-parser.js";
+import { extractSecretRefs, validateSecrets } from "./workflow-parser.ts";
 
 describe("extractSecretRefs", () => {
   let tmpDir: string;
@@ -857,7 +857,7 @@ jobs:
 
 // ─── isWorkflowRelevant ───────────────────────────────────────────────────────
 
-import { isWorkflowRelevant } from "./workflow-parser.js";
+import { isWorkflowRelevant } from "./workflow-parser.ts";
 
 describe("isWorkflowRelevant", () => {
   // Helper to build a template with push event config
@@ -1078,7 +1078,7 @@ describe("expandExpressions — toJSON", () => {
 
 // ─── Cross-job outputs: needs context ─────────────────────────────────────────
 
-import { parseJobOutputDefs } from "./workflow-parser.js";
+import { parseJobOutputDefs } from "./workflow-parser.ts";
 
 describe("parseJobOutputDefs", () => {
   let tmpDir: string;
@@ -1496,7 +1496,7 @@ describe("expandExpressions real-world patterns", () => {
 
 // ─── Job-level if conditions ──────────────────────────────────────────────────
 
-import { evaluateJobIf, parseJobIf, parseStepIf } from "./workflow-parser.js";
+import { evaluateJobIf, parseJobIf, parseStepIf } from "./workflow-parser.ts";
 
 describe("parseJobIf", () => {
   let tmpDir: string;
@@ -1661,7 +1661,7 @@ describe("evaluateJobIf", () => {
 
 // ─── strategy.fail-fast ──────────────────────────────────────────────────────
 
-import { parseFailFast } from "./workflow-parser.js";
+import { parseFailFast } from "./workflow-parser.ts";
 
 describe("parseFailFast", () => {
   let tmpDir: string;
@@ -1745,7 +1745,7 @@ jobs:
 
 // ─── parseWorkflowSteps with needsContext ─────────────────────────────────────
 
-import { parseWorkflowSteps } from "./workflow-parser.js";
+import { parseWorkflowSteps } from "./workflow-parser.ts";
 
 describe("parseWorkflowSteps with needsContext", () => {
   let tmpDir: string;
@@ -2052,7 +2052,7 @@ jobs:
 
 // ─── extractVarRefs & validateVars ────────────────────────────────────────────
 
-import { extractVarRefs, validateVars } from "./workflow-parser.js";
+import { extractVarRefs, validateVars } from "./workflow-parser.ts";
 
 describe("extractVarRefs", () => {
   // SPEC-V-011: workflow with no var refs returns empty array
@@ -2450,7 +2450,7 @@ jobs:
   });
 });
 
-import { runnerContextFromRunsOn } from "./workflow-parser.js";
+import { runnerContextFromRunsOn } from "./workflow-parser.ts";
 
 describe("runnerContextFromRunsOn", () => {
   it("classifies macos-14 to macOS/ARM64", () => {
@@ -2481,7 +2481,7 @@ describe("runnerContextFromRunsOn", () => {
   });
 });
 
-import { parseJobRunsOn } from "./workflow-parser.js";
+import { parseJobRunsOn } from "./workflow-parser.ts";
 
 describe("parseJobRunsOn", () => {
   let tmpDir: string;

--- a/packages/cli/src/workflow/workflow-parser.ts
+++ b/packages/cli/src/workflow/workflow-parser.ts
@@ -4,7 +4,7 @@ import crypto from "crypto";
 import { execSync } from "child_process";
 import { minimatch } from "minimatch";
 import { parse as parseYaml } from "yaml";
-import { classifyRunsOn } from "../runner/runs-on-compat.js";
+import { classifyRunsOn } from "../runner/runs-on-compat.ts";
 
 /**
  * Values used to resolve `${{ runner.os }}` / `${{ runner.arch }}` at
@@ -38,6 +38,7 @@ export function runnerContextFromRunsOn(labels: string[]): RunnerContext {
 // which Node 22+ rejects. Register a custom ESM loader hook that transparently
 // adds the missing attribute before we dynamically import the module.
 import { register } from "node:module";
+import { fileURLToPath } from "node:url";
 
 let hookRegistered = false;
 
@@ -45,7 +46,13 @@ async function loadWorkflowParser() {
   if (!hookRegistered) {
     hookRegistered = true;
     try {
-      register("../hooks/json-loader.js", import.meta.url);
+      // Source builds run the .ts file directly under Node's native TS support;
+      // published builds run the .js compiled by tsc. Pick whichever exists so
+      // the same code works in both contexts.
+      const srcUrl = new URL("../hooks/json-loader.ts", import.meta.url);
+      const distUrl = new URL("../hooks/json-loader.js", import.meta.url);
+      const url = fs.existsSync(fileURLToPath(srcUrl)) ? srcUrl : distUrl;
+      register(url);
     } catch {
       // In test environments (Vitest), the hook file may not resolve and
       // Vite already handles JSON imports via its inline config.

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -8,7 +8,10 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true
   },
   "include": ["src/**/*", "scripts/**/*"],
   "exclude": ["src/**/*.test.ts"]

--- a/packages/dtu-github-actions/package.json
+++ b/packages/dtu-github-actions/package.json
@@ -31,8 +31,8 @@
     "access": "public"
   },
   "scripts": {
-    "dev": "(pnpm dlx kill-port 8910 || true) && tsx src/server/start.ts",
-    "simulate": "tsx src/simulate.ts",
+    "dev": "(pnpm dlx kill-port 8910 || true) && node src/server/start.ts",
+    "simulate": "node src/simulate.ts",
     "build": "tsgo",
     "typecheck": "tsgo",
     "test": "vitest run"
@@ -47,10 +47,9 @@
     "@types/body-parser": "^1.19.6",
     "@types/node": "^22.10.2",
     "@types/polka": "^0.5.8",
-    "tsx": "^4.19.2",
     "vitest": "^4.0.18"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   }
 }

--- a/packages/dtu-github-actions/src/ephemeral.ts
+++ b/packages/dtu-github-actions/src/ephemeral.ts
@@ -1,6 +1,6 @@
 import http from "node:http";
-import { setCacheDir } from "./server/store.js";
-import { bootstrapAndReturnApp } from "./server/index.js";
+import { setCacheDir } from "./server/store.ts";
+import { bootstrapAndReturnApp } from "./server/index.ts";
 
 export interface EphemeralDtu {
   /** Full URL including port for CLI access (127.0.0.1), e.g. "http://127.0.0.1:49823" */

--- a/packages/dtu-github-actions/src/server.test.ts
+++ b/packages/dtu-github-actions/src/server.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, beforeEach, beforeAll, afterAll } from "vitest";
-import { state } from "./server/store.js";
-import { bootstrapAndReturnApp } from "./server/index.js";
-import { getBaseUrl } from "./server/routes/dtu.js";
+import { state } from "./server/store.ts";
+import { bootstrapAndReturnApp } from "./server/index.ts";
+import { getBaseUrl } from "./server/routes/dtu.ts";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import type { Polka } from "polka";
 import fs from "node:fs";
 import path from "node:path";
-import { getDtuLogPath } from "./server/logger.js";
+import { getDtuLogPath } from "./server/logger.ts";
 
 let PORT: number;
 

--- a/packages/dtu-github-actions/src/server/index.ts
+++ b/packages/dtu-github-actions/src/server/index.ts
@@ -3,16 +3,16 @@ import bodyParser from "body-parser";
 import { exec } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { config } from "../config.js";
-import { state } from "./store.js";
-import { setupDtuLogging, getDtuLogPath } from "./logger.js";
+import { config } from "../config.ts";
+import { state } from "./store.ts";
+import { setupDtuLogging, getDtuLogPath } from "./logger.ts";
 
 // Routes
-import { registerDtuRoutes } from "./routes/dtu.js";
-import { registerGithubRoutes } from "./routes/github.js";
-import { registerActionRoutes } from "./routes/actions/index.js";
-import { registerCacheRoutes } from "./routes/cache.js";
-import { registerArtifactRoutes } from "./routes/artifacts.js";
+import { registerDtuRoutes } from "./routes/dtu.ts";
+import { registerGithubRoutes } from "./routes/github.ts";
+import { registerActionRoutes } from "./routes/actions/index.ts";
+import { registerCacheRoutes } from "./routes/cache.ts";
+import { registerArtifactRoutes } from "./routes/artifacts.ts";
 
 async function terminateOldProcess() {
   // Kill existing process on DTU port

--- a/packages/dtu-github-actions/src/server/routes/actions/action-tarball.test.ts
+++ b/packages/dtu-github-actions/src/server/routes/actions/action-tarball.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, beforeAll, afterAll } from "vitest";
-import { state, getActionTarballsDir } from "../../store.js";
-import { bootstrapAndReturnApp } from "../../index.js";
+import { state, getActionTarballsDir } from "../../store.ts";
+import { bootstrapAndReturnApp } from "../../index.ts";
 import fs from "node:fs";
 import path from "node:path";
 import type { AddressInfo } from "node:net";

--- a/packages/dtu-github-actions/src/server/routes/actions/generators.test.ts
+++ b/packages/dtu-github-actions/src/server/routes/actions/generators.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createJobResponse } from "./generators.js";
+import { createJobResponse } from "./generators.ts";
 
 describe("createJobResponse", () => {
   const basePayload = {

--- a/packages/dtu-github-actions/src/server/routes/actions/generators.ts
+++ b/packages/dtu-github-actions/src/server/routes/actions/generators.ts
@@ -11,13 +11,13 @@ function createMockJwt(planId: string, jobId: string): string {
   ).toString("base64url");
   return `${header}.${payload}.mock-signature`;
 }
-import {
+import type {
   MessageResponse,
   JobStep,
   JobVariable,
   ContextData,
   PipelineAgentJobRequest,
-} from "../../../types.js";
+} from "../../../types.ts";
 
 // Helper to convert JS objects to ContextData
 function toContextData(obj: any): any {

--- a/packages/dtu-github-actions/src/server/routes/actions/index.ts
+++ b/packages/dtu-github-actions/src/server/routes/actions/index.ts
@@ -1,4 +1,4 @@
-import { Polka } from "polka";
+import type { Polka } from "polka";
 import { execSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
@@ -6,9 +6,9 @@ import https from "node:https";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
-import { state, getActionTarballsDir } from "../../store.js";
-import { getBaseUrl } from "../dtu.js";
-import { createJobResponse } from "./generators.js";
+import { state, getActionTarballsDir } from "../../store.ts";
+import { getBaseUrl } from "../dtu.ts";
+import { createJobResponse } from "./generators.ts";
 
 // ─── Action tarball cache ──────────────────────────────────────────────────────
 // Downloads action tarballs from GitHub on first use and serves them from disk

--- a/packages/dtu-github-actions/src/server/routes/actions/setup-node-mock.test.ts
+++ b/packages/dtu-github-actions/src/server/routes/actions/setup-node-mock.test.ts
@@ -5,9 +5,9 @@ import os from "node:os";
 import path from "node:path";
 import type { AddressInfo } from "node:net";
 import type { Polka } from "polka";
-import { state, getActionTarballsDir } from "../../store.js";
-import { bootstrapAndReturnApp } from "../../index.js";
-import { rewriteSetupNodeTarball } from "./index.js";
+import { state, getActionTarballsDir } from "../../store.ts";
+import { bootstrapAndReturnApp } from "../../index.ts";
+import { rewriteSetupNodeTarball } from "./index.ts";
 
 const HARDCODED_URL = "`https://api.github.com/repos/";
 const REWRITTEN_URL_FRAGMENT = "process.env.GITHUB_API_URL";

--- a/packages/dtu-github-actions/src/server/routes/artifacts.ts
+++ b/packages/dtu-github-actions/src/server/routes/artifacts.ts
@@ -1,9 +1,9 @@
-import { Polka } from "polka";
+import type { Polka } from "polka";
 import fs from "node:fs";
 import path from "node:path";
-import { state } from "../store.js";
-import { getBaseUrl } from "./dtu.js";
-import { config } from "../../config.js";
+import { state } from "../store.ts";
+import { getBaseUrl } from "./dtu.ts";
+import { config } from "../../config.ts";
 
 const ARTIFACT_DIR = path.join(config.DTU_CACHE_DIR, "artifacts");
 if (!fs.existsSync(ARTIFACT_DIR)) {

--- a/packages/dtu-github-actions/src/server/routes/cache.test.ts
+++ b/packages/dtu-github-actions/src/server/routes/cache.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, beforeAll, afterAll } from "vitest";
-import { state } from "../store.js";
-import { bootstrapAndReturnApp } from "../index.js";
-import { config } from "../../config.js";
+import { state } from "../store.ts";
+import { bootstrapAndReturnApp } from "../index.ts";
+import { config } from "../../config.ts";
 import fs from "node:fs";
 import path from "node:path";
 import type { AddressInfo } from "node:net";

--- a/packages/dtu-github-actions/src/server/routes/cache.ts
+++ b/packages/dtu-github-actions/src/server/routes/cache.ts
@@ -1,10 +1,10 @@
-import { Polka } from "polka";
+import type { Polka } from "polka";
 import fs from "node:fs";
 import path from "node:path";
 import { execSync } from "node:child_process";
-import { state } from "../store.js";
-import { getBaseUrl } from "./dtu.js";
-import { config } from "../../config.js";
+import { state } from "../store.ts";
+import { getBaseUrl } from "./dtu.ts";
+import { config } from "../../config.ts";
 
 // Ensure DTU has a temp dir for caching
 const CACHE_DIR = config.DTU_CACHE_DIR;

--- a/packages/dtu-github-actions/src/server/routes/dtu.ts
+++ b/packages/dtu-github-actions/src/server/routes/dtu.ts
@@ -1,9 +1,9 @@
-import { Polka } from "polka";
+import type { Polka } from "polka";
 import crypto from "node:crypto";
 import fs from "node:fs";
 
-import { state } from "../store.js";
-import { createJobResponse } from "./actions/generators.js";
+import { state } from "../store.ts";
+import { createJobResponse } from "./actions/generators.ts";
 
 // Base URL extractor middleware (to handle localhost vs host.docker.internal properly)
 // NOTE: strip \r\n from the Host header — HTTP/1.1 runners can include a trailing \r

--- a/packages/dtu-github-actions/src/server/routes/github.ts
+++ b/packages/dtu-github-actions/src/server/routes/github.ts
@@ -1,7 +1,7 @@
 import { execSync } from "node:child_process";
-import { Polka } from "polka";
-import { state } from "../store.js";
-import { getBaseUrl } from "./dtu.js";
+import type { Polka } from "polka";
+import { state } from "../store.ts";
+import { getBaseUrl } from "./dtu.ts";
 
 const EMPTY_TARBALL = execSync("tar czf - -T /dev/null");
 

--- a/packages/dtu-github-actions/src/server/start.ts
+++ b/packages/dtu-github-actions/src/server/start.ts
@@ -1,6 +1,6 @@
-import { config } from "../config.js";
-import { bootstrapAndReturnApp } from "./index.js";
-import { getDtuLogPath, setWorkingDirectory, DTU_ROOT } from "./logger.js";
+import { config } from "../config.ts";
+import { bootstrapAndReturnApp } from "./index.ts";
+import { getDtuLogPath, setWorkingDirectory, DTU_ROOT } from "./logger.ts";
 import path from "node:path";
 
 let workingDir = process.env.AGENT_CI_WORKING_DIR;

--- a/packages/dtu-github-actions/src/server/store.ts
+++ b/packages/dtu-github-actions/src/server/store.ts
@@ -1,7 +1,7 @@
 import http from "node:http";
 import fs from "node:fs";
 import path from "node:path";
-import { config } from "../config.js";
+import { config } from "../config.ts";
 
 let CACHE_DIR = config.DTU_CACHE_DIR;
 let CACHES_FILE = path.join(CACHE_DIR, "caches.json");

--- a/packages/dtu-github-actions/src/simulate.ts
+++ b/packages/dtu-github-actions/src/simulate.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import crypto from "node:crypto";
-import { config } from "./config.js";
+import { config } from "./config.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/packages/dtu-github-actions/tsconfig.json
+++ b/packages/dtu-github-actions/tsconfig.json
@@ -9,7 +9,10 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true
   },
   "include": ["src/**/*"],
   "exclude": ["src/**/*.test.ts"]

--- a/packages/ts-runner/package.json
+++ b/packages/ts-runner/package.json
@@ -31,13 +31,12 @@
   "scripts": {
     "build": "tsgo",
     "typecheck": "tsgo",
-    "ts-runner": "tsx src/cli.ts"
+    "ts-runner": "node src/cli.ts"
   },
   "devDependencies": {
-    "@types/node": "^22.10.2",
-    "tsx": "^4.21.0"
+    "@types/node": "^22.10.2"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   }
 }

--- a/packages/ts-runner/tsconfig.json
+++ b/packages/ts-runner/tsconfig.json
@@ -9,7 +9,10 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true
   },
   "include": ["src/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,12 +38,12 @@ importers:
       oxlint:
         specifier: 1.48.0
         version: 1.48.0
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.2)
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
 
   apps/website:
     dependencies:
@@ -136,9 +136,6 @@ importers:
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.11
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.2)
@@ -167,9 +164,6 @@ importers:
       '@types/polka':
         specifier: ^0.5.8
         version: 0.5.8
-      tsx:
-        specifier: ^4.19.2
-        version: 4.21.0
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.2)
@@ -179,9 +173,6 @@ importers:
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.11
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
 
 packages:
 
@@ -7573,6 +7564,7 @@ snapshots:
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
+    optional: true
 
   get-uri@6.0.5:
     dependencies:
@@ -8903,7 +8895,8 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
-  resolve-pkg-maps@1.0.0: {}
+  resolve-pkg-maps@1.0.0:
+    optional: true
 
   restore-cursor@5.1.0:
     dependencies:
@@ -9412,10 +9405,11 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.3
+      esbuild: 0.27.7
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
+    optional: true
 
   tweetnacl@0.14.5: {}
 

--- a/scripts/agent-ci-dev.sh
+++ b/scripts/agent-ci-dev.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Dev-only wrapper: runs agent-ci against local development code (via tsx)
-# instead of the published package. Not intended for end users.
+# Dev-only wrapper: runs agent-ci against local development code instead of
+# the published package. Uses Node's native TypeScript support (Node >=24).
+# Not intended for end users.
 set -euo pipefail
 
 SOURCE="${BASH_SOURCE[0]}"
@@ -17,4 +18,4 @@ pnpm --silent --dir "$REPO_ROOT/packages/dtu-github-actions" run build 2>/dev/nu
   pnpm --dir "$REPO_ROOT/packages/dtu-github-actions" run build
 
 # Run CLI from the caller's working directory
-exec "$REPO_ROOT/node_modules/.bin/tsx" "$REPO_ROOT/packages/cli/src/cli.ts" "$@"
+exec node "$REPO_ROOT/packages/cli/src/cli.ts" "$@"


### PR DESCRIPTION
## Problem

This codebase has development scripts written in TypeScript. To run them, the project relies on a small tool called `tsx`. Every dev-only command — the wrapper that runs the agent-ci command-line tool from source, the smoke-test launcher, the demo recorder — invokes `tsx some-file.ts` instead of `node some-file.ts`. That works, but it has costs:

- `tsx` is one more dependency to install, keep up to date, and audit.
- It is a separate runtime with its own startup overhead and its own quirks.
- Newer contributors have to learn what `tsx` is and when to use it.

Node.js 24 makes that tool unnecessary. Node 24 reads TypeScript files directly. It strips the type annotations at load time and runs the rest as plain JavaScript. `node some-file.ts` simply works.

This pull request adopts that built-in feature and removes `tsx` from the project.

## Solution

1. Require Node 24 or newer in every workspace's `engines.node` field.
2. Replace every `tsx some-file.ts` invocation in package scripts with `node some-file.ts`. That includes the shell wrapper `scripts/agent-ci-dev.sh` and the demo project's run script.
3. Remove `tsx` from every workspace's development dependencies.
4. Bump the test workflow in continuous integration to Node 24.

For Node's built-in TypeScript support to work with the codebase's import convention, three settings change in every workspace's `tsconfig.json`:

- `allowImportingTsExtensions: true` — lets a source file write `import { foo } from "./bar.ts"`. Without this the compiler refuses the `.ts` extension.
- `rewriteRelativeImportExtensions: true` — tells the compiler to rewrite each `.ts` path back to `.js` when it emits the compiled output. Published packages look unchanged to consumers.
- `verbatimModuleSyntax: true` — every type-only import must now use the explicit `import type` keyword. Without this, Node would fail at load time the first time it imported a name that turns out to be just a type and not a runtime value.

All 72 source files that previously imported each other with the `.js` extension have been rewritten to use `.ts`. A handful of imports that bring in only types — `Job`, `Polka`, and the message-response types in the `dtu-github-actions` package — gain the explicit `import type` keyword.

One small twist: the workflow parser registers a custom file-loader hook to work around an upstream package that imports JSON files without a required attribute. The path to that hook is now picked at run time. The development build of agent-ci finds it as a `.ts` file; the published build finds it as the compiled `.js` file. The same source code works in both contexts.

## Technical Summary

- `engines.node`: `>=22` → `>=24` in `packages/cli`, `packages/dtu-github-actions`, and `packages/ts-runner`.
- `tsx` removed from `devDependencies` in the repository root and in all three packages.
- Scripts updated:
  - `package.json` (root): `agent-ci`, `parse:diff`, `ts-runner`
  - `packages/cli/package.json`: `agent-ci`
  - `packages/dtu-github-actions/package.json`: `dev`, `simulate`
  - `packages/ts-runner/package.json`: `ts-runner`
  - `.docs/marketing/demo-recording/package.json`: `agent-ci`
  - `scripts/agent-ci-dev.sh`: hard-coded `tsx` path replaced with `node`
- Three TypeScript compiler options added to every workspace `tsconfig.json` (see Solution).
- 72 source files rewritten so relative imports use the `.ts` extension.
- 8 imports converted to `import type` to satisfy the stricter module-syntax rule.
- `workflow-parser.ts` picks the loader-hook path at run time so the same source supports the development build (uses the `.ts` file) and the compiled build (uses the `.js` file).
- Root `package.json` gains `"type": "module"` (no existing `.js` files in the repository root were affected) and lists `yaml` as a development dependency. `scripts/diff-parse.ts` uses `yaml` directly; until now it relied on the dependency being hoisted up from the `cli` package.
- Continuous integration: `.github/workflows/tests.yml` bumps `node-version` from `22` to `24`. Smoke workflows that set `node-version: 22` are deliberately left alone — they are fixtures that exercise the `actions/setup-node` action with a specific Node version and are not the project's own runtime.

Verified locally with Node 24:

- `pnpm -w run check` — clean (type-check, lint, format, compatibility table, diff parser).
- `node packages/cli/src/cli.ts --help` — runs the source directly with no extra tools.
- The full smoke suite (`pnpm agent-ci-dev run --all`) finishes with 45 of 45 jobs passing, after one expected retry of the known-flaky `bun-setup` test.

Breaking change for contributors: anyone still on Node 22 needs to install Node 24 before pulling this branch.