### PR TITLE
perf(cli): parallelize the startup git calls

### DIFF
--- a/.changeset/async-startup-git-calls.md
+++ b/.changeset/async-startup-git-calls.md
@@ -1,0 +1,30 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+perf(cli): parallelize the startup git calls
+
+The first thing `agent-ci run` does is ask git for several pieces of
+information: the current branch, the head commit SHA, the changed
+files, the remote slug, and (when the tree is dirty) an ephemeral
+commit that captures the working-tree state. Each call shelled out to
+`execSync`, blocking the event loop for ~50–200 ms.
+
+This change converts each of those helpers to use `execFile` via
+`promisify`, so they return promises. `handleWorkflow` then runs them
+concurrently with `Promise.all` instead of one at a time.
+
+Functions converted:
+
+- `getFirstRemoteUrl` and `resolveRepoSlug` in `config.ts`
+- `computeDirtySha` in `runner/dirty-sha.ts`
+- `getChangedFiles` in `workflow/workflow-parser.ts`
+- `resolveHeadSha`, `resolveBaseSha`, and `persistRunResult` in
+  `commands/run.ts`
+
+Switching from `execSync(command-string)` to `execFile("git", [args])`
+also removes a shell escaping step on every call — args are passed as
+an array, not a single string.
+
+Refs #334.

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,4 +1,7 @@
-import { execSync } from "node:child_process";
+import { execFile, execSync } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileP = promisify(execFile);
 import path from "node:path";
 import fs from "node:fs";
 import type Docker from "dockerode";
@@ -259,13 +262,13 @@ function resolveWorkflowArgPath(workflow: string, repoRoot: string): string {
  * finish sentinel, and exit. Used by both the --all and single-workflow
  * code paths so they share the same shutdown sequence.
  */
-function finalizeRun(opts: {
+async function finalizeRun(opts: {
   results: JobResult[];
   parsed: ParsedRunArgs;
   repoRoot: string;
   startedAt: Date;
   branch?: string;
-}): never {
+}): Promise<never> {
   const { results, parsed, repoRoot, startedAt, branch } = opts;
   if (results.length > 0) {
     printSummary(results);
@@ -273,13 +276,13 @@ function finalizeRun(opts: {
   if (parsed.commitStatus) {
     postCommitStatus(results, parsed.sha, parsed.githubToken);
   }
-  persistRunResult({ results, repoRoot, startedAt, sha: parsed.sha, branch });
+  await persistRunResult({ results, repoRoot, startedAt, sha: parsed.sha, branch });
   const anyFailed = results.length === 0 || results.some((r) => !r.succeeded);
   emitRunFinishSentinel(anyFailed ? "failed" : "passed");
   process.exit(anyFailed ? 1 : 0);
 }
 
-export default async function runCmd(args: string[]): Promise<never> {
+export default async function runCmd(args: string[]): Promise<void> {
   const parsed = parseRunArgs(args);
 
   // ── Detached-worker dispatch (issue #315) ────────────────────────────────
@@ -329,15 +332,19 @@ export default async function runCmd(args: string[]): Promise<never> {
 
   if (parsed.runAll) {
     const repoRoot = resolveRepoRoot();
-    const branch = execSync("git rev-parse --abbrev-ref HEAD", { cwd: repoRoot }).toString().trim();
-    const changedFiles = getChangedFiles(repoRoot);
+    // Branch and changed-files are independent — kick both off together.
+    const [{ stdout: branchOut }, changedFiles] = await Promise.all([
+      execFileP("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: repoRoot }),
+      getChangedFiles(repoRoot),
+    ]);
+    const branch = branchOut.trim();
     const relevant = await discoverRelevantWorkflows(repoRoot, branch, changedFiles);
     if (relevant.length === 0) {
       console.log(`[Agent CI] No relevant workflows found for branch '${branch}'.`);
       process.exit(0);
     }
     const results = await runWorkflows({ workflowPaths: relevant, ...runWorkflowsOpts });
-    finalizeRun({ results, parsed, repoRoot, startedAt, branch });
+    await finalizeRun({ results, parsed, repoRoot, startedAt, branch });
   }
 
   if (!parsed.workflow) {
@@ -350,7 +357,7 @@ export default async function runCmd(args: string[]): Promise<never> {
   const repoRoot = resolveRepoRoot();
   const workflowPath = resolveWorkflowArgPath(parsed.workflow, repoRoot);
   const results = await runWorkflows({ workflowPaths: [workflowPath], ...runWorkflowsOpts });
-  finalizeRun({ results, parsed, repoRoot, startedAt });
+  await finalizeRun({ results, parsed, repoRoot, startedAt });
 }
 
 // ─── prefetchRunnerImages ──────────────────────────────────────────────────
@@ -840,7 +847,7 @@ async function runWorkflows(options: {
       // Multiple workflows (--all mode)
       // Determine warm-cache status from the first workflow's repo root
       const firstRepoRoot = resolveRepoRootFromWorkflow(workflowPaths[0]);
-      config.GITHUB_REPO ??= resolveRepoSlug(firstRepoRoot);
+      config.GITHUB_REPO ??= await resolveRepoSlug(firstRepoRoot);
       const repoSlug = config.GITHUB_REPO.replace("/", "-");
       let lockfileHash = "no-lockfile";
       try {
@@ -1119,18 +1126,22 @@ async function handleWorkflow(options: {
     setWorkingDirectory(DEFAULT_WORKING_DIR);
   }
 
-  const { headSha, shaRef } = sha
-    ? resolveHeadSha(repoRoot, sha)
-    : { headSha: undefined, shaRef: undefined };
-  // Always resolve a SHA that represents the code being executed.
-  // When the working tree is dirty and no explicit --sha was given, compute an
-  // ephemeral commit SHA that captures the dirty state (including untracked files).
-  // This is purely informational — actions/checkout is always stubbed, so no
-  // workflow will ever try to fetch this SHA from a remote.
-  const realHeadSha =
-    headSha ?? computeDirtySha(repoRoot) ?? resolveHeadSha(repoRoot, "HEAD").headSha;
-  const baseSha = resolveBaseSha(repoRoot, realHeadSha);
-  const githubRepo = config.GITHUB_REPO ?? resolveRepoSlug(repoRoot);
+  // Resolve startup git / remote calls concurrently. headSha, dirtySha, the
+  // repo slug, and the upstream remote URL are independent — running them in
+  // parallel saves ~half a second on every invocation.
+  // Always resolve a SHA that represents the code being executed: an explicit
+  // --sha wins, then a dirty-tree ephemeral SHA, then plain HEAD. Information
+  // only — actions/checkout is stubbed, so no workflow tries to fetch it.
+  const [explicitHead, dirtySha, headSlug, slugFromRemote] = await Promise.all([
+    sha ? resolveHeadSha(repoRoot, sha) : Promise.resolve(undefined),
+    sha ? Promise.resolve(undefined) : computeDirtySha(repoRoot),
+    resolveHeadSha(repoRoot, "HEAD"),
+    config.GITHUB_REPO ? Promise.resolve(config.GITHUB_REPO) : resolveRepoSlug(repoRoot),
+  ]);
+  const { headSha, shaRef } = explicitHead ?? { headSha: undefined, shaRef: undefined };
+  const realHeadSha = headSha ?? dirtySha ?? headSlug.headSha;
+  const baseSha = await resolveBaseSha(repoRoot, realHeadSha);
+  const githubRepo = slugFromRemote;
   config.GITHUB_REPO = githubRepo;
   const [owner, name] = githubRepo.split("/");
 
@@ -1709,12 +1720,10 @@ function resolveRepoRootFromWorkflow(workflowPath: string): string {
   return repoRoot === "/" ? resolveRepoRoot() : repoRoot;
 }
 
-function resolveHeadSha(repoRoot: string, sha: string) {
+async function resolveHeadSha(repoRoot: string, sha: string) {
   try {
-    return {
-      headSha: execSync(`git rev-parse ${sha}`, { cwd: repoRoot }).toString().trim(),
-      shaRef: sha,
-    };
+    const { stdout } = await execFileP("git", ["rev-parse", sha], { cwd: repoRoot });
+    return { headSha: stdout.trim(), shaRef: sha };
   } catch {
     throw new Error(`Failed to resolve ref: ${sha}`);
   }
@@ -1735,21 +1744,25 @@ function emitRunFinishSentinel(status: "passed" | "failed"): void {
   );
 }
 
-function persistRunResult(opts: {
+async function persistRunResult(opts: {
   results: JobResult[];
   repoRoot: string;
   startedAt: Date;
   sha?: string;
   branch?: string;
-}): void {
+}): Promise<void> {
   try {
-    const repo = config.GITHUB_REPO ?? resolveRepoSlug(opts.repoRoot);
-    const branch =
+    const [repo, branch, headSha] = await Promise.all([
+      config.GITHUB_REPO ?? resolveRepoSlug(opts.repoRoot),
       opts.branch ??
-      execSync("git rev-parse --abbrev-ref HEAD", { cwd: opts.repoRoot }).toString().trim();
-    const headSha = (
-      opts.sha ?? execSync("git rev-parse HEAD", { cwd: opts.repoRoot }).toString()
-    ).trim();
+        execFileP("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: opts.repoRoot }).then((r) =>
+          r.stdout.trim(),
+        ),
+      opts.sha ??
+        execFileP("git", ["rev-parse", "HEAD"], { cwd: opts.repoRoot }).then((r) =>
+          r.stdout.trim(),
+        ),
+    ]);
     writeRunResult({
       repo,
       branch,
@@ -1765,10 +1778,11 @@ function persistRunResult(opts: {
 }
 
 /** Resolve the parent commit SHA for push-event `before` context. */
-function resolveBaseSha(repoRoot: string, headSha?: string): string | undefined {
+async function resolveBaseSha(repoRoot: string, headSha?: string): Promise<string | undefined> {
   try {
     const ref = headSha && headSha !== "HEAD" ? `${headSha}~1` : "HEAD~1";
-    return execSync(`git rev-parse ${ref}`, { cwd: repoRoot, stdio: "pipe" }).toString().trim();
+    const { stdout } = await execFileP("git", ["rev-parse", ref], { cwd: repoRoot });
+    return stdout.trim();
   } catch {
     return undefined;
   }

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -46,23 +46,23 @@ describe("getFirstRemoteUrl", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("returns origin URL when origin exists", () => {
+  it("returns origin URL when origin exists", async () => {
     execSync("git remote add origin https://github.com/test/repo.git", {
       cwd: tmpDir,
       stdio: "pipe",
     });
-    expect(getFirstRemoteUrl(tmpDir)).toBe("https://github.com/test/repo.git");
+    expect(await getFirstRemoteUrl(tmpDir)).toBe("https://github.com/test/repo.git");
   });
 
-  it("falls back to first remote when origin does not exist", () => {
+  it("falls back to first remote when origin does not exist", async () => {
     execSync("git remote add upstream https://github.com/test/upstream.git", {
       cwd: tmpDir,
       stdio: "pipe",
     });
-    expect(getFirstRemoteUrl(tmpDir)).toBe("https://github.com/test/upstream.git");
+    expect(await getFirstRemoteUrl(tmpDir)).toBe("https://github.com/test/upstream.git");
   });
 
-  it("prefers origin over other remotes", () => {
+  it("prefers origin over other remotes", async () => {
     execSync("git remote add upstream https://github.com/test/upstream.git", {
       cwd: tmpDir,
       stdio: "pipe",
@@ -71,17 +71,17 @@ describe("getFirstRemoteUrl", () => {
       cwd: tmpDir,
       stdio: "pipe",
     });
-    expect(getFirstRemoteUrl(tmpDir)).toBe("https://github.com/test/origin.git");
+    expect(await getFirstRemoteUrl(tmpDir)).toBe("https://github.com/test/origin.git");
   });
 
-  it("returns null when no remotes exist", () => {
-    expect(getFirstRemoteUrl(tmpDir)).toBeNull();
+  it("returns null when no remotes exist", async () => {
+    expect(await getFirstRemoteUrl(tmpDir)).toBeNull();
   });
 
-  it("returns null for non-git directory", () => {
+  it("returns null for non-git directory", async () => {
     const nonGitDir = fs.mkdtempSync(path.join(os.tmpdir(), "no-git-"));
     try {
-      expect(getFirstRemoteUrl(nonGitDir)).toBeNull();
+      expect(await getFirstRemoteUrl(nonGitDir)).toBeNull();
     } finally {
       fs.rmSync(nonGitDir, { recursive: true, force: true });
     }
@@ -100,45 +100,47 @@ describe("resolveRepoSlug", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("detects owner/repo from remote URL", () => {
+  it("detects owner/repo from remote URL", async () => {
     execSync("git remote add origin https://github.com/acme/widgets.git", {
       cwd: tmpDir,
       stdio: "pipe",
     });
-    expect(resolveRepoSlug(tmpDir)).toBe("acme/widgets");
+    expect(await resolveRepoSlug(tmpDir)).toBe("acme/widgets");
   });
 
-  it("detects owner/repo from SSH remote", () => {
+  it("detects owner/repo from SSH remote", async () => {
     execSync("git remote add origin git@github.com:acme/widgets.git", {
       cwd: tmpDir,
       stdio: "pipe",
     });
-    expect(resolveRepoSlug(tmpDir)).toBe("acme/widgets");
+    expect(await resolveRepoSlug(tmpDir)).toBe("acme/widgets");
   });
 
-  it("throws when no remotes exist and no fallback given", () => {
-    expect(() => resolveRepoSlug(tmpDir)).toThrow(/Could not detect GitHub repository/);
+  it("throws when no remotes exist and no fallback given", async () => {
+    await expect(resolveRepoSlug(tmpDir)).rejects.toThrow(/Could not detect GitHub repository/);
   });
 
-  it("returns fallback when no remotes exist", () => {
-    expect(resolveRepoSlug(tmpDir, "org/fallback")).toBe("org/fallback");
+  it("returns fallback when no remotes exist", async () => {
+    expect(await resolveRepoSlug(tmpDir, "org/fallback")).toBe("org/fallback");
   });
 
-  it("throws for non-git directory without fallback", () => {
+  it("throws for non-git directory without fallback", async () => {
     const nonGitDir = fs.mkdtempSync(path.join(os.tmpdir(), "no-git-"));
     try {
-      expect(() => resolveRepoSlug(nonGitDir)).toThrow(/Could not detect GitHub repository/);
+      await expect(resolveRepoSlug(nonGitDir)).rejects.toThrow(
+        /Could not detect GitHub repository/,
+      );
     } finally {
       fs.rmSync(nonGitDir, { recursive: true, force: true });
     }
   });
 
-  it("uses non-origin remote when origin is absent", () => {
+  it("uses non-origin remote when origin is absent", async () => {
     execSync("git remote add upstream https://github.com/acme/upstream.git", {
       cwd: tmpDir,
       stdio: "pipe",
     });
-    expect(resolveRepoSlug(tmpDir)).toBe("acme/upstream");
+    expect(await resolveRepoSlug(tmpDir)).toBe("acme/upstream");
   });
 });
 
@@ -169,23 +171,23 @@ describe("GITHUB_REPO env var override priority", () => {
     expect(result).toBe("override/from-env");
   });
 
-  it("auto-detects when env var is not set", () => {
+  it("auto-detects when env var is not set", async () => {
     execSync("git remote add origin https://github.com/detected/repo.git", {
       cwd: tmpDir,
       stdio: "pipe",
     });
     config.GITHUB_REPO = undefined;
 
-    const result = config.GITHUB_REPO ?? resolveRepoSlug(tmpDir);
+    const result = config.GITHUB_REPO ?? (await resolveRepoSlug(tmpDir));
     expect(result).toBe("detected/repo");
   });
 
-  it("throws when neither env var nor remote is available", () => {
+  it("throws when neither env var nor remote is available", async () => {
     config.GITHUB_REPO = undefined;
 
-    expect(() => {
-      return config.GITHUB_REPO ?? resolveRepoSlug(tmpDir);
-    }).toThrow(/Could not detect GitHub repository/);
+    await expect(
+      (async () => config.GITHUB_REPO ?? (await resolveRepoSlug(tmpDir)))(),
+    ).rejects.toThrow(/Could not detect GitHub repository/);
   });
 });
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,24 +1,29 @@
-import { execSync } from "child_process";
+import { execFile } from "child_process";
+import { promisify } from "util";
 import fs from "fs";
 import path from "path";
 import { PROJECT_ROOT } from "./output/working-directory.ts";
+
+const execFileP = promisify(execFile);
 
 /**
  * Get the URL of the first git remote, preferring 'origin'.
  * Uses `git remote get-url` which is scoped to the repo (unlike `git config`
  * which can leak values from global/system config on CI runners).
  */
-export function getFirstRemoteUrl(cwd: string): string | null {
-  const exec = (cmd: string) =>
-    execSync(cmd, { cwd, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+export async function getFirstRemoteUrl(cwd: string): Promise<string | null> {
+  const git = async (...args: string[]): Promise<string> => {
+    const { stdout } = await execFileP("git", args, { cwd, encoding: "utf-8" });
+    return stdout.trim();
+  };
   try {
-    return exec("git remote get-url origin") || null;
+    return (await git("remote", "get-url", "origin")) || null;
   } catch {
     // origin doesn't exist — fall back to the first listed remote
     try {
-      const firstName = exec("git remote").split("\n")[0];
+      const firstName = (await git("remote")).split("\n")[0];
       if (firstName) {
-        return exec(`git remote get-url ${firstName}`) || null;
+        return (await git("remote", "get-url", firstName)) || null;
       }
     } catch {}
   }
@@ -38,8 +43,8 @@ export function parseRepoSlug(remoteUrl: string): string | null {
  * Detect `owner/repo` from the git remote in the given directory.
  * Throws if detection fails and no fallback is provided.
  */
-export function resolveRepoSlug(cwd: string, fallback?: string): string {
-  const remoteUrl = getFirstRemoteUrl(cwd);
+export async function resolveRepoSlug(cwd: string, fallback?: string): Promise<string> {
+  const remoteUrl = await getFirstRemoteUrl(cwd);
   if (remoteUrl) {
     const slug = parseRepoSlug(remoteUrl);
     if (slug) {

--- a/packages/cli/src/runner/dirty-sha.test.ts
+++ b/packages/cli/src/runner/dirty-sha.test.ts
@@ -22,39 +22,39 @@ describe("computeDirtySha", () => {
     fs.rmSync(repoDir, { recursive: true, force: true });
   });
 
-  it("returns undefined for a clean working tree", () => {
-    expect(computeDirtySha(repoDir)).toBeUndefined();
+  it("returns undefined for a clean working tree", async () => {
+    expect(await computeDirtySha(repoDir)).toBeUndefined();
   });
 
-  it("returns a SHA when tracked files are modified", () => {
+  it("returns a SHA when tracked files are modified", async () => {
     fs.writeFileSync(path.join(repoDir, "initial.txt"), "modified");
-    const sha = computeDirtySha(repoDir);
+    const sha = await computeDirtySha(repoDir);
     expect(sha).toBeDefined();
     expect(sha).toMatch(/^[0-9a-f]{40}$/);
   });
 
-  it("returns a SHA when untracked files are present", () => {
+  it("returns a SHA when untracked files are present", async () => {
     fs.writeFileSync(path.join(repoDir, "untracked.txt"), "new file");
-    const sha = computeDirtySha(repoDir);
+    const sha = await computeDirtySha(repoDir);
     expect(sha).toBeDefined();
     expect(sha).toMatch(/^[0-9a-f]{40}$/);
   });
 
-  it("returns a different SHA for different dirty states", () => {
+  it("returns a different SHA for different dirty states", async () => {
     fs.writeFileSync(path.join(repoDir, "a.txt"), "content a");
-    const sha1 = computeDirtySha(repoDir);
+    const sha1 = await computeDirtySha(repoDir);
 
     // Stage and commit a.txt, then modify differently
     execSync("git add -A && git commit -m 'add a'", { cwd: repoDir, stdio: "pipe" });
     fs.writeFileSync(path.join(repoDir, "a.txt"), "content b");
-    const sha2 = computeDirtySha(repoDir);
+    const sha2 = await computeDirtySha(repoDir);
 
     expect(sha1).toBeDefined();
     expect(sha2).toBeDefined();
     expect(sha1).not.toBe(sha2);
   });
 
-  it("does not move HEAD or create refs", () => {
+  it("does not move HEAD or create refs", async () => {
     const headBefore = execSync("git rev-parse HEAD", { cwd: repoDir, stdio: "pipe" })
       .toString()
       .trim();
@@ -63,7 +63,7 @@ describe("computeDirtySha", () => {
       .trim();
 
     fs.writeFileSync(path.join(repoDir, "dirty.txt"), "dirty");
-    computeDirtySha(repoDir);
+    await computeDirtySha(repoDir);
 
     const headAfter = execSync("git rev-parse HEAD", { cwd: repoDir, stdio: "pipe" })
       .toString()
@@ -76,7 +76,7 @@ describe("computeDirtySha", () => {
     expect(refsAfter).toBe(refsBefore);
   });
 
-  it("does not modify the real index", () => {
+  it("does not modify the real index", async () => {
     // Stage nothing, but have an untracked file
     fs.writeFileSync(path.join(repoDir, "untracked.txt"), "new");
 
@@ -84,7 +84,7 @@ describe("computeDirtySha", () => {
       .toString()
       .trim();
 
-    computeDirtySha(repoDir);
+    await computeDirtySha(repoDir);
 
     const statusAfter = execSync("git status --porcelain", { cwd: repoDir, stdio: "pipe" })
       .toString()
@@ -93,9 +93,9 @@ describe("computeDirtySha", () => {
     expect(statusAfter).toBe(statusBefore);
   });
 
-  it("returns a valid commit object parented on HEAD", () => {
+  it("returns a valid commit object parented on HEAD", async () => {
     fs.writeFileSync(path.join(repoDir, "dirty.txt"), "content");
-    const sha = computeDirtySha(repoDir);
+    const sha = await computeDirtySha(repoDir);
     expect(sha).toBeDefined();
 
     // Verify it's a valid commit object

--- a/packages/cli/src/runner/dirty-sha.ts
+++ b/packages/cli/src/runner/dirty-sha.ts
@@ -1,6 +1,9 @@
-import { execSync } from "child_process";
+import { execFile } from "child_process";
+import { promisify } from "util";
 import path from "path";
 import fs from "fs";
+
+const execFileP = promisify(execFile);
 
 /**
  * Compute a SHA that represents the current dirty working-tree state, as if
@@ -9,25 +12,19 @@ import fs from "fs";
  *
  * Returns `undefined` when the tree is clean (no uncommitted changes).
  */
-export function computeDirtySha(repoRoot: string): string | undefined {
+export async function computeDirtySha(repoRoot: string): Promise<string | undefined> {
+  const git = async (env: NodeJS.ProcessEnv | undefined, ...args: string[]): Promise<string> => {
+    const { stdout } = await execFileP("git", args, { cwd: repoRoot, encoding: "utf-8", env });
+    return stdout.trim();
+  };
   try {
     // Quick check: anything dirty?
-    const status = execSync("git status --porcelain", {
-      cwd: repoRoot,
-      stdio: "pipe",
-    })
-      .toString()
-      .trim();
+    const status = await git(undefined, "status", "--porcelain");
     if (!status) {
       return undefined;
     }
 
-    const gitDir = execSync("git rev-parse --git-dir", {
-      cwd: repoRoot,
-      stdio: "pipe",
-    })
-      .toString()
-      .trim();
+    const gitDir = await git(undefined, "rev-parse", "--git-dir");
     const absoluteGitDir = path.isAbsolute(gitDir) ? gitDir : path.join(repoRoot, gitDir);
     const tmpIndex = path.join(absoluteGitDir, `index-agent-ci-${Date.now()}`);
 
@@ -38,26 +35,21 @@ export function computeDirtySha(repoRoot: string): string | undefined {
       const env = { ...process.env, GIT_INDEX_FILE: tmpIndex };
 
       // Stage everything (tracked + untracked, respecting .gitignore) into the temp index.
-      execSync("git add -A", { cwd: repoRoot, stdio: "pipe", env });
+      await git(env, "add", "-A");
 
       // Write a tree object from the temp index.
-      const tree = execSync("git write-tree", {
-        cwd: repoRoot,
-        stdio: "pipe",
-        env,
-      })
-        .toString()
-        .trim();
+      const tree = await git(env, "write-tree");
 
       // Create an ephemeral commit object parented on HEAD — no ref is updated.
-      const sha = execSync(`git commit-tree ${tree} -p HEAD -m "agent-ci: dirty working tree"`, {
-        cwd: repoRoot,
-        stdio: "pipe",
-      })
-        .toString()
-        .trim();
-
-      return sha;
+      return await git(
+        undefined,
+        "commit-tree",
+        tree,
+        "-p",
+        "HEAD",
+        "-m",
+        "agent-ci: dirty working tree",
+      );
     } finally {
       try {
         fs.unlinkSync(tmpIndex);

--- a/packages/cli/src/workflow/workflow-parser.ts
+++ b/packages/cli/src/workflow/workflow-parser.ts
@@ -1,10 +1,13 @@
 import fs from "fs";
 import path from "path";
 import crypto from "crypto";
-import { execSync } from "child_process";
+import { execFile } from "child_process";
+import { promisify } from "util";
 import { minimatch } from "minimatch";
 import { parse as parseYaml } from "yaml";
 import { classifyRunsOn } from "../runner/runs-on-compat.ts";
+
+const execFileP = promisify(execFile);
 
 /**
  * Values used to resolve `${{ runner.os }}` / `${{ runner.arch }}` at
@@ -1223,14 +1226,13 @@ export async function parseWorkflowContainer(
  * Get the list of files changed in the current commit relative to the previous
  * commit. Returns an empty array on error (safe fallback: all workflows run).
  */
-export function getChangedFiles(repoRoot: string): string[] {
+export async function getChangedFiles(repoRoot: string): Promise<string[]> {
   try {
-    const output = execSync("git diff --name-only HEAD~1", {
+    const { stdout } = await execFileP("git", ["diff", "--name-only", "HEAD~1"], {
       cwd: repoRoot,
       encoding: "utf-8",
-      stdio: ["pipe", "pipe", "pipe"],
     });
-    return output
+    return stdout
       .trim()
       .split("\n")
       .filter((f) => f.length > 0);


### PR DESCRIPTION
## Problem

The first thing `agent-ci run` does on every invocation is ask `git` for several pieces of information:

- the current branch name (`git rev-parse --abbrev-ref HEAD`)
- the head commit hash (`git rev-parse HEAD`)
- the list of files changed in the previous commit (`git diff --name-only HEAD~1`)
- the project's GitHub repository slug, taken from the `origin` remote URL
- (when the working tree is dirty) an ephemeral commit that captures the staged-plus-unstaged state, so the run still has a SHA to display

Each call used Node's `execSync`, which blocks the entire event loop while waiting for `git` to return. On a typical machine each shell-out takes 50 to 200 milliseconds. The calls happened in sequence, so half a second to a full second of every run was the command-line tool sitting idle, waiting on subprocess pipes.

This is the second piece of work listed in issue #334. The first piece — lazy-loading command modules so simple commands don't drag in the whole runner graph — already landed.

## Solution

Convert each helper to use `execFile` via Node's `promisify`, so they return promises instead of blocking. Then run the independent ones concurrently with `Promise.all`. The longest one wins instead of all of them adding up.

Functions converted to async:

- `getFirstRemoteUrl` and `resolveRepoSlug` in `packages/cli/src/config.ts`
- `computeDirtySha` in `packages/cli/src/runner/dirty-sha.ts`
- `getChangedFiles` in `packages/cli/src/workflow/workflow-parser.ts`
- `resolveHeadSha`, `resolveBaseSha`, and `persistRunResult` in `packages/cli/src/commands/run.ts`

In `handleWorkflow`, the four startup calls — explicit-SHA resolution, dirty-tree commit, HEAD resolution, and remote-slug detection — now run concurrently. Same for the `--all` branch's branch-name and changed-files lookups.

Switching from `execSync("git command-string")` to `execFile("git", ["arg1", "arg2"])` also removes a shell-escaping step on every call. The arguments are passed as an array, not a single string, so there is no shell to escape them through.

This pull request does not touch the docker-side subprocess calls (`docker ps`, `docker network rm`, `docker volume prune`, …). Some of those are reached from signal handlers, which Node requires to be synchronous. Converting the remaining ones is a separate follow-up.

## Technical Summary

- New `execFileP = promisify(execFile)` in each touched file. Replaces direct `execSync` calls.
- `handleWorkflow`: a single `Promise.all` runs explicit-SHA, dirty-SHA, HEAD-SHA and remote-slug resolution in parallel. The local fall-through (`headSha ?? dirty ?? plain HEAD`) is unchanged.
- `runCmd --all`: a single `Promise.all` runs the branch lookup and the changed-files git diff together.
- `finalizeRun` is now async because `persistRunResult` is. Both call sites in `runCmd` `await` it.
- `runCmd`'s declared return type widened from `Promise<never>` to `Promise<void>` — the same final `process.exit` still runs, but the awaited `Promise<never>` confused the compiler's reachability analysis.
- Tests for `config.test.ts` and `runner/dirty-sha.test.ts` updated to `await` the now-async helpers.
- No behaviour change.

Verified locally with Node 24:

- `pnpm -r run typecheck` — clean
- `pnpm check` — clean
- Vitest: 754 of 754 tests pass (the docker-shutdown integration tests are excluded; they run `npx tsx -e` in an isolated process and trip over an unrelated local npm config quirk that also affects `main`).
- Full smoke suite (`pnpm agent-ci-dev run --all`): 45 of 45 jobs pass after one retry of the known-flaky nested-secrets test.

Refs #334.