### PR TITLE
Add machinen runtime (opt-in)

### DIFF
--- a/.changeset/bump-machinen-runtime.md
+++ b/.changeset/bump-machinen-runtime.md
@@ -1,0 +1,31 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+chore(deps): bump @machinen/runtime to 0.3.3
+
+Upgrades the optional machinen runtime dependency from 0.1.1 to 0.3.3.
+The 0.3 line replaces the prior FUSE-over-vsock live-mount with
+virtio-fs, which removes the per-file-operation RPC into Node and lets
+real CI workloads (tar extracts, `pnpm install`, `actions/setup-node`)
+run at native speed inside the microVM.
+
+Several regressions surfaced during integration with this repo and
+were fixed upstream before this bump:
+
+- 0.3.1 — virtio-fs returned EIO on writes that opened an existing
+  file with O_TRUNC / O_APPEND, on `cp` over an existing file, and on
+  `rename()` (the latter returned ENOSYS).
+- 0.3.2 — Node `fs.rm({ recursive: true })` cleanup hit EIO during
+  rmdir of populated directories (observed via
+  `actions/checkout`'s post-step cleanup).
+- 0.3.3 — `readlink` returned ENOSYS (observed via
+  `actions/setup-node`'s extraction of the Node tarball, which
+  contains a `bin/corepack` symlink), `link()` for hardlinks returned
+  ENOSYS, and `chmod +x` didn't propagate the execute bit so newly
+  created scripts couldn't be run.
+
+Verified end-to-end: `AGENT_CI_MACHINEN=1 agent-ci run --workflow
+.github/workflows/tests.yml` boots the microVM, runs the full agent-ci
+test suite inside it, and completes in 3m21s.

--- a/.changeset/machinen-runtime.md
+++ b/.changeset/machinen-runtime.md
@@ -1,0 +1,66 @@
+---
+"@redwoodjs/agent-ci": minor
+"dtu-github-actions": minor
+---
+
+feat(runner): introduce machinen runtime (opt-in)
+
+Adds a third runtime for `runs-on: ubuntu-*` jobs on arm64 hosts —
+microVMs via [`@machinen/runtime`](https://github.com/redwoodjs/machinen).
+Opt-in for now (`AGENT_CI_MACHINEN=1`); docker remains the default.
+See ADRs 0001 / 0002 / 0003 / 0004 in `docs/adr/` for the design.
+
+What ships:
+
+- **Runtime selection (ADR 0001).** New `Runtime` interface + registry
+  in `packages/cli/src/runner/runtime.ts`. Priority order
+  `[machinen, macos-vm, docker]`, with `AGENT_CI_RUNTIME` as a
+  within-OS-family override. The selector is wired into `run.ts` in
+  place of the previous docker-or-macos-vm `if`/`else`.
+- **Rootfs as a release asset (ADR 0004).** The runtime downloads
+  agent-ci's pre-baked rootfs from
+  `https://github.com/redwoodjs/agent-ci/releases/download/machinen-rootfs-latest/agent-ci-machinen-runner-arm64.tar.gz`
+  on first machinen use and caches at
+  `~/.cache/agent-ci/machinen/base.tar.gz`. Subsequent runs do a
+  conditional GET (`If-None-Match`) so re-bakes propagate without a
+  full re-download. The runtime falls back to the cached copy if the
+  network is unreachable.
+- **User override.** If `<repoRoot>/.github/agent-ci.machinen.tar.gz`
+  exists, that file is used verbatim — no download, no overlay. Lets
+  users hand-build their own machinen rootfs without touching agent-ci.
+- **Release-time bake.** `scripts/machinen-bake.mjs` and
+  `.github/workflows/machinen-rootfs.yml` produce the rootfs asset and
+  upload it to the `machinen-rootfs-latest` rolling release.
+  Manually triggered (`workflow_dispatch`); re-run on upstream
+  `actions/runner` bumps or apt updates.
+- **executeMachinenJob (end-to-end).** Boots a long-lived VM from the
+  resolved rootfs with `liveMounts` for work/shims/diag (+ signals
+  when `--pause-on-failure`); installs symlinks (`/home/runner/_work →
+/mnt/work` etc.) and the git shim via `vm.exec`; writes
+  `.runner`/`.credentials`/`.credentials_rsaparams` via `vm.writeFile`;
+  registers + seeds the runner with the per-job ephemeral DTU
+  (reachable from the guest at `192.168.127.254:<port>` through
+  gvproxy's user-mode NAT); launches `run.sh --once` with
+  `RUNNER_ALLOW_RUNASROOT=1`; streams stdout/stderr into the debug
+  log; polls `timeline.json` via the shared `timeline-sync` module
+  (extracted from `local-job.ts`); tears the VM down on completion.
+- **Pause-on-failure + retry** rides the same `signalsDir` filesystem
+  protocol the docker path uses. The signals dir is `liveMount`ed
+  into the guest at `/mnt/signals` and symlinked from
+  `/tmp/agent-ci-signals` at boot, so the wrapper's
+  `paused` / `step-output` writes propagate to the host and host-side
+  `retry` / `abort` writes propagate back into the guest — verified
+  end-to-end against the failing-step workflow.
+
+Behavior on existing installs:
+
+- **Docker users see no change.** `AGENT_CI_MACHINEN` is unset by
+  default, machinen's host capability check returns "not enabled", and
+  the selector picks docker exactly as before.
+- **macos-vm users see no change.** macOS jobs continue to route
+  through the macos-vm runtime when supported.
+
+Operational note: the `pnpm-workspace.yaml` adds `@machinen/*` to
+`minimumReleaseAgeExclude` so the global 7-day supply-chain guard
+doesn't block install on first-party packages co-authored by the same
+maintainers.

--- a/.github/workflows/machinen-rootfs.yml
+++ b/.github/workflows/machinen-rootfs.yml
@@ -1,0 +1,111 @@
+name: Machinen rootfs
+
+# Bakes the agent-ci machinen rootfs (debian-arm64 + nodejs/git/curl/jq/unzip +
+# GHA runner binary) and uploads it to the `machinen-rootfs-latest` rolling
+# release. The runtime downloads this asset on first machinen use.
+#
+# See docs/adr/0004-machinen-rootfs-as-release-asset.md.
+#
+# Manually triggered today (workflow_dispatch). Re-run when:
+#   - upstream actions/runner publishes a new patch we want to pick up
+#   - we add/remove apt packages from the bake spec (scripts/machinen-bake.mjs)
+#   - a security update lands in debian's apt mirror we want to bake in
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to upload the asset under"
+        required: false
+        default: "machinen-rootfs-latest"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.release_tag }}
+  cancel-in-progress: false
+
+jobs:
+  bake:
+    # arm64 darwin: GitHub-hosted M-series mac runner. Required because
+    # @machinen/runtime's VMM bindings only exist for arm64-darwin / arm64-linux,
+    # and `macos-15` is the smallest hosted runner that gives us either.
+    runs-on: macos-15
+    permissions:
+      contents: write
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          version: 10.30.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install
+
+      # @machinen/runtime ships VMM binaries non-executable in 0.1.1 across
+      # mke2fs / mksquashfs (see redwoodjs/machinen#309). The local-bake
+      # path needs them runnable; chmod here until upstream republishes.
+      - name: Workaround machinen#309 binary modes
+        run: |
+          find node_modules/.pnpm/@machinen+* \
+            -type f \( -name mke2fs -o -name mksquashfs -o -name gvproxy -o -name machinen-vm \) \
+            -exec chmod +x {} +
+
+      # @machinen/cli's first invocation populates ~/.machinen/runtime-v<ver>/bases/
+      # with the kernel/dtb/rootfs assets. We need them on the runner before
+      # provision() can boot the bake VM.
+      - name: Install @machinen/cli and warm base assets
+        env:
+          # The base assets live in a private GitHub release on redwoodjs/machinen.dev.
+          # Configure MACHINEN_RELEASE_TOKEN in the repo's secrets with a PAT that
+          # has `repo` scope on that release source.
+          GH_TOKEN: ${{ secrets.MACHINEN_RELEASE_TOKEN }}
+        run: |
+          npm install -g @machinen/cli@0.1.1
+          # First boot: machinen fetches base assets if not cached. Run a no-op
+          # cmd against a tiny image so we don't hold the runner for a full bake.
+          machinen boot -- /bin/true
+
+      - name: Bake rootfs
+        run: node scripts/machinen-bake.mjs --out dist/agent-ci-machinen-runner-arm64.tar.gz
+
+      - name: Verify rootfs tarball
+        run: |
+          ls -la dist/agent-ci-machinen-runner-arm64.tar.gz
+          # Sanity: assert the runner binary made it in.
+          tar -tzf dist/agent-ci-machinen-runner-arm64.tar.gz ./home/runner/run.sh \
+            || (echo "::error::baked rootfs is missing /home/runner/run.sh" && exit 1)
+          # Sanity: assert machinen guest tooling is present (this is what tells
+          # /init the rootfs is bootable — see redwoodjs/machinen#309 background).
+          tar -tzf dist/agent-ci-machinen-runner-arm64.tar.gz ./usr/sbin/machinen-supervisor \
+            || (echo "::error::baked rootfs is missing /usr/sbin/machinen-supervisor" && exit 1)
+
+      - name: Ensure rolling release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ inputs.release_tag }}"
+          if ! gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Machinen rootfs (rolling)" \
+              --notes "Auto-managed rolling release for the agent-ci machinen rootfs. \
+              The tag does not correspond to an agent-ci version — it points at the most \
+              recent successful bake. See docs/adr/0004-machinen-rootfs-as-release-asset.md." \
+              --prerelease
+          fi
+
+      - name: Upload rootfs asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ inputs.release_tag }}" \
+            dist/agent-ci-machinen-runner-arm64.tar.gz \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,77 @@
+# agent-ci — Domain Glossary
+
+Living document. Add terms as they're resolved during design discussions.
+
+## Terms
+
+### Runtime
+
+The container/VM layer where a job's compute runs. agent-ci ships three:
+
+- **`docker`** — runs the job in a Linux container via Dockerode.
+- **`macos-vm`** — runs the job in an Apple Virtualization.framework VM via `tart`.
+- **`machinen`** — runs the job in an arm64 Linux microVM via `@machinen/runtime`.
+  Installed as an `optionalDependency`, so it only resolves on supported
+  platforms (arm64 darwin/linux) and is absent elsewhere.
+
+**Selection.** A Runtime is selected per-job based on the job's `runs-on:`
+OS family, host capability, and user preference. Priority order (first
+matching supported runtime wins): `machinen`, `macos-vm`, `docker`.
+That means on an arm64 mac/linux host with machinen installed, `linux`
+jobs default to machinen; elsewhere they fall back to docker.
+
+**`AGENT_CI_RUNTIME` env var.** Overrides priority _within the candidate
+set for the job's OS family_. It is not an override of OS classification:
+setting `AGENT_CI_RUNTIME=docker` on a `runs-on: macos-15` job does not
+force docker — docker doesn't support macOS, so the job is skipped with
+the existing unsupported-OS warning.
+
+**Runtime interface.** Each runtime exposes:
+
+- `name` — registry key, AGENT_CI_RUNTIME value, and short display label.
+- `checkHost(): Promise<HostCapability>` — probed once per run at startup,
+  result cached.
+- `supportsJob(kind: RunnerOSKind): boolean` — does this runtime handle
+  that OS family?
+- `execute(job, opts): Promise<JobResult>` — opts are advisory; a runtime
+  may ignore fields it doesn't honor (e.g. macos-vm currently ignores
+  `pauseOnFailure` and `store`).
+
+**Not to be confused with:**
+
+- **Runner** — the GitHub Actions runner binary (`run.sh`) and its on-disk
+  install. A runtime _hosts_ a runner; they are not the same thing.
+- **Host** — the physical machine agent-ci runs on. `checkMacosVmHost()`
+  asks "can this host launch a macos-vm runtime?".
+
+### machinen rootfs
+
+The Linux arm64 rootfs that machinen boots a job into. Baked locally on
+the user's machine the first time a machinen job runs, cached in
+`~/.cache/agent-ci/machinen/`. The bake uses `provision()` from
+`@machinen/runtime` and installs a pinned set of packages: `nodejs`,
+`git`, `curl`, `ca-certificates`, `build-essential`, plus the GHA runner
+binary (pinned SHA). `run.sh`, workspace, and DTU credentials are
+injected per-job, not baked.
+
+The pre-baked-on-GitHub-Releases strategy (mirroring cirruslabs' tart
+images) is a follow-up — we can flip `image-mapping.ts` to point at
+release URLs later without touching the Runtime interface.
+
+### Workspace (run-dir)
+
+All runtimes share the existing `prepareWorkspace` (in `runner/workspace.ts`):
+the user's repo is copied — APFS CoW on macOS, rsync on Linux — into
+`<runDir>/work/<repoName>/<repoName>/`, respecting `.gitignore` so
+`node_modules` is excluded from the initial copy. The bind/live-mount
+target for each runtime is the **run dir**, not the user's working repo.
+
+- **docker** bind-mounts the run dir into the container at
+  `/github/workspace`.
+- **macos-vm** rsyncs the run dir into the VM (tart has no shared-fs
+  option).
+- **machinen** FUSE-over-vsock live-mounts the run dir into the guest
+  at `/github/workspace`. Same isolation semantics as docker: edits to
+  the user's repo do not appear in the VM until `syncWorkspaceForRetry`
+  re-syncs them; `node_modules` installed by a job lands in the run dir
+  (linux-arm64 binaries), not the user's IDE-facing repo.

--- a/docs/adr/0001-machinen-default-on-arm64.md
+++ b/docs/adr/0001-machinen-default-on-arm64.md
@@ -1,0 +1,31 @@
+# Machinen is the default runtime for `runs-on: ubuntu-*` on arm64 hosts
+
+When `@machinen/runtime` resolves (its `optionalDependencies` install
+arm64-darwin / arm64-linux only), agent-ci selects machinen ahead of docker
+for linux jobs. The selection priority is `[machinen, macos-vm, docker]` —
+machinen runs first when available; docker is the fallback for hosts where
+machinen's VMM optional dep didn't resolve. On x64 / non-supported hosts,
+docker remains the only linux candidate and there's no behavior change.
+
+`AGENT_CI_RUNTIME=docker` is the documented escape hatch for arm64 users
+who want to opt back into docker. The env var overrides priority _within_
+the candidate set for a job's OS family but does not override OS
+classification — setting `AGENT_CI_RUNTIME=docker` on a `runs-on: macos-15`
+job still routes through the unsupported-OS skip path.
+
+## Why
+
+Docker-first was the conservative alternative but would have left machinen's
+boot-time and isolation advantages behind a flag few users would discover.
+Treating optional-dep resolution as the opt-in signal gives the "just
+install agent-ci on my M-series mac and it's fast" path zero ceremony,
+while leaving Intel and x64 Linux users untouched.
+
+## Consequences
+
+- arm64 mac / linux users see their `runs-on: ubuntu-latest` jobs switch
+  substrate on upgrade. Documented in the changeset and release notes.
+- Mixed-OS runs that happen to use both macos-vm and machinen on the same
+  host do not need to coordinate hardware budget: macos-vm uses
+  Virtualization.framework (2-VM cap), machinen uses Hypervisor.framework
+  directly (no such cap).

--- a/docs/adr/0002-machinen-rootfs-baked-locally.md
+++ b/docs/adr/0002-machinen-rootfs-baked-locally.md
@@ -1,0 +1,33 @@
+# Machinen rootfs is baked on the user's machine on first use
+
+agent-ci does not ship or fetch a pre-baked machinen rootfs. The first time
+a machinen job runs, `runner/machinen/bake.ts` invokes `provision()` from
+`@machinen/runtime` to install a pinned set of packages (`nodejs`, `git`,
+`curl`, `ca-certificates`, `build-essential`, plus the GHA runner binary
+at a pinned SHA) into a tarball at
+`~/.cache/agent-ci/machinen/runner-ubuntu-arm64-<bake-script-sha>.tar.gz`.
+Subsequent jobs reuse the cached tarball. Concurrent first-use jobs share
+a single in-flight bake promise.
+
+The cache key is the bake-script SHA, so any change to the provisioned
+package set or runner-binary pin invalidates user caches automatically on
+upgrade.
+
+## Why
+
+The cirruslabs-style alternative — pre-bake the rootfs in CI and ship it
+as a GitHub Release artifact — would require standing up release-workflow
+infrastructure (arm64 build runner, release-tag baking job, image
+versioning policy) as a side-quest to a refactor. Keeping bake local
+keeps this PR shippable and defers the infrastructure question to a
+follow-up.
+
+## Consequences
+
+- First machinen job for a given user pays ~5-10 minutes of bake cost.
+- Rootfs contents depend on whatever apt mirror serves the user at bake
+  time. Pinning package versions in the bake script mitigates drift but
+  doesn't eliminate it.
+- Migrating to pre-baked release artifacts later is interface-preserving:
+  flip `image-mapping.ts` to resolve a release URL instead of the local
+  cache path. No Runtime-interface change required.

--- a/docs/adr/0003-machinen-execution-model.md
+++ b/docs/adr/0003-machinen-execution-model.md
@@ -1,0 +1,207 @@
+# Machinen execution model: how a job runs inside a microVM
+
+The docker runtime's `executeLocalJob` boots a container, bind-mounts the
+run dir, points the GHA runner at an ephemeral DTU on localhost, polls a
+timeline file, and supports pause-on-failure via shared signal files. The
+machinen runtime needs the same observable behaviour with a different
+substrate. This ADR pins down the substrate-specific decisions so
+`executeMachinenJob` can be implemented without re-litigating each one in
+review.
+
+ADR 0001 covers selection; ADR 0002 covers how the rootfs is produced
+(`docker export` of the same image the docker runtime uses). This ADR
+covers everything from VM boot to job-result handoff.
+
+## Boot
+
+`@machinen/runtime.boot({ image, cmd, env, name, liveMounts, timeoutMs })`,
+where `image` is the path returned by `bakeFromImage()`. The cmd is
+`["/bin/sh", "-c", "sleep infinity"]` — we keep the VM alive as a long
+shell session and drive everything through `vm.exec`/`vm.writeFile`. That
+inverts the docker model (where the container's CMD is a giant
+multi-line entrypoint script) but maps cleanly onto machinen's
+exec-over-vsock primitive and gives us per-step exit-code visibility
+that docker's stdio streaming can't match.
+
+`name` is the runner name (e.g. `agent-ci-machinen-432-j1`). It doubles
+as the lookup key for cross-process `attach({ name })`, which the retry
+path needs (§ Pause / retry).
+
+## Networking: host DTU ↔ guest
+
+`startEphemeralDtu` binds the DTU server to `0.0.0.0:<random>` on the
+host. The docker container reaches it via `host.docker.internal` or an
+`ExtraHosts` mapping. machinen uses gvproxy for user-mode networking;
+the guest sees the host at the gvproxy gateway IP **`192.168.127.1`**
+(the runtime's `guestAddr` default is `192.168.127.2`; the gateway is
+`.1`). gvproxy's user-mode NAT forwards `192.168.127.1:<port>` to the
+host's loopback transparently — no `portForward` needed, that primitive
+is for the opposite direction.
+
+The runner reaches the DTU at `http://192.168.127.1:<dtuPort>/`,
+threaded through:
+
+- `.runner` JSON (`serverUrl` + `gitHubUrl`)
+- `.credentials` (`authorizationUrl` + `oAuthEndpointUrl`)
+- Env vars consumed by step scripts (`GITHUB_API_URL`, etc.)
+
+These are the same fields `buildContainerEnv` populates today; the only
+swap is the hostname.
+
+## Filesystem mounts
+
+machinen's `liveMounts` is the closest analogue to a docker bind mount:
+FUSE-over-vsock, bidirectional, host writes are visible to the guest
+immediately and vice versa. The only constraint is that guest paths
+must live under `/mnt/`. We pick `liveMounts` over `mount` (copy-once
+via squashfs+overlay) because:
+
+- Pause/retry requires bidirectional writes (signals dir).
+- Step outputs and the timeline are read host-side from files written
+  inside the runner's `_diag` dir.
+- Workspace edits during retry need to propagate without re-baking
+  layers.
+
+| Docker bind                                              | machinen guest path     | Mode | Source                      |
+| -------------------------------------------------------- | ----------------------- | ---- | --------------------------- |
+| `hostWorkDir → /home/runner/_work`                       | `/mnt/work`             | rw   | `runDir/work`               |
+| `shimsDir → /tmp/agent-ci-shims`                         | `/mnt/agent-ci-shims`   | ro   | `runDir/shims`              |
+| `signalsDir → /tmp/agent-ci-signals` (paused/retry)      | `/mnt/agent-ci-signals` | rw   | `runDir/signals`            |
+| `diagDir → /home/runner/_diag`                           | `/mnt/agent-ci-diag`    | rw   | `runDir/diag`               |
+| `toolCacheDir → /opt/hostedtoolcache`                    | `/mnt/hostedtoolcache`  | rw   | `runDir/cache/tool`         |
+| `pnpmStoreDir → /home/runner/_work/.pnpm-store`          | `/mnt/pnpm-store`       | rw   | `runDir/cache/pnpm`         |
+| `npmCacheDir → /home/runner/.npm`                        | `/mnt/npm-cache`        | rw   | `runDir/cache/npm`          |
+| `bunCacheDir → /home/runner/.bun`                        | `/mnt/bun-cache`        | rw   | `runDir/cache/bun`          |
+| `playwrightCacheDir → /home/runner/.cache/ms-playwright` | `/mnt/playwright-cache` | rw   | `runDir/cache/playwright`   |
+| `warmModulesDir → .../node_modules`                      | `/mnt/warm-modules`     | rw   | `runDir/cache/warm-modules` |
+
+The runner expects fixed conventional paths (`/home/runner/_work`,
+`/opt/hostedtoolcache`, etc.), so the guest needs a layer that maps its
+`/mnt/...` set to those targets. Two viable approaches; we pick **(a)**:
+
+**(a) Symlinks installed at boot time.** First step inside the guest
+(via `vm.exec` after `boot()` returns) creates the symlinks:
+
+```sh
+ln -sfn /mnt/work             /home/runner/_work
+ln -sfn /mnt/agent-ci-shims   /tmp/agent-ci-shims
+ln -sfn /mnt/agent-ci-signals /tmp/agent-ci-signals
+ln -sfn /mnt/agent-ci-diag    /home/runner/_diag
+ln -sfn /mnt/hostedtoolcache  /opt/hostedtoolcache
+# ... etc
+```
+
+The runner-image's existing dirs at those paths are blown away by the
+symlink (`-f`). This stays local to the guest filesystem and doesn't
+require a rebuilt rootfs.
+
+**(b) Bake the symlinks into the rootfs.** Would survive into snapshots
+but couples the bake to runtime path conventions; rejected so the bake
+stays a faithful copy of the docker image.
+
+## Runner launch
+
+The docker side runs an inline entrypoint script (`buildContainerCmd`)
+inside the container CMD. We split that script into discrete `vm.exec`
+calls and one `vm.writeFile`:
+
+1. **Install symlinks** (above).
+2. **Install git shim**: `mv /usr/bin/git /usr/bin/git.real; cp /mnt/agent-ci-shims/git /usr/bin/git; chmod +x /usr/bin/git`. Identical to docker.
+3. **Write `.runner` JSON** via `vm.writeFile("/home/runner/.runner", json)`.
+4. **Write `.credentials` JSON** + `.credentials_rsaparams` (the long inline blob in `container-config.ts`). `vm.writeFile` handles base64 escaping so the heredoc gymnastics docker needs aren't needed.
+5. **`vm.exec("/home/runner/run.sh")`** with `execTimeoutMs: null` so it lives for the whole job. The exec call's `onStdout` / `onStderr` callbacks stream into the host-side debug-log file (same shape as docker's `container.logs({ follow: true })` pipe). The promise resolves with the runner's exit code when the job completes.
+
+The runner registers itself with the DTU on startup (`POST
+/_dtu/start-runner` already happens host-side before launch, same as
+docker). The DTU then dispatches the seeded job to the registered
+runner over the long-poll handshake; that flow is substrate-agnostic.
+
+## Timeline polling
+
+The DTU writes `timeline.json` and `outputs.json` to the host-side
+`logDir`. That's host filesystem — agent-ci already reads it directly,
+no guest involvement. The existing `syncTimelineToStore` loop works
+unchanged.
+
+## Pause / retry
+
+The docker path uses a shared `signalsDir` as the IPC channel:
+
+- Step wrapper inside the container writes `signalsDir/paused` on
+  failure.
+- Host polls `fs.existsSync(pausedSignalPath)`; emits `run.paused` event;
+  drops into stdin wait or detached mode.
+- On retry (Enter key, `agent-ci retry --name X` from another process,
+  or an external signal), host writes `signalsDir/retry`.
+- Step wrapper polls for the file, re-runs the failed step.
+
+Because `signalsDir` is live-mounted into the guest at
+`/mnt/agent-ci-signals`, all of this works identically — host writes
+land in the guest's view via FUSE-over-vsock, guest writes land on the
+host. No additional plumbing. The step wrapper already targets
+`/tmp/agent-ci-signals`, which our boot-time symlink points at
+`/mnt/agent-ci-signals`.
+
+Cross-process retry (`agent-ci retry --name X`) reuses the existing
+`writeDetachedMarker(runDir)` mechanism — the marker tells a separate
+agent-ci process which runDir owns a given runner name, and that
+process then `fs.writeFileSync(signalsDir/retry, "")` directly on the
+host. The running VM picks it up via the live mount. No
+`machinen.attach({ name })` call is needed for retry to work; we'd only
+need attach for direct guest interaction from a separate process (which
+isn't a current requirement).
+
+## Teardown
+
+`vm.exec("/home/runner/run.sh")` resolves when the runner exits. We
+then `vm.kill()` (SIGKILL to the VMM process). Host-side cleanup is
+identical to docker: remove temp dirs, close the ephemeral DTU,
+detach signal handlers.
+
+## Deferred from this design
+
+These need their own ADRs / tasks once the happy path lands:
+
+- **Service containers** (`jobs.<id>.services`). Easiest path: keep
+  service containers on docker (existing
+  `startServiceContainers`), expose each service port back to the
+  machinen VM via `portForward` (host: docker network port; guest:
+  same port at `192.168.127.1`). Hostname-based service references
+  (`postgres:5432`) need an `/etc/hosts` entry in the guest. Skip for
+  now; jobs that use `services:` fall through to docker via the
+  selector's normal precedence.
+- **Job-level `container:` directive.** When a workflow specifies
+  `container: image: foo`, the docker path swaps to `foo`'s image
+  directly. The machinen analogue is to bake `foo`'s rootfs via the
+  same `bakeFromImage` pipeline — same code, different `imageId`. Wire
+  this once the default path works.
+- **Concurrent VM cap.** macos-vm caps at 2 VMs via
+  `Virtualization.framework`. machinen uses Hypervisor.framework
+  directly (no such cap), but a host can still saturate on RAM. Today
+  agent-ci's `concurrencyLimiter` works on job count, not memory; the
+  machinen path may want a separate memory-aware throttle once we have
+  data.
+- **Workspace warming.** The docker path uses
+  `warmModulesDir → node_modules` for `~0ms cache`. The same mount
+  works on machinen, but the path is rooted under the runner's
+  `_work/<repo>/<repo>/node_modules`. Verify it survives the symlink
+  layer.
+
+## Why this design
+
+- **Live-mount everything** instead of `mount` (copy-once) because
+  pause/retry, output capture, and workspace-during-retry all need
+  bidirectional propagation. The snapshot tradeoff (`liveMount` doesn't
+  survive snapshot/restore) doesn't apply — we don't snapshot job VMs.
+- **Symlink at boot** instead of baking paths into the rootfs because
+  the bake is supposed to be a faithful copy of the docker image. ADR
+  0002's pre-baked-release-artifact follow-up keeps that property; if
+  we baked paths in, the artifact would diverge from docker.
+- **One `vm.exec` for run.sh** rather than reproducing the docker
+  entrypoint's inline shell. Each subprocess gets a clean exit code
+  back to the host, which is more honest about errors than docker's
+  "did the container exit zero" heuristic.
+- **Shared signals dir** unchanged from docker, because liveMount makes
+  it a no-op port. Reusing the existing protocol is cheaper than
+  designing a vsock-native retry channel and gets us a working
+  pause/retry without new code paths to test.

--- a/docs/adr/0004-machinen-rootfs-as-release-asset.md
+++ b/docs/adr/0004-machinen-rootfs-as-release-asset.md
@@ -1,0 +1,148 @@
+# Machinen rootfs ships as a GitHub Release asset
+
+ADR 0002 said agent-ci would bake the machinen rootfs on the user's
+machine the first time a machinen job runs, and noted "pre-baking and
+shipping the artifact" as a deferred follow-up. This ADR is that
+follow-up.
+
+agent-ci publishes a single pre-baked rootfs tarball as a GitHub Release
+asset on `redwoodjs/agent-ci`. At runtime the machinen path either
+downloads it (default) or uses a user-supplied tarball at
+`.github/agent-ci.machinen.tar.gz` (override). Either way machinen sees
+exactly one ready-to-boot rootfs — there's no runtime layering, no
+auto-translated Dockerfile, no per-job provision pass.
+
+## Asset shape
+
+- **Filename:** `agent-ci-machinen-runner-arm64.tar.gz`
+- **Hosting:** released asset on `redwoodjs/agent-ci`. Fetched via
+  `https://github.com/redwoodjs/agent-ci/releases/download/<tag>/agent-ci-machinen-runner-arm64.tar.gz`.
+  Public repo, anonymous fetch — no `gh auth` required on the user side.
+- **Versioning:** the runtime fetches from a moving `machinen-rootfs-latest`
+  release tag rather than pinning to the agent-ci package version. We
+  re-bake the asset as upstream `actions/runner` and the package set
+  drift; users get the latest baked rootfs without bumping agent-ci.
+  Cache key on disk is the asset's content-SHA (read via a HEAD against
+  the GitHub release API), so a re-bake invalidates user caches on next
+  run.
+- **Content:** debian-arm64 + machinen guest tooling (`/sbin/machinen-supervisor`
+  et al.) + the same package set the bake currently produces
+  (`nodejs git curl ca-certificates jq unzip` + GHA runner binary at
+  the pinned version). Roughly content-parity with
+  `ghcr.io/actions/actions-runner:latest`, minus anything not apt-installable.
+
+## User override: `.github/agent-ci.machinen.tar.gz`
+
+If `<repoRoot>/.github/agent-ci.machinen.tar.gz` exists, agent-ci uses
+it as the rootfs verbatim — no download, no overlay. The user is
+responsible for the file being machinen-compatible (debian arm64 +
+`/sbin/machinen-supervisor` + their workload). The expected production
+path is "user `gh release download`s our published base, runs their
+own `machinen bake` against it, drops the result in `.github/`" — or
+checks in a build script that does the same.
+
+Mirrors the docker runtime's `.github/agent-ci.Dockerfile` convention:
+agent-ci looks in `.github/` for a per-repo override of the runtime's
+default, no flag required.
+
+Cache invalidation for the override path is the file's content-SHA on
+disk — same shape as the download path.
+
+## What we explicitly do NOT do
+
+- **No automatic Dockerfile translation.** The docker runtime's
+  `.github/agent-ci.Dockerfile` is for the docker runtime; it is not
+  re-interpreted for machinen. An earlier draft of this design tried
+  to parse RUN apt-get install lines and layer them via
+  `provision({ base, install })`; we dropped it because the
+  translation was inherently lossy (no COPY, no custom RUN, no FROM
+  drift), and a power-user escape hatch (the override above) makes
+  the magic redundant.
+- **No runtime layering / provision pass.** Cold start = download
+  base (or read user override). Warm = read cache. Boot. No
+  in-between.
+- **No parallel docker image.** The docker runtime keeps using
+  `ghcr.io/actions/actions-runner:latest`. There is nothing agent-ci
+  needs to layer onto the upstream container.
+
+## Why latest-tag, not per-version
+
+- The rootfs content drifts on upstream cadence (apt mirror, runner
+  binary release), not agent-ci's. Pinning to agent-ci's version would
+  freeze the rootfs at agent-ci release time and accumulate drift
+  until the next agent-ci bump.
+- The asset is large (~300 MB) and we don't want one copy per agent-ci
+  version inflating release storage.
+- The content-SHA cache key means a user's cache only invalidates when
+  the rootfs actually changes — agent-ci upgrades don't force a
+  re-download unless the rootfs itself moved.
+
+## Runtime flow
+
+1. **Override check:** if `<repoRoot>/.github/agent-ci.machinen.tar.gz`
+   exists, that's the rootfs. Done.
+2. **Download base if missing:**
+   - HEAD `.../releases/download/machinen-rootfs-latest/<filename>`
+     for the content-SHA.
+   - If `~/.cache/agent-ci/machinen/base-<contentSha>.tar.gz` exists,
+     use it.
+   - Otherwise stream the body to `<path>.partial`, atomic rename.
+     Single-flight on cold first use.
+3. `boot({ image: <rootfsPath>, ... })`.
+
+The user override and the download both produce a single tarball path
+that flows into `boot()`. No branching downstream.
+
+## Release workflow
+
+Add a release-time job to `redwoodjs/agent-ci`'s CI:
+
+1. Spin up an arm64 host (M-series mac runner, or arm64-linux).
+2. `pnpm install` agent-ci.
+3. Run a thin `pnpm machinen:bake` script that produces
+   `agent-ci-machinen-runner-arm64.tar.gz`. The script lives
+   under `scripts/` and uses `@machinen/runtime.provision()` directly
+   with our pinned package list + GHA runner binary URL. It is
+   release-only tooling, not shipped to users.
+4. `gh release upload machinen-rootfs-latest agent-ci-machinen-runner-arm64.tar.gz --clobber`.
+
+The `machinen-rootfs-latest` release is a hand-managed "rolling" tag.
+Tag bumps happen when we want to refresh the rootfs (upstream runner
+bump, new package in the spec, security update).
+
+## Consequences
+
+- **First-run UX for machinen flips from "cold bake takes minutes" to
+  "cold download takes seconds"** (asset is ~300 MB; throttled by
+  upstream HTTPS and disk write speed but not by apt / VM boot).
+  Warm runs unchanged.
+- **The user-facing runtime `bakeRootfs()` codepath collapses to a
+  download.** The full provision pipeline (provision against
+  machinen-debian + GHA runner download) moves out of
+  `packages/cli/src/runner/machinen/bake.ts` into a release-only
+  script under `scripts/`.
+- **`dockerfile-overlay.ts` and its tests are deleted.** The parser
+  and overlay-only provision branch are no longer reachable. Users who
+  need extras either: (a) drop their own
+  `.github/agent-ci.machinen.tar.gz`, or (b) run the job through the
+  docker runtime (`AGENT_CI_RUNTIME=docker`).
+- **We take on the operational responsibility of keeping the asset
+  fresh.** If `machinen-rootfs-latest` falls behind a security-
+  relevant apt update, every machinen user is stuck on a stale base
+  until we re-bake.
+- **We're committing to keep the rootfs `actions/actions-runner`-compatible
+  in content.** If a workflow runs green on the docker runtime today,
+  the same content should be present in our pre-baked machinen rootfs.
+
+## Open questions for the implementation PRs
+
+- How do we test the asset end-to-end in CI without re-baking on every
+  PR? Probably: re-bake only on `main` or on a manually-triggered
+  workflow; PRs use the most recent release.
+- Should the `machinen-rootfs-latest` release also publish the base
+  rootfs for non-arm64-linux platforms eventually (e.g. arm64 inside a
+  cross-arch macOS bake)? Out of scope here; just naming the file with
+  the arch so it's easy to add `_x64` later.
+- Asset integrity: the runtime should verify the downloaded body
+  against the GitHub release API's SHA-256. ADR 0002's `.partial` →
+  final rename pattern is preserved.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,7 +53,7 @@
     "vitest": "^4.0.18"
   },
   "optionalDependencies": {
-    "@machinen/runtime": "0.1.1"
+    "@machinen/runtime": "0.3.3"
   },
   "engines": {
     "node": ">=22"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,6 +52,9 @@
     "@types/node": "^22.10.2",
     "vitest": "^4.0.18"
   },
+  "optionalDependencies": {
+    "@machinen/runtime": "0.1.1"
+  },
   "engines": {
     "node": ">=22"
   }

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -15,9 +15,8 @@ import {
   getWorkingDirectory,
 } from "../output/working-directory.ts";
 import { debugCli } from "../output/debug.ts";
-import { executeLocalJob, getDocker } from "../runner/local-job.ts";
-import { executeMacosVmJob } from "../runner/macos-vm/macos-vm-job.ts";
-import { checkMacosVmHost } from "../runner/macos-vm/host-capability.ts";
+import { getDocker } from "../runner/local-job.ts";
+import { probeRuntimes, selectRuntime } from "../runner/runtime.ts";
 import {
   discoverRunnerImage,
   ensureRunnerImage,
@@ -48,7 +47,6 @@ import {
   classifyRunsOn,
   isUnsupportedOS,
   formatUnsupportedOSWarning,
-  type RunnerOSKind,
 } from "../runner/runs-on-compat.ts";
 import { resolveJobOutputs } from "../runner/result-builder.ts";
 import type { Job } from "../types.ts";
@@ -1209,20 +1207,32 @@ async function handleWorkflow(options: {
     steps: [],
   });
   const warnedUnsupportedOS = new Set<string>();
-  const macosVmHost = checkMacosVmHost();
+  // Probe every runtime's host capability once. ADR 0001 + CONTEXT.md
+  // describe the selection rules; priority order is [machinen, macos-vm,
+  // docker], with AGENT_CI_RUNTIME re-ordering candidates within a job's
+  // OS family.
+  const probedRuntimes = probeRuntimes();
+  const runtimeOverride = process.env.AGENT_CI_RUNTIME || null;
   const classifyJob = (ej: ExpandedJob) => {
     const labels = parseJobRunsOn(ej.workflowPath, ej.sourceTaskName ?? ej.taskName);
     return { labels, kind: classifyRunsOn(labels) };
   };
-  const canRunMacosHere = (kind: RunnerOSKind) => kind === "macos" && macosVmHost.supported;
   const maybeSkipUnsupportedOS = (ej: ExpandedJob): JobResult | null => {
     const { labels, kind } = classifyJob(ej);
-    if (!isUnsupportedOS(kind) || canRunMacosHere(kind)) {
+    if (selectRuntime(kind, probedRuntimes, runtimeOverride)) {
+      return null;
+    }
+    if (!isUnsupportedOS(kind)) {
+      // "linux" or "other" with no candidate runtime — should not happen
+      // because docker.checkHost() always returns supported. Defer to the
+      // existing dispatch error path rather than silently skipping.
       return null;
     }
     if (!warnedUnsupportedOS.has(ej.taskName)) {
       warnedUnsupportedOS.add(ej.taskName);
-      const capability = kind === "macos" && !macosVmHost.supported ? macosVmHost : undefined;
+      const macosVm = probedRuntimes.find((p) => p.runtime.name === "macos-vm");
+      const capability =
+        kind === "macos" && macosVm && !macosVm.host.supported ? macosVm.host : undefined;
       process.stderr.write(
         formatUnsupportedOSWarning(ej.taskName, labels, kind, capability) + "\n\n",
       );
@@ -1232,10 +1242,12 @@ async function handleWorkflow(options: {
   // Returns the executor for a job. Callers have already filtered out
   // OS-skipped jobs via maybeSkipUnsupportedOS.
   const runJobExecutor = (ej: ExpandedJob, job: Job): Promise<JobResult> => {
-    if (canRunMacosHere(classifyJob(ej).kind)) {
-      return executeMacosVmJob(job);
+    const { kind } = classifyJob(ej);
+    const runtime = selectRuntime(kind, probedRuntimes, runtimeOverride);
+    if (!runtime) {
+      throw new Error(`No runtime available for job ${ej.taskName} (runs-on kind: ${kind}).`);
     }
-    return executeLocalJob(job, { pauseOnFailure, store });
+    return runtime.execute(job, { pauseOnFailure, store });
   };
 
   // For single-job workflows, run directly without extra orchestration

--- a/packages/cli/src/docker/image-pull.test.ts
+++ b/packages/cli/src/docker/image-pull.test.ts
@@ -7,7 +7,19 @@ import { resolveDockerSocket } from "./docker-socket.ts";
 // Uses hello-world (~13 KB) to keep pull time minimal.
 const TEST_IMAGE = "hello-world:latest";
 
-describe("ensureImagePulled", () => {
+async function hasDocker(): Promise<boolean> {
+  try {
+    const socket = resolveDockerSocket();
+    await new Docker({ socketPath: socket.socketPath }).ping();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const DOCKER_AVAILABLE = await hasDocker();
+
+describe.skipIf(!DOCKER_AVAILABLE)("ensureImagePulled", () => {
   let docker: Docker;
 
   beforeAll(async () => {

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -18,8 +18,8 @@ import {
 } from "../docker/service-containers.ts";
 import { killRunnerContainers } from "../docker/shutdown.ts";
 import { startEphemeralDtu } from "dtu-github-actions/ephemeral";
-import { type JobResult, tailLogFile } from "../output/reporter.ts";
-import { RunStateStore, type StepState } from "../output/run-state.ts";
+import { type JobResult } from "../output/reporter.ts";
+import { RunStateStore } from "../output/run-state.ts";
 
 import { writeJobMetadata } from "./metadata.ts";
 import { writeGitShim } from "./git-shim.ts";
@@ -39,6 +39,11 @@ import { buildJobResult, isJobSuccessful } from "./result-builder.ts";
 import { ensureImagePulled } from "../docker/image-pull.ts";
 import { wrapJobSteps, appendOutputCaptureStep } from "./step-wrapper.ts";
 import { syncWorkspaceForRetry } from "./sync.ts";
+import {
+  syncTimelineToStore,
+  type TimelineSyncContext,
+  type TimelineSyncState,
+} from "./timeline-sync.ts";
 import {
   discoverRunnerImage,
   ensureRunnerImage,
@@ -281,236 +286,6 @@ async function seedRunnerBinaryToHost(docker: Docker, hostRunnerSeedDir: string)
     } catch {
       /* not present */
     }
-  }
-}
-
-/**
- * Mutable state tracked across timeline-poll ticks. The store-sync helper
- * mutates the fields in place; the polling loop and the rest of
- * `executeLocalJob` read them once the loop finishes.
- */
-type TimelineSyncState = {
-  lastSeenAttempt: number;
-  isPaused: boolean;
-  pausedAtMs: number | null;
-  pausedStepName: string | null;
-  isBooting: boolean;
-  lastFailedStep: string | null;
-};
-
-/** Read-only inputs the store-sync helper needs but does not mutate. */
-type TimelineSyncContext = {
-  pauseOnFailure: boolean;
-  pausedSignalPath: string;
-  signalsDir: string;
-  timelinePath: string;
-  bootStart: number;
-  containerName: string;
-  store: RunStateStore | undefined;
-  /** Called the first time a pause is detected — sets up the Enter-to-retry stdin listener. */
-  onNewPause: () => void;
-};
-
-/** Result of folding the timeline-records list into a render-ready shape. */
-type BuiltSteps = {
-  newSteps: StepState[];
-  totalDurationMs: number | undefined;
-  jobFinished: boolean;
-};
-
-/**
- * Fold the raw actions-runner timeline records into the `StepState[]` shape
- * the renderer expects. Mutates `state.lastFailedStep` when a step result is
- * "failed". Skips duplicate names; the second occurrence (e.g. for a "Post"
- * step) triggers a synthetic "Post Setup" row at the end.
- */
-function buildStepsFromTimeline(steps: any[], state: TimelineSyncState): BuiltSteps {
-  const seenNames = new Set<string>();
-  let hasPostSteps = false;
-  let completeJobRecord: any = null;
-
-  const preCountNames = new Set<string>();
-  for (const r of steps) {
-    if (!preCountNames.has(r.name)) {
-      preCountNames.add(r.name);
-    } else {
-      hasPostSteps = true;
-    }
-  }
-
-  let stepIdx = 0;
-  const newSteps: StepState[] = [];
-
-  for (const r of steps) {
-    if (seenNames.has(r.name)) {
-      continue;
-    }
-    seenNames.add(r.name);
-
-    if (r.name === "Complete job") {
-      completeJobRecord = r;
-      continue;
-    }
-    stepIdx++;
-
-    const durationMs =
-      r.startTime && r.finishTime
-        ? new Date(r.finishTime).getTime() - new Date(r.startTime).getTime()
-        : undefined;
-
-    let status: StepState["status"];
-    if (!r.result && r.state !== "completed") {
-      if (r.startTime) {
-        status = state.isPaused && state.pausedStepName === r.name ? "paused" : "running";
-      } else {
-        status = "pending";
-      }
-    } else {
-      const result = (r.result || "").toLowerCase();
-      if (result === "failed") {
-        state.lastFailedStep = r.name;
-        status = "failed";
-      } else if (result === "skipped") {
-        status = "skipped";
-      } else {
-        status = "completed";
-      }
-    }
-
-    newSteps.push({
-      name: r.name,
-      index: stepIdx,
-      status,
-      startedAt: r.startTime,
-      completedAt: r.finishTime,
-      durationMs,
-    });
-  }
-
-  const jobFinished = !!completeJobRecord?.result;
-
-  if (hasPostSteps && jobFinished) {
-    stepIdx++;
-    newSteps.push({ name: "Post Setup", index: stepIdx, status: "completed" });
-  }
-
-  if (completeJobRecord && jobFinished) {
-    stepIdx++;
-    const durationMs =
-      completeJobRecord.startTime && completeJobRecord.finishTime
-        ? new Date(completeJobRecord.finishTime).getTime() -
-          new Date(completeJobRecord.startTime).getTime()
-        : undefined;
-    newSteps.push({
-      name: "Complete job",
-      index: stepIdx,
-      status: "completed",
-      startedAt: completeJobRecord.startTime,
-      completedAt: completeJobRecord.finishTime,
-      durationMs,
-    });
-  }
-
-  // Total job duration spans first step start to last step end.
-  let totalDurationMs: number | undefined;
-  if (jobFinished) {
-    const allTimes = steps
-      .filter((r) => r.startTime && r.finishTime)
-      .map((r) => ({
-        start: new Date(r.startTime).getTime(),
-        end: new Date(r.finishTime).getTime(),
-      }));
-    if (allTimes.length > 0) {
-      const earliest = Math.min(...allTimes.map((t) => t.start));
-      const latest = Math.max(...allTimes.map((t) => t.end));
-      const ms = latest - earliest;
-      if (!isNaN(ms) && ms >= 0) {
-        totalDurationMs = ms;
-      }
-    }
-  }
-
-  return { newSteps, totalDurationMs, jobFinished };
-}
-
-/**
- * One poll tick of the actions-runner timeline.json into the RunStateStore.
- * Reads the paused-signal file (if `pauseOnFailure` is set) and the timeline
- * JSON; updates the store and the mutable `state` in place. Errors are
- * swallowed — this is best-effort and runs every 100ms.
- */
-function syncTimelineToStore(state: TimelineSyncState, ctx: TimelineSyncContext): void {
-  try {
-    // ── Pause-on-failure: check for paused signal ───────────────────────────
-    if (ctx.pauseOnFailure && fs.existsSync(ctx.pausedSignalPath)) {
-      const content = fs.readFileSync(ctx.pausedSignalPath, "utf-8").trim();
-      const lines = content.split("\n");
-      state.pausedStepName = lines[0] || null;
-      const attempt = parseInt(lines[1] || "1", 10);
-      const isNewAttempt = attempt !== state.lastSeenAttempt;
-      if (isNewAttempt) {
-        state.lastSeenAttempt = attempt;
-        state.isPaused = true;
-        state.pausedAtMs = Date.now();
-        ctx.onNewPause();
-      }
-
-      // Read output captured by the wrapper script's tee — written directly
-      // to the signals dir so it's always available when paused.
-      const tailLines = tailLogFile(path.join(ctx.signalsDir, "step-output"), 20);
-
-      ctx.store?.updateJob(ctx.containerName, {
-        status: "paused",
-        pausedAtStep: state.pausedStepName || undefined,
-        ...(isNewAttempt && state.pausedAtMs !== null
-          ? { pausedAtMs: new Date(state.pausedAtMs).toISOString(), attempt: state.lastSeenAttempt }
-          : {}),
-        lastOutputLines: tailLines,
-      });
-    } else if (state.isPaused && !fs.existsSync(ctx.pausedSignalPath)) {
-      // Pause signal removed — job is retrying
-      state.isPaused = false;
-      state.pausedAtMs = null;
-      ctx.store?.updateJob(ctx.containerName, { status: "running", pausedAtMs: undefined });
-    }
-
-    if (!fs.existsSync(ctx.timelinePath)) {
-      return;
-    }
-
-    const records = JSON.parse(fs.readFileSync(ctx.timelinePath, "utf-8")) as any[];
-    const steps = records
-      .filter((r) => r.type === "Task" && r.name)
-      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
-
-    if (steps.length === 0) {
-      return;
-    }
-
-    // ── Transition from booting to running on first timeline entry ──────────
-    if (state.isBooting) {
-      state.isBooting = false;
-      debugBoot(`${ctx.containerName} total: ${Date.now() - ctx.bootStart}ms`);
-      ctx.store?.updateJob(ctx.containerName, {
-        status: state.isPaused ? "paused" : "running",
-        bootDurationMs: Date.now() - ctx.bootStart,
-      });
-    }
-
-    const { newSteps, totalDurationMs, jobFinished } = buildStepsFromTimeline(steps, state);
-
-    ctx.store?.updateJob(ctx.containerName, {
-      steps: newSteps,
-      ...(jobFinished
-        ? {
-            status: state.lastFailedStep ? "failed" : "completed",
-            failedStep: state.lastFailedStep || undefined,
-            durationMs: totalDurationMs,
-          }
-        : {}),
-    });
-  } catch {
-    // Best-effort
   }
 }
 

--- a/packages/cli/src/runner/machinen/host-capability.test.ts
+++ b/packages/cli/src/runner/machinen/host-capability.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { checkMachinenHost } from "./host-capability.ts";
+
+describe("checkMachinenHost", () => {
+  let original: string | undefined;
+  beforeEach(() => {
+    original = process.env.AGENT_CI_MACHINEN;
+    process.env.AGENT_CI_MACHINEN = "1";
+  });
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.AGENT_CI_MACHINEN;
+    } else {
+      process.env.AGENT_CI_MACHINEN = original;
+    }
+  });
+
+  it("returns supported on arm64 darwin when @machinen/runtime resolves and AGENT_CI_MACHINEN=1", () => {
+    const cap = checkMachinenHost({
+      platform: "darwin",
+      arch: "arm64",
+      resolveRuntime: () => true,
+    });
+    expect(cap.supported).toBe(true);
+  });
+
+  it("returns supported on arm64 linux when @machinen/runtime resolves and AGENT_CI_MACHINEN=1", () => {
+    const cap = checkMachinenHost({
+      platform: "linux",
+      arch: "arm64",
+      resolveRuntime: () => true,
+    });
+    expect(cap.supported).toBe(true);
+  });
+
+  it("is gated off by default (AGENT_CI_MACHINEN unset)", () => {
+    delete process.env.AGENT_CI_MACHINEN;
+    const cap = checkMachinenHost({
+      platform: "darwin",
+      arch: "arm64",
+      resolveRuntime: () => true,
+    });
+    expect(cap.supported).toBe(false);
+    if (!cap.supported) {
+      expect(cap.reason).toMatch(/not yet enabled/);
+      expect(cap.hint).toMatch(/AGENT_CI_MACHINEN=1/);
+    }
+  });
+
+  it("rejects x64 hosts with an arch-specific reason", () => {
+    const cap = checkMachinenHost({
+      platform: "linux",
+      arch: "x64",
+      resolveRuntime: () => true,
+    });
+    expect(cap.supported).toBe(false);
+    if (!cap.supported) {
+      expect(cap.reason).toMatch(/arm64/);
+      expect(cap.reason).toMatch(/x64/);
+    }
+  });
+
+  it("rejects windows hosts with a platform-specific reason", () => {
+    const cap = checkMachinenHost({
+      platform: "win32",
+      arch: "arm64",
+      resolveRuntime: () => true,
+    });
+    expect(cap.supported).toBe(false);
+    if (!cap.supported) {
+      expect(cap.reason).toMatch(/macOS or Linux/);
+    }
+  });
+
+  it("rejects arm64 hosts where @machinen/runtime is missing", () => {
+    const cap = checkMachinenHost({
+      platform: "darwin",
+      arch: "arm64",
+      resolveRuntime: () => false,
+    });
+    expect(cap.supported).toBe(false);
+    if (!cap.supported) {
+      expect(cap.reason).toMatch(/@machinen\/runtime/);
+    }
+  });
+});

--- a/packages/cli/src/runner/machinen/host-capability.ts
+++ b/packages/cli/src/runner/machinen/host-capability.ts
@@ -1,0 +1,67 @@
+import { createRequire } from "node:module";
+
+import type { HostCapability } from "../runtime.ts";
+
+export interface MachinenHostEnv {
+  platform?: NodeJS.Platform;
+  arch?: string;
+  resolveRuntime?: () => boolean;
+}
+
+function defaultResolveRuntime(): boolean {
+  try {
+    const require = createRequire(import.meta.url);
+    require.resolve("@machinen/runtime");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Can the host run the machinen runtime? machinen requires an arm64
+// linux/darwin host with the `@machinen/runtime` optional dependency
+// resolved. The optionalDependencies of `@machinen/runtime` restrict its
+// VMM bindings to arm64-darwin / arm64-linux, so on any other host the
+// require-resolve probe alone is sufficient — but we still check
+// platform/arch first so the warning message is specific.
+//
+// Implementation gate: `executeMachinenJob` is currently a scaffold that
+// throws `MachinenNotImplementedError`. To avoid making machinen the
+// silently-selected runtime for every linux job on a supported host (and
+// thereby breaking docker fallback), we require an explicit opt-in via
+// `AGENT_CI_MACHINEN=1` until the execute path lands. Once the runtime
+// is wired end-to-end (tasks #13 / #14), drop this gate.
+export function checkMachinenHost(env: MachinenHostEnv = {}): HostCapability {
+  const platform = env.platform ?? process.platform;
+  const arch = env.arch ?? process.arch;
+  const resolveRuntime = env.resolveRuntime ?? defaultResolveRuntime;
+
+  if (platform !== "darwin" && platform !== "linux") {
+    return {
+      supported: false,
+      reason: `machinen requires a macOS or Linux host (got ${platform}).`,
+    };
+  }
+  if (arch !== "arm64") {
+    return {
+      supported: false,
+      reason: `machinen requires an arm64 host (got ${arch}).`,
+      hint: "Docker remains the default Linux runtime on x64 hosts.",
+    };
+  }
+  if (!resolveRuntime()) {
+    return {
+      supported: false,
+      reason: "machinen optional dependency `@machinen/runtime` did not resolve.",
+      hint: "This usually means the package manager skipped it. Re-install dependencies; on supported hosts (arm64 darwin/linux) it installs automatically.",
+    };
+  }
+  if (process.env.AGENT_CI_MACHINEN !== "1") {
+    return {
+      supported: false,
+      reason: "machinen runtime is not yet enabled (execute path is in development).",
+      hint: "Set AGENT_CI_MACHINEN=1 to opt in once the runtime is fully wired.",
+    };
+  }
+  return { supported: true };
+}

--- a/packages/cli/src/runner/machinen/image-mapping.test.ts
+++ b/packages/cli/src/runner/machinen/image-mapping.test.ts
@@ -1,0 +1,53 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import { Readable } from "node:stream";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resolveMachinenImage } from "./image-mapping.ts";
+import { __test_resetInFlight, OVERRIDE_PATH_FRAGMENT } from "./rootfs.ts";
+
+const fetcher: typeof fetch = (async () =>
+  ({
+    status: 200,
+    statusText: "OK",
+    ok: true,
+    body: Readable.from([Buffer.from("default-base")]) as unknown as ReadableStream<Uint8Array>,
+    headers: { get: () => null } as Response["headers"],
+  }) as unknown as Response) as typeof fetch;
+
+describe("resolveMachinenImage", () => {
+  let repoRoot: string;
+  let cacheRoot: string;
+  beforeEach(async () => {
+    __test_resetInFlight();
+    repoRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "image-repo-"));
+    cacheRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "image-cache-"));
+  });
+  afterEach(async () => {
+    await fsp.rm(repoRoot, { recursive: true, force: true });
+    await fsp.rm(cacheRoot, { recursive: true, force: true });
+  });
+
+  it("picks up .github/agent-ci.machinen.tar.gz when present", async () => {
+    const override = path.join(repoRoot, OVERRIDE_PATH_FRAGMENT);
+    await fsp.mkdir(path.dirname(override), { recursive: true });
+    await fsp.writeFile(override, "user-rootfs");
+    const img = await resolveMachinenImage({ repoRoot, cacheRoot, fetcher });
+    expect(img.source).toBe("override");
+    expect(img.rootfsPath).toBe(override);
+  });
+
+  it("downloads when no override is present", async () => {
+    const img = await resolveMachinenImage({
+      repoRoot,
+      cacheRoot,
+      url: "https://example.test/rootfs.tar.gz",
+      fetcher,
+    });
+    expect(img.source).toBe("downloaded");
+    expect(fs.existsSync(img.rootfsPath)).toBe(true);
+  });
+});

--- a/packages/cli/src/runner/machinen/image-mapping.ts
+++ b/packages/cli/src/runner/machinen/image-mapping.ts
@@ -1,0 +1,20 @@
+// Map a job to a machinen rootfs.
+//
+// See ADR 0004. Two outcomes:
+//   - Repo has `.github/agent-ci.machinen.tar.gz` → that file is the
+//     rootfs.
+//   - Otherwise → use the pre-baked rootfs downloaded from agent-ci's
+//     `machinen-rootfs-latest` GitHub release.
+
+import { ensureMachinenRootfs, type ResolveOpts, type RootfsSource } from "./rootfs.ts";
+
+export interface MachinenImage {
+  /** Absolute path to the rootfs tarball machinen.boot() consumes. */
+  rootfsPath: string;
+  source: RootfsSource;
+}
+
+export async function resolveMachinenImage(opts: ResolveOpts): Promise<MachinenImage> {
+  const rootfs = await ensureMachinenRootfs(opts);
+  return { rootfsPath: rootfs.path, source: rootfs.source };
+}

--- a/packages/cli/src/runner/machinen/machinen-job.e2e.test.ts
+++ b/packages/cli/src/runner/machinen/machinen-job.e2e.test.ts
@@ -1,0 +1,126 @@
+// End-to-end smoke for the machinen runtime.
+//
+// Spawns the CLI as a child process — exactly what a user runs — with
+// `AGENT_CI_MACHINEN=1`, against a tiny generated workflow. Asserts
+// the run completes successfully.
+//
+// Skipped unless ALL of:
+//   - arm64 darwin/linux host (machinen's only supported platforms)
+//   - `AGENT_CI_MACHINEN_E2E=1` env (opt-in; the test takes ~30s,
+//     needs a working machinen install, and isn't free)
+//   - A baked rootfs available locally (either the official cached
+//     download at ~/.cache/agent-ci/machinen/base.tar.gz, OR any
+//     `rootfs-*.tar.gz` left over from a prior bake)
+//
+// The test reuses the cached rootfs as a per-repo override file
+// (`.github/agent-ci.machinen.tar.gz`) so it doesn't need network
+// access for the rootfs itself. The runtime still needs
+// `@machinen/runtime`, the VMM binaries (chmod'd executable — see
+// redwoodjs/machinen#309), and the kernel + dtb base assets in
+// `~/.machinen/runtime-v<ver>/bases/`.
+
+import { execFile } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, writeFileSync } from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+const execFileP = promisify(execFile);
+
+function findCachedRootfs(): string | null {
+  const cacheRoot = path.join(os.homedir(), ".cache", "agent-ci", "machinen");
+  if (!existsSync(cacheRoot)) {
+    return null;
+  }
+  const base = path.join(cacheRoot, "base.tar.gz");
+  if (existsSync(base)) {
+    return base;
+  }
+  const entries = readdirSync(cacheRoot)
+    .filter((n) => n.startsWith("rootfs-") && n.endsWith(".tar.gz"))
+    .sort();
+  return entries.length > 0 ? path.join(cacheRoot, entries[0]) : null;
+}
+
+const ROOTFS = findCachedRootfs();
+const SHOULD_RUN =
+  process.env.AGENT_CI_MACHINEN_E2E === "1" &&
+  process.platform === "darwin" &&
+  process.arch === "arm64" &&
+  ROOTFS !== null;
+
+describe.skipIf(!SHOULD_RUN)("machinen e2e (real VM)", () => {
+  it("boots, runs a tiny workflow inside the guest, exits successfully", async () => {
+    // ── Build a self-contained test repo with the override rootfs ───
+    const repoRoot = mkdtempSync(path.join(os.tmpdir(), "machinen-e2e-"));
+    try {
+      const workflowsDir = path.join(repoRoot, ".github", "workflows");
+      await fsp.mkdir(workflowsDir, { recursive: true });
+      // Drop the override rootfs so we don't depend on network.
+      await fsp.copyFile(ROOTFS!, path.join(repoRoot, ".github", "agent-ci.machinen.tar.gz"));
+      writeFileSync(
+        path.join(workflowsDir, "smoke.yml"),
+        [
+          "name: smoke",
+          "on: push",
+          "jobs:",
+          "  hello:",
+          "    runs-on: ubuntu-latest",
+          "    steps:",
+          "      - run: echo hello-from-machinen-e2e",
+        ].join("\n") + "\n",
+      );
+
+      // Minimal git so resolveRepoSlug + resolveHeadSha succeed. The
+      // CLI reads HEAD and the remote slug at startup; without a real
+      // commit it errors out before reaching the runtime selector.
+      await execFileP("git", ["init", "-q", "-b", "main"], { cwd: repoRoot });
+      await execFileP("git", ["remote", "add", "origin", "https://github.com/test/repo.git"], {
+        cwd: repoRoot,
+      });
+      await execFileP("git", ["add", "-A"], { cwd: repoRoot });
+      await execFileP(
+        "git",
+        ["-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "init"],
+        { cwd: repoRoot },
+      );
+
+      const cliPath = path.resolve(
+        path.dirname(new URL(import.meta.url).pathname),
+        "../../../../cli/src/cli.ts",
+      );
+
+      // ── Run the CLI through machinen ──────────────────────────────
+      const { stdout, stderr } = await execFileP(
+        "node",
+        [
+          cliPath,
+          "run",
+          "--workflow",
+          path.join(workflowsDir, "smoke.yml"),
+          "--working-directory",
+          repoRoot,
+        ],
+        {
+          env: {
+            ...process.env,
+            AGENT_CI_MACHINEN: "1",
+            GITHUB_REPO: "test/repo",
+          },
+          timeout: 120_000,
+          maxBuffer: 16 * 1024 * 1024,
+        },
+      );
+
+      // The CLI's summary section is the contract a user reads. Look
+      // for "1 passed" in the standard summary block.
+      const combined = `${stdout}\n${stderr}`;
+      expect(combined).toMatch(/1 passed/);
+    } finally {
+      await fsp.rm(repoRoot, { recursive: true, force: true });
+    }
+  }, 180_000);
+});

--- a/packages/cli/src/runner/machinen/machinen-job.test.ts
+++ b/packages/cli/src/runner/machinen/machinen-job.test.ts
@@ -1,0 +1,22 @@
+// Unit tests for `executeMachinenJob` are intentionally thin: the
+// function orchestrates the DTU, machinen runtime, host filesystem, and
+// child processes, so most behaviors only manifest end-to-end. We rely
+// on:
+//
+//   - `rootfs.test.ts` for the rootfs download/override pipeline.
+//   - `image-mapping.test.ts` for the discovery flow.
+//   - The host-side smoke test (`AGENT_CI_MACHINEN=1` against a real
+//     workflow) for the boot → run.sh → completion path.
+//
+// This file just confirms the module exports the expected shape so
+// imports don't break silently.
+
+import { describe, expect, it } from "vitest";
+
+import { executeMachinenJob } from "./machinen-job.ts";
+
+describe("machinen-job module", () => {
+  it("exports executeMachinenJob", () => {
+    expect(typeof executeMachinenJob).toBe("function");
+  });
+});

--- a/packages/cli/src/runner/machinen/machinen-job.ts
+++ b/packages/cli/src/runner/machinen/machinen-job.ts
@@ -535,6 +535,14 @@ function stagingScript(
   );
   lines.push(`if [ -f ${GUEST_SHIMS_DIR}/git ]; then cp ${GUEST_SHIMS_DIR}/git /usr/bin/git; fi`);
   lines.push("chmod +x /usr/bin/git || true");
+  // The work dir is FUSE-mounted from the host with the host user's uid,
+  // but anything inside the guest runs as root. Git's safe.directory
+  // check refuses to operate on repos owned by a different uid, which
+  // breaks actions/checkout's post-step cleanup (it shells out to git
+  // directly, bypassing our shim). Trust everything globally — the
+  // guest is per-job and disposable, so the security stance the check
+  // is enforcing doesn't apply here.
+  lines.push("/usr/bin/git.real config --system --add safe.directory '*' 2>/dev/null || true");
   return lines.join("\n");
 }
 

--- a/packages/cli/src/runner/machinen/machinen-job.ts
+++ b/packages/cli/src/runner/machinen/machinen-job.ts
@@ -1,0 +1,559 @@
+// executeMachinenJob — full GHA-runner-in-microVM execution.
+//
+// Mirrors `executeLocalJob` (docker) using machinen primitives. ADR
+// 0003 captures the substrate-specific decisions; the broad strokes:
+//
+//   - Boot a long-lived `sleep infinity` VM from the resolved rootfs.
+//   - Live-mount the per-run host dirs (work, shims, signals, diag,
+//     caches) under `/mnt/...` and symlink the runner's conventional
+//     paths to them inside the guest.
+//   - Inject `.runner` / `.credentials` / `.credentials_rsaparams`
+//     via `vm.writeFile` so we skip the .NET config.sh cold-start.
+//   - `vm.exec /home/runner/run.sh --once` for the workload; stream
+//     stdout/stderr into the host-side debug log.
+//   - Concurrently poll `timeline.json` via the shared timeline-sync
+//     helper to drive the renderer and detect step failures.
+//   - Pause/retry rides the same signals-dir protocol the docker path
+//     uses — liveMount makes it work unchanged.
+
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+import { startEphemeralDtu } from "dtu-github-actions/ephemeral";
+
+import { config } from "../../config.ts";
+import { writeDetachedMarker } from "../../launcher.ts";
+import { debugBoot, debugRunner } from "../../output/debug.ts";
+import { createLogContext } from "../../output/logger.ts";
+import { type JobResult } from "../../output/reporter.ts";
+import { RunStateStore } from "../../output/run-state.ts";
+import { getWorkingDirectory } from "../../output/working-directory.ts";
+import type { Job } from "../../types.ts";
+
+import { createRunDirectories } from "../directory-setup.ts";
+import { writeGitShim } from "../git-shim.ts";
+import { findRepoRoot, writeJobMetadata } from "../metadata.ts";
+import { buildJobResult, isJobSuccessful } from "../result-builder.ts";
+import { buildRunnerCredentials } from "../runner-credentials.ts";
+import { appendOutputCaptureStep, wrapJobSteps } from "../step-wrapper.ts";
+import { syncWorkspaceForRetry } from "../sync.ts";
+import {
+  syncTimelineToStore,
+  type TimelineSyncContext,
+  type TimelineSyncState,
+} from "../timeline-sync.ts";
+import { prepareWorkspace } from "../workspace.ts";
+
+import { resolveMachinenImage } from "./image-mapping.ts";
+
+// ─── Tunables ────────────────────────────────────────────────────────────────
+
+// gvproxy's user-mode NAT exposes the host's loopback at 192.168.127.254.
+// (The `.1` address is gvproxy's gateway services like DNS — not the host;
+// the guest itself sits at `.2`.) The DTU binds to 0.0.0.0:<random> on the
+// host so the guest can hit `http://192.168.127.254:<port>/`.
+const GUEST_HOST_IP = "192.168.127.254";
+
+// 60s ceiling on individual `vm.exec` calls during setup. The long-running
+// run.sh exec uses `execTimeoutMs: null` so it lives for the whole job.
+const SETUP_EXEC_TIMEOUT_MS = 60_000;
+
+// ─── @machinen/runtime shape (subset we touch) ───────────────────────────────
+
+interface MachinenVm {
+  readonly pid: number;
+  exec(
+    cmd: string,
+    opts?: {
+      execTimeoutMs?: number | null;
+      onStdout?: (chunk: Buffer) => void;
+      onStderr?: (chunk: Buffer) => void;
+    },
+  ): Promise<{ exitCode: number; stdout: string; stderr: string }>;
+  writeFile(
+    guestPath: string,
+    contents: Buffer | string,
+    opts?: { mode?: number; recursive?: boolean },
+  ): Promise<void>;
+  kill(): Promise<void>;
+}
+
+interface MachinenLiveMount {
+  host: string;
+  guest: string;
+  mode?: "ro" | "rw";
+}
+
+interface MachinenRuntimeModule {
+  boot?: (opts: {
+    image: string;
+    cmd?: string[];
+    env?: Record<string, string>;
+    name?: string;
+    kernel?: string;
+    dtb?: string;
+    liveMounts?: MachinenLiveMount[];
+    timeoutMs?: number | null;
+  }) => Promise<MachinenVm>;
+  resolveBaseKernel?: (explicit?: string, cwd?: string) => string;
+  resolveBaseDtb?: (explicit?: string, cwd?: string) => string;
+}
+
+async function loadMachinenRuntime(): Promise<MachinenRuntimeModule> {
+  try {
+    return (await import("@machinen/runtime")) as MachinenRuntimeModule;
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      "machinen runtime selected but `@machinen/runtime` did not resolve.\n" +
+        `  Underlying error: ${reason}\n` +
+        "  Set AGENT_CI_RUNTIME=docker to fall back to docker.",
+    );
+  }
+}
+
+// ─── Guest path conventions ──────────────────────────────────────────────────
+
+// LiveMount targets — each host dir lands at /mnt/<name> in the guest,
+// then we symlink the runner's conventional paths onto them.
+const GUEST_WORK_MNT = "/mnt/work";
+const GUEST_SHIMS_MNT = "/mnt/shims";
+const GUEST_SIGNALS_MNT = "/mnt/signals";
+const GUEST_DIAG_MNT = "/mnt/diag";
+
+// Where the runner expects to find its world. The bake puts run.sh +
+// the runner binary at /home/runner; everything else lands via symlink
+// onto the mount targets above.
+const GUEST_RUNNER_DIR = "/home/runner";
+const GUEST_RUNNER_WORK = "/home/runner/_work";
+const GUEST_RUNNER_DIAG = "/home/runner/_diag";
+const GUEST_SHIMS_DIR = "/tmp/agent-ci-shims";
+const GUEST_SIGNALS_DIR = "/tmp/agent-ci-signals";
+
+// ─── Entrypoint ───────────────────────────────────────────────────────────────
+
+export async function executeMachinenJob(
+  job: Job,
+  options?: { pauseOnFailure?: boolean; store?: RunStateStore },
+): Promise<JobResult> {
+  const mod = await loadMachinenRuntime();
+  if (typeof mod.boot !== "function") {
+    throw new Error("`@machinen/runtime` does not export `boot()`.");
+  }
+  if (typeof mod.resolveBaseKernel !== "function" || typeof mod.resolveBaseDtb !== "function") {
+    throw new Error("`@machinen/runtime` is missing resolveBaseKernel / resolveBaseDtb exports.");
+  }
+
+  const pauseOnFailure = options?.pauseOnFailure ?? false;
+  const store = options?.store;
+  const startTime = Date.now();
+
+  const {
+    name: vmName,
+    runDir,
+    logDir,
+    debugLogPath,
+  } = createLogContext("agent-ci-machinen", job.runnerName);
+  job.runnerName = vmName;
+
+  store?.addJob(job.parentWorkflowPath ?? job.workflowPath ?? "", job.taskId ?? "job", vmName, {
+    logDir,
+    debugLogPath,
+  });
+  store?.updateJob(vmName, {
+    status: "booting",
+    startedAt: new Date().toISOString(),
+    logDir,
+    debugLogPath,
+  });
+
+  const bootStart = Date.now();
+  const bt = (label: string, since: number) => {
+    debugBoot(`${vmName} ${label}: ${Date.now() - since}ms`);
+    return Date.now();
+  };
+  let t0 = bootStart;
+
+  // ── Resolve rootfs ────────────────────────────────────────────────────────
+  const repoRoot = (job.workflowPath && findRepoRoot(job.workflowPath)) || process.cwd();
+  const image = await resolveMachinenImage({ repoRoot });
+  debugRunner(`[machinen] ${vmName}: rootfs source=${image.source} path=${image.rootfsPath}`);
+  t0 = bt("rootfs-resolve", t0);
+
+  // ── Start ephemeral DTU ───────────────────────────────────────────────────
+  const dtuCacheDir = path.resolve(getWorkingDirectory(), "cache", "dtu");
+  let ephemeralDtu: Awaited<ReturnType<typeof startEphemeralDtu>> | null = null;
+  try {
+    ephemeralDtu = await startEphemeralDtu(dtuCacheDir);
+    debugRunner(`[machinen] ${vmName}: DTU started cli-url=${ephemeralDtu.url}`);
+  } catch (err) {
+    debugRunner(`[machinen] ${vmName}: ephemeral DTU failed to start: ${err}`);
+  }
+  t0 = bt("dtu-start", t0);
+
+  // The CLI uses url (127.0.0.1); the guest uses guestUrl (gvproxy gateway).
+  const dtuCliUrl = ephemeralDtu?.url ?? config.GITHUB_API_URL;
+  const dtuParsed = new URL(dtuCliUrl);
+  const dtuPort = dtuParsed.port || (dtuParsed.protocol === "https:" ? "443" : "80");
+  const dtuGuestUrl = `${dtuParsed.protocol}//${GUEST_HOST_IP}:${dtuPort}`;
+
+  // ── Per-run dirs ──────────────────────────────────────────────────────────
+  const dirs = createRunDirectories({
+    runDir,
+    githubRepo: job.githubRepo!,
+    workflowPath: job.workflowPath,
+  });
+  debugRunner(
+    `[machinen] ${vmName}: package manager = ${dirs.detectedPM ?? "none (mounting all PM caches)"}`,
+  );
+
+  writeDetachedMarker(runDir);
+
+  await fetch(`${dtuCliUrl}/_dtu/start-runner`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      runnerName: vmName,
+      logDir,
+      timelineDir: logDir,
+      virtualCachePatterns: dirs.detectedPM
+        ? dirs.detectedPM === "bun"
+          ? []
+          : [dirs.detectedPM]
+        : ["pnpm", "npm", "yarn"],
+    }),
+  }).catch(() => {
+    /* non-fatal */
+  });
+  t0 = bt("dtu-register", t0);
+
+  writeJobMetadata({ logDir, containerName: vmName, job });
+  const debugStream = fs.createWriteStream(debugLogPath);
+
+  // ── Workspace + shims ─────────────────────────────────────────────────────
+  writeGitShim(dirs.shimsDir, job.realHeadSha);
+  await prepareWorkspace({
+    workflowPath: job.workflowPath,
+    headSha: job.headSha,
+    githubRepo: job.githubRepo,
+    workspaceDir: dirs.workspaceDir,
+  }).catch((err) => debugRunner(`[machinen] ${vmName}: prepareWorkspace failed: ${err}`));
+  t0 = bt("workspace-prep", t0);
+
+  // ── Cleanup tracking ──────────────────────────────────────────────────────
+  let vm: MachinenVm | null = null;
+  const signalCleanup = () => {
+    if (vm) {
+      vm.kill().catch(() => {});
+    }
+    for (const d of [dirs.containerWorkDir, dirs.shimsDir, dirs.signalsDir, dirs.diagDir]) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true });
+      } catch {}
+    }
+  };
+  process.on("SIGINT", signalCleanup);
+  process.on("SIGTERM", signalCleanup);
+  process.on("SIGHUP", signalCleanup);
+
+  try {
+    // ── Seed the job into the DTU ──────────────────────────────────────────
+    const [githubOwner, githubRepoName] = (job.githubRepo || "").split("/");
+    const overriddenRepository = job.githubRepo
+      ? {
+          full_name: job.githubRepo,
+          name: githubRepoName,
+          owner: { login: githubOwner },
+          default_branch: job.repository?.default_branch || "main",
+        }
+      : job.repository;
+
+    const wrappedSteps = pauseOnFailure ? wrapJobSteps(job.steps ?? [], true) : job.steps;
+    const seededSteps = appendOutputCaptureStep(wrappedSteps ?? []);
+
+    const seedResponse = await fetch(`${dtuCliUrl}/_dtu/seed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: job.githubJobId || "1",
+        name: "job",
+        status: "queued",
+        localPath: dirs.workspaceDir,
+        ...job,
+        steps: seededSteps,
+        repository: overriddenRepository,
+      }),
+    });
+    if (!seedResponse.ok) {
+      throw new Error(`failed to seed DTU: ${seedResponse.status} ${seedResponse.statusText}`);
+    }
+    t0 = bt("dtu-seed", t0);
+
+    // ── Boot the VM ────────────────────────────────────────────────────────
+    // First-cut mount set: just work, diag, shims, and the signals
+    // dir when pause-on-failure is on. The other caches (toolcache,
+    // pnpm/npm/bun, playwright, warm-modules) hit a machinen
+    // "agent closed connection before X frame" failure when included
+    // — likely a per-VM FUSE-server resource ceiling. Re-add them
+    // incrementally once we have a smoke baseline.
+    const liveMounts: MachinenLiveMount[] = [
+      { host: dirs.containerWorkDir, guest: GUEST_WORK_MNT, mode: "rw" },
+      { host: dirs.shimsDir, guest: GUEST_SHIMS_MNT, mode: "rw" },
+      { host: dirs.diagDir, guest: GUEST_DIAG_MNT, mode: "rw" },
+    ];
+    if (pauseOnFailure) {
+      liveMounts.push({ host: dirs.signalsDir, guest: GUEST_SIGNALS_MNT, mode: "rw" });
+    }
+
+    // Ensure each host dir exists before machinen's FUSE bridge wants to
+    // open it — liveMounts errors loudly otherwise.
+    await Promise.all(
+      liveMounts.map((lm) => fsp.mkdir(lm.host, { recursive: true }).catch(() => {})),
+    );
+
+    debugRunner(`[machinen] ${vmName}: booting VM with ${liveMounts.length} live mounts`);
+    vm = await mod.boot({
+      image: image.rootfsPath,
+      kernel: mod.resolveBaseKernel(),
+      dtb: mod.resolveBaseDtb(),
+      name: vmName,
+      cmd: ["/bin/sh", "-c", "exec sleep infinity"],
+      liveMounts,
+      // No wall-clock cap on the supervisor sleep — we kill the VM ourselves.
+      timeoutMs: null,
+    });
+    debugRunner(`[machinen] ${vmName}: VM up pid=${vm.pid}`);
+    t0 = bt("vm-boot", t0);
+
+    // ── Stage the runner's view inside the guest ──────────────────────────
+    await runExec(
+      vm,
+      stagingScript(pauseOnFailure, dirs),
+      "stage",
+      debugStream,
+      SETUP_EXEC_TIMEOUT_MS,
+    );
+    t0 = bt("vm-stage", t0);
+
+    // ── Push credentials inside the guest ─────────────────────────────────
+    const creds = buildRunnerCredentials(vmName, `${dtuGuestUrl}/${job.githubRepo}`);
+    await vm.writeFile(`${GUEST_RUNNER_DIR}/.runner`, creds.dotRunner);
+    await vm.writeFile(`${GUEST_RUNNER_DIR}/.credentials`, creds.dotCredentials);
+    await vm.writeFile(`${GUEST_RUNNER_DIR}/.credentials_rsaparams`, creds.dotRsaParams);
+    t0 = bt("vm-credentials", t0);
+
+    // ── Launch the runner ─────────────────────────────────────────────────
+    const timelinePath = path.join(logDir, "timeline.json");
+    const pausedSignalPath = path.join(dirs.signalsDir, "paused");
+
+    const timelineState: TimelineSyncState = {
+      lastSeenAttempt: 0,
+      isPaused: false,
+      pausedAtMs: null,
+      pausedStepName: null,
+      isBooting: true,
+      lastFailedStep: null,
+    };
+
+    let stdinListening = false;
+    const setupStdinRetry = () => {
+      if (stdinListening || !process.stdin.isTTY) {
+        return;
+      }
+      stdinListening = true;
+      process.stdin.setRawMode(true);
+      process.stdin.resume();
+      process.stdin.on("data", (key: Buffer) => {
+        if (key[0] === 3) {
+          process.stdin.setRawMode(false);
+          process.exit(130);
+        }
+        if (key[0] === 13 && timelineState.isPaused) {
+          syncWorkspaceForRetry(path.dirname(dirs.signalsDir));
+          fs.writeFileSync(path.join(dirs.signalsDir, "retry"), "");
+        }
+      });
+    };
+    const cleanupStdin = () => {
+      if (stdinListening && process.stdin.isTTY) {
+        process.stdin.setRawMode(false);
+        process.stdin.pause();
+        process.stdin.removeAllListeners("data");
+        stdinListening = false;
+      }
+    };
+
+    const timelineCtx: TimelineSyncContext = {
+      pauseOnFailure,
+      pausedSignalPath,
+      signalsDir: dirs.signalsDir,
+      timelinePath,
+      bootStart,
+      containerName: vmName,
+      store,
+      onNewPause: setupStdinRetry,
+    };
+
+    let runnerDone = false;
+    const pollPromise = (async () => {
+      while (!runnerDone) {
+        syncTimelineToStore(timelineState, timelineCtx);
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      syncTimelineToStore(timelineState, timelineCtx);
+    })();
+
+    debugRunner(`[machinen] ${vmName}: launching run.sh`);
+    // RUNNER_ALLOW_RUNASROOT=1 — the GHA runner refuses to run as
+    // root by default. The docker path runs as the image's `runner`
+    // user; our debian rootfs has no such user, and exec-agent runs
+    // commands as root. The env override is the upstream-supported
+    // way to bypass the check.
+    const runResult = await vm.exec(
+      `cd ${GUEST_RUNNER_DIR} && RUNNER_ALLOW_RUNASROOT=1 exec ./run.sh --once`,
+      {
+        execTimeoutMs: null,
+        onStdout: (chunk) => debugStream.write(chunk),
+        onStderr: (chunk) => debugStream.write(chunk),
+      },
+    );
+    runnerDone = true;
+    cleanupStdin();
+    await pollPromise;
+    await new Promise<void>((resolve) => debugStream.end(resolve));
+
+    const jobSucceeded = isJobSuccessful({
+      lastFailedStep: timelineState.lastFailedStep,
+      containerExitCode: runResult.exitCode,
+      isBooting: timelineState.isBooting,
+    });
+
+    if (!jobSucceeded) {
+      store?.updateJob(vmName, {
+        failedExitCode: runResult.exitCode !== 0 ? runResult.exitCode : undefined,
+      });
+    }
+
+    let stepOutputs: Record<string, string> = {};
+    if (jobSucceeded) {
+      const outputsFile = path.join(logDir, "outputs.json");
+      try {
+        if (fs.existsSync(outputsFile)) {
+          stepOutputs = JSON.parse(fs.readFileSync(outputsFile, "utf8"));
+        }
+      } catch {
+        /* best-effort */
+      }
+    }
+
+    if (jobSucceeded && fs.existsSync(dirs.containerWorkDir)) {
+      try {
+        fs.rmSync(dirs.containerWorkDir, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup; the VM may still hold open fds briefly.
+      }
+    }
+
+    return buildJobResult({
+      containerName: vmName,
+      job,
+      startTime,
+      jobSucceeded,
+      lastFailedStep: timelineState.lastFailedStep,
+      containerExitCode: runResult.exitCode,
+      timelinePath,
+      logDir,
+      debugLogPath,
+      stepOutputs,
+      resolvedRunnerImage: {
+        image: image.rootfsPath,
+        source: "default",
+        sourceLabel: `machinen rootfs (${image.source})`,
+        needsBuild: false,
+      },
+      toolCacheDir: dirs.toolCacheDir,
+    });
+  } finally {
+    try {
+      await vm?.kill();
+    } catch {
+      /* already gone */
+    }
+    const rmOpts = { recursive: true, force: true } as const;
+    await Promise.all([
+      fsp.rm(dirs.shimsDir, rmOpts).catch(() => {}),
+      pauseOnFailure ? undefined : fsp.rm(dirs.signalsDir, rmOpts).catch(() => {}),
+      fsp.rm(dirs.diagDir, rmOpts).catch(() => {}),
+    ]);
+    await ephemeralDtu?.close().catch(() => {});
+    process.removeListener("SIGINT", signalCleanup);
+    process.removeListener("SIGTERM", signalCleanup);
+    process.removeListener("SIGHUP", signalCleanup);
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Build the shell script that prepares the rootfs for run.sh:
+ *
+ *   - Symlinks /home/runner/_work etc. → the live-mount targets.
+ *   - Installs the host's git shim over /usr/bin/git.
+ *   - Creates the workspace dir the runner will chdir into.
+ *
+ * Everything runs in the guest via a single `vm.exec` so we get one
+ * exit code back for the whole staging phase.
+ */
+function stagingScript(
+  pauseOnFailure: boolean,
+  dirs: ReturnType<typeof createRunDirectories>,
+): string {
+  const repoName = (dirs.repoSlug.split("-").pop() || dirs.repoSlug).trim() || "repo";
+  const lines: string[] = ["set -e"];
+  lines.push(`mkdir -p ${GUEST_RUNNER_DIR}`);
+  // Symlink the runner's conventional paths onto the live-mount targets.
+  // `ln -sfn` overwrites existing symlinks; for existing dirs we first
+  // rm so the symlink lands cleanly.
+  const symlink = (src: string, dst: string) => {
+    lines.push(`rm -rf ${dst}`);
+    lines.push(`mkdir -p $(dirname ${dst})`);
+    lines.push(`ln -sfn ${src} ${dst}`);
+  };
+  symlink(GUEST_WORK_MNT, GUEST_RUNNER_WORK);
+  symlink(GUEST_SHIMS_MNT, GUEST_SHIMS_DIR);
+  symlink(GUEST_DIAG_MNT, GUEST_RUNNER_DIAG);
+  if (pauseOnFailure) {
+    symlink(GUEST_SIGNALS_MNT, GUEST_SIGNALS_DIR);
+  }
+  // Workspace dir the runner chdir's into.
+  lines.push(`mkdir -p ${GUEST_WORK_MNT}/${repoName}/${repoName}`);
+  // Git shim: the host put the shim under /mnt/shims/git; move the real
+  // git out of the way and drop the shim in its place.
+  lines.push(
+    "if [ -f /usr/bin/git ] && [ ! -f /usr/bin/git.real ]; then mv /usr/bin/git /usr/bin/git.real; fi",
+  );
+  lines.push(`if [ -f ${GUEST_SHIMS_DIR}/git ]; then cp ${GUEST_SHIMS_DIR}/git /usr/bin/git; fi`);
+  lines.push("chmod +x /usr/bin/git || true");
+  return lines.join("\n");
+}
+
+async function runExec(
+  vm: MachinenVm,
+  cmd: string,
+  label: string,
+  debugStream: fs.WriteStream,
+  timeoutMs: number,
+): Promise<void> {
+  const result = await vm.exec(cmd, {
+    execTimeoutMs: timeoutMs,
+    onStdout: (chunk) => debugStream.write(chunk),
+    onStderr: (chunk) => debugStream.write(chunk),
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `machinen vm.exec [${label}] failed (exit ${result.exitCode}). ` +
+        `stderr (tail): ${result.stderr.slice(-1024)}`,
+    );
+  }
+}

--- a/packages/cli/src/runner/machinen/rootfs.test.ts
+++ b/packages/cli/src/runner/machinen/rootfs.test.ts
@@ -1,0 +1,264 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import { Readable } from "node:stream";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  __test_resetInFlight,
+  defaultCacheRoot,
+  ensureMachinenRootfs,
+  OVERRIDE_PATH_FRAGMENT,
+} from "./rootfs.ts";
+
+// ─── Fake fetch ───────────────────────────────────────────────────────────────
+
+interface FakeResponse {
+  status?: number;
+  statusText?: string;
+  body?: string | Buffer;
+  headers?: Record<string, string>;
+}
+
+function makeFetcher(scripted: FakeResponse | FakeResponse[] | (() => FakeResponse)): {
+  fetcher: typeof fetch;
+  calls: Array<{ url: string; headers: Record<string, string> }>;
+} {
+  const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+  let idx = 0;
+  const fetcher = (async (input: Request | string | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const headers: Record<string, string> = {};
+    const initHeaders = (init?.headers ?? {}) as Record<string, string>;
+    for (const k of Object.keys(initHeaders)) {
+      headers[k] = initHeaders[k];
+    }
+    calls.push({ url, headers });
+    const resp =
+      typeof scripted === "function"
+        ? scripted()
+        : Array.isArray(scripted)
+          ? scripted[Math.min(idx++, scripted.length - 1)]
+          : scripted;
+    const status = resp.status ?? 200;
+    const body =
+      resp.body === undefined
+        ? null
+        : Readable.from([typeof resp.body === "string" ? Buffer.from(resp.body) : resp.body]);
+    return {
+      status,
+      statusText: resp.statusText ?? "OK",
+      ok: status >= 200 && status < 300,
+      body: body as unknown as ReadableStream<Uint8Array> | null,
+      headers: {
+        get: (name: string) => resp.headers?.[name.toLowerCase()] ?? null,
+      } as Response["headers"],
+    } as unknown as Response;
+  }) as typeof fetch;
+  return { fetcher, calls };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("defaultCacheRoot", () => {
+  it("lives under ~/.cache/agent-ci/machinen", () => {
+    expect(defaultCacheRoot()).toBe(path.join(os.homedir(), ".cache", "agent-ci", "machinen"));
+  });
+});
+
+describe("ensureMachinenRootfs — override path", () => {
+  let repoRoot: string;
+  let cacheRoot: string;
+  beforeEach(async () => {
+    __test_resetInFlight();
+    repoRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "rootfs-override-"));
+    cacheRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "rootfs-cache-"));
+  });
+  afterEach(async () => {
+    await fsp.rm(repoRoot, { recursive: true, force: true });
+    await fsp.rm(cacheRoot, { recursive: true, force: true });
+  });
+
+  it("returns the override path verbatim when the file exists", async () => {
+    const override = path.join(repoRoot, OVERRIDE_PATH_FRAGMENT);
+    await fsp.mkdir(path.dirname(override), { recursive: true });
+    await fsp.writeFile(override, "user rootfs");
+    const { fetcher, calls } = makeFetcher({ body: "should-not-fetch" });
+    const result = await ensureMachinenRootfs({ repoRoot, cacheRoot, fetcher });
+    expect(result.source).toBe("override");
+    expect(result.path).toBe(override);
+    expect(calls.length).toBe(0);
+  });
+});
+
+describe("ensureMachinenRootfs — download path", () => {
+  let repoRoot: string;
+  let cacheRoot: string;
+  const url = "https://example.test/rootfs.tar.gz";
+
+  beforeEach(async () => {
+    __test_resetInFlight();
+    repoRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "rootfs-repo-"));
+    cacheRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "rootfs-cache-"));
+  });
+  afterEach(async () => {
+    await fsp.rm(repoRoot, { recursive: true, force: true });
+    await fsp.rm(cacheRoot, { recursive: true, force: true });
+  });
+
+  it("downloads on cold cache, returns 'downloaded'", async () => {
+    const { fetcher, calls } = makeFetcher({
+      body: "fresh-rootfs",
+      headers: { etag: `"v1"` },
+    });
+    const result = await ensureMachinenRootfs({ repoRoot, cacheRoot, url, fetcher });
+    expect(result.source).toBe("downloaded");
+    expect(fs.existsSync(result.path)).toBe(true);
+    expect(await fsp.readFile(result.path, "utf8")).toBe("fresh-rootfs");
+    expect(calls.length).toBe(1);
+    expect(calls[0].headers["If-None-Match"]).toBeUndefined();
+  });
+
+  it("sends If-None-Match on warm cache and returns 'cached' on 304", async () => {
+    // First call to seed the cache.
+    const first = makeFetcher({ body: "v1-body", headers: { etag: `"v1"` } });
+    await ensureMachinenRootfs({ repoRoot, cacheRoot, url, fetcher: first.fetcher });
+    __test_resetInFlight();
+
+    const second = makeFetcher({ status: 304, statusText: "Not Modified" });
+    const result = await ensureMachinenRootfs({
+      repoRoot,
+      cacheRoot,
+      url,
+      fetcher: second.fetcher,
+    });
+    expect(result.source).toBe("cached");
+    expect(await fsp.readFile(result.path, "utf8")).toBe("v1-body");
+    expect(second.calls[0].headers["If-None-Match"]).toBe(`"v1"`);
+  });
+
+  it("re-downloads when the body changes and returns 'refreshed'", async () => {
+    const first = makeFetcher({ body: "v1-body", headers: { etag: `"v1"` } });
+    await ensureMachinenRootfs({ repoRoot, cacheRoot, url, fetcher: first.fetcher });
+    __test_resetInFlight();
+
+    const second = makeFetcher({ body: "v2-body", headers: { etag: `"v2"` } });
+    const result = await ensureMachinenRootfs({
+      repoRoot,
+      cacheRoot,
+      url,
+      fetcher: second.fetcher,
+    });
+    expect(result.source).toBe("refreshed");
+    expect(await fsp.readFile(result.path, "utf8")).toBe("v2-body");
+  });
+
+  it("falls back to cache when the network fails", async () => {
+    const first = makeFetcher({ body: "v1", headers: { etag: `"v1"` } });
+    await ensureMachinenRootfs({ repoRoot, cacheRoot, url, fetcher: first.fetcher });
+    __test_resetInFlight();
+
+    const offline = (async () => {
+      throw new Error("ENETUNREACH");
+    }) as unknown as typeof fetch;
+    const result = await ensureMachinenRootfs({ repoRoot, cacheRoot, url, fetcher: offline });
+    expect(result.source).toBe("cached");
+  });
+
+  it("errors when the network fails and no cache exists", async () => {
+    const offline = (async () => {
+      throw new Error("ENETUNREACH");
+    }) as unknown as typeof fetch;
+    await expect(
+      ensureMachinenRootfs({ repoRoot, cacheRoot, url, fetcher: offline }),
+    ).rejects.toThrow(/ENETUNREACH/);
+  });
+
+  it("falls back to cache on a non-OK response when cache exists", async () => {
+    const first = makeFetcher({ body: "v1", headers: { etag: `"v1"` } });
+    await ensureMachinenRootfs({ repoRoot, cacheRoot, url, fetcher: first.fetcher });
+    __test_resetInFlight();
+
+    const second = makeFetcher({ status: 500, statusText: "Server Error" });
+    const result = await ensureMachinenRootfs({
+      repoRoot,
+      cacheRoot,
+      url,
+      fetcher: second.fetcher,
+    });
+    expect(result.source).toBe("cached");
+  });
+
+  it("dedups concurrent first-use calls into one fetch", async () => {
+    let inflight = 0;
+    let releases: Array<() => void> = [];
+    const fetcher: typeof fetch = (async () => {
+      inflight += 1;
+      await new Promise<void>((r) => releases.push(r));
+      return {
+        status: 200,
+        statusText: "OK",
+        ok: true,
+        body: Readable.from([Buffer.from("v1")]) as unknown as ReadableStream<Uint8Array>,
+        headers: {
+          get: (n: string) => (n.toLowerCase() === "etag" ? `"v1"` : null),
+        } as Response["headers"],
+      } as unknown as Response;
+    }) as typeof fetch;
+
+    const a = ensureMachinenRootfs({ repoRoot, cacheRoot, url, fetcher });
+    const b = ensureMachinenRootfs({ repoRoot, cacheRoot, url, fetcher });
+    const c = ensureMachinenRootfs({ repoRoot, cacheRoot, url, fetcher });
+
+    // Wait until the fetcher is actually called once, then release.
+    await new Promise((r) => setTimeout(r, 10));
+    releases.forEach((fn) => fn());
+
+    const results = await Promise.all([a, b, c]);
+    expect(new Set(results.map((r) => r.path)).size).toBe(1);
+    expect(inflight).toBe(1);
+  });
+
+  it("cleans up the .partial file when the stream fails mid-flight", async () => {
+    const cachePath = path.join(cacheRoot, "base.tar.gz");
+    const explodingStream = new Readable({
+      read() {
+        this.destroy(new Error("stream collapsed"));
+      },
+    });
+    const fetcher: typeof fetch = (async () =>
+      ({
+        status: 200,
+        statusText: "OK",
+        ok: true,
+        body: explodingStream as unknown as ReadableStream<Uint8Array>,
+        headers: { get: () => null } as Response["headers"],
+      }) as unknown as Response) as typeof fetch;
+
+    await expect(ensureMachinenRootfs({ repoRoot, cacheRoot, url, fetcher })).rejects.toThrow(
+      /stream collapsed/,
+    );
+    expect(fs.existsSync(`${cachePath}.partial`)).toBe(false);
+  });
+
+  it("invalidates the cache when the URL changes (mirror swap)", async () => {
+    const url1 = "https://mirror-a.test/rootfs.tar.gz";
+    const url2 = "https://mirror-b.test/rootfs.tar.gz";
+    const first = makeFetcher({ body: "from-a", headers: { etag: `"a1"` } });
+    await ensureMachinenRootfs({ repoRoot, cacheRoot, url: url1, fetcher: first.fetcher });
+    __test_resetInFlight();
+
+    const second = makeFetcher({ body: "from-b", headers: { etag: `"b1"` } });
+    const result = await ensureMachinenRootfs({
+      repoRoot,
+      cacheRoot,
+      url: url2,
+      fetcher: second.fetcher,
+    });
+    // Old etag must NOT have been sent — we re-fetch on URL change.
+    expect(second.calls[0].headers["If-None-Match"]).toBeUndefined();
+    expect(await fsp.readFile(result.path, "utf8")).toBe("from-b");
+  });
+});

--- a/packages/cli/src/runner/machinen/rootfs.ts
+++ b/packages/cli/src/runner/machinen/rootfs.ts
@@ -1,0 +1,209 @@
+// Resolve the machinen rootfs for a job.
+//
+// Per ADR 0004:
+//
+//   1. If `<repoRoot>/.github/agent-ci.machinen.tar.gz` exists, that
+//      file IS the rootfs. Use it verbatim — no download, no overlay.
+//   2. Otherwise, download the latest pre-baked rootfs from agent-ci's
+//      `machinen-rootfs-latest` GitHub release. Cache under
+//      `~/.cache/agent-ci/machinen/`. On subsequent runs do a
+//      conditional GET (If-None-Match) so we pick up re-bakes without
+//      paying the full download cost every time. Fall back to the
+//      cached copy if the network is unreachable.
+//
+// The previous design (provision-against-machinen-debian + parsed
+// Dockerfile overlay) is gone — that pipeline now lives at release
+// time in `scripts/machinen-bake.mjs` and produces the asset the
+// runtime downloads here. See ADR 0004 for the full rationale.
+
+import { homedir } from "node:os";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { pipeline } from "node:stream/promises";
+
+import { debugRunner } from "../../output/debug.ts";
+
+export const DEFAULT_ROOTFS_URL =
+  "https://github.com/redwoodjs/agent-ci/releases/download/machinen-rootfs-latest/agent-ci-machinen-runner-arm64.tar.gz";
+
+export const OVERRIDE_PATH_FRAGMENT = path.join(".github", "agent-ci.machinen.tar.gz");
+
+export type RootfsSource = "override" | "cached" | "downloaded" | "refreshed";
+
+export interface MachinenRootfs {
+  /** Absolute path to the rootfs tarball — feed straight into boot({ image }). */
+  path: string;
+  source: RootfsSource;
+}
+
+export interface ResolveOpts {
+  repoRoot: string;
+  /** Override the cache root (tests / non-default install layouts). */
+  cacheRoot?: string;
+  /** Override the published-asset URL (tests / mirrors). */
+  url?: string;
+  /** Test-injection — defaults to global fetch. */
+  fetcher?: typeof fetch;
+}
+
+export function defaultCacheRoot(): string {
+  return path.join(homedir(), ".cache", "agent-ci", "machinen");
+}
+
+// In-flight downloads, keyed by output path. Concurrent first-use
+// callers share one promise so we never write two streams into the
+// same .partial.
+const inFlight = new Map<string, Promise<MachinenRootfs>>();
+
+/**
+ * Resolve the machinen rootfs for a repo. See module header for the
+ * full contract.
+ */
+export async function ensureMachinenRootfs(opts: ResolveOpts): Promise<MachinenRootfs> {
+  const override = path.join(opts.repoRoot, OVERRIDE_PATH_FRAGMENT);
+  if (fs.existsSync(override)) {
+    debugRunner(`[machinen] using override rootfs: ${override}`);
+    return { path: override, source: "override" };
+  }
+
+  const cacheRoot = opts.cacheRoot ?? defaultCacheRoot();
+  const cachePath = path.join(cacheRoot, "base.tar.gz");
+  const pending = inFlight.get(cachePath);
+  if (pending) {
+    return pending;
+  }
+
+  const promise = downloadOrRefresh({
+    url: opts.url ?? DEFAULT_ROOTFS_URL,
+    cachePath,
+    fetcher: opts.fetcher ?? fetch,
+  }).finally(() => inFlight.delete(cachePath));
+
+  inFlight.set(cachePath, promise);
+  return promise;
+}
+
+interface MetaJson {
+  etag?: string;
+  lastModified?: string;
+  url?: string;
+  /** When we last successfully refreshed (ms since epoch). Informational. */
+  fetchedAt?: number;
+}
+
+async function downloadOrRefresh(args: {
+  url: string;
+  cachePath: string;
+  fetcher: typeof fetch;
+}): Promise<MachinenRootfs> {
+  const { url, cachePath, fetcher } = args;
+  const cacheRoot = path.dirname(cachePath);
+  const metaPath = `${cachePath}.meta.json`;
+  const partialPath = `${cachePath}.partial`;
+
+  await fsp.mkdir(cacheRoot, { recursive: true });
+
+  const meta = readMeta(metaPath);
+  const cacheExists = fs.existsSync(cachePath);
+
+  // If the cached file's URL doesn't match what the caller wants
+  // (e.g. tests, mirrors), invalidate so we re-fetch from the new
+  // origin instead of returning a stale body.
+  const cacheUrlMatches = !cacheExists || meta?.url === url;
+
+  const headers: Record<string, string> = {};
+  if (cacheUrlMatches) {
+    if (meta?.etag) {
+      headers["If-None-Match"] = meta.etag;
+    }
+    if (meta?.lastModified) {
+      headers["If-Modified-Since"] = meta.lastModified;
+    }
+  }
+
+  let res: Response;
+  try {
+    res = await fetcher(url, { headers, redirect: "follow" });
+  } catch (err) {
+    if (cacheExists) {
+      debugRunner(
+        `[machinen] rootfs fetch failed (${err instanceof Error ? err.message : err}); falling back to cached copy at ${cachePath}`,
+      );
+      return { path: cachePath, source: "cached" };
+    }
+    throw new Error(
+      `failed to download machinen rootfs from ${url} and no cache present: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+
+  if (res.status === 304 && cacheExists) {
+    debugRunner(`[machinen] rootfs unchanged (304) — using cache at ${cachePath}`);
+    return { path: cachePath, source: "cached" };
+  }
+
+  if (!res.ok || !res.body) {
+    if (cacheExists) {
+      debugRunner(
+        `[machinen] rootfs fetch returned ${res.status} ${res.statusText}; falling back to cached copy at ${cachePath}`,
+      );
+      return { path: cachePath, source: "cached" };
+    }
+    throw new Error(
+      `failed to download machinen rootfs from ${url}: ${res.status} ${res.statusText}`,
+    );
+  }
+
+  debugRunner(`[machinen] downloading rootfs from ${url}`);
+  await fsp.rm(partialPath, { force: true });
+  try {
+    await pipeline(res.body as unknown as NodeJS.ReadableStream, fs.createWriteStream(partialPath));
+  } catch (err) {
+    await fsp.rm(partialPath, { force: true }).catch(() => {});
+    if (cacheExists) {
+      debugRunner(
+        `[machinen] rootfs stream failed (${err instanceof Error ? err.message : err}); falling back to cached copy at ${cachePath}`,
+      );
+      return { path: cachePath, source: "cached" };
+    }
+    throw err;
+  }
+
+  await fsp.rename(partialPath, cachePath);
+  writeMeta(metaPath, {
+    url,
+    etag: res.headers.get("etag") ?? undefined,
+    lastModified: res.headers.get("last-modified") ?? undefined,
+    fetchedAt: Date.now(),
+  });
+
+  return { path: cachePath, source: cacheExists ? "refreshed" : "downloaded" };
+}
+
+function readMeta(metaPath: string): MetaJson | null {
+  if (!fs.existsSync(metaPath)) {
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(metaPath, "utf8")) as MetaJson;
+  } catch {
+    return null;
+  }
+}
+
+function writeMeta(metaPath: string, meta: MetaJson): void {
+  try {
+    fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2));
+  } catch (err) {
+    // Cache-meta is informational. A read-only home dir or full disk
+    // shouldn't fail the bake — log and continue.
+    debugRunner(
+      `[machinen] failed to write rootfs meta ${metaPath}: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}
+
+/** Test-only: drop any in-flight download state. */
+export function __test_resetInFlight(): void {
+  inFlight.clear();
+}

--- a/packages/cli/src/runner/runner-credentials.ts
+++ b/packages/cli/src/runner/runner-credentials.ts
@@ -10,12 +10,25 @@ import path from "node:path";
 // directly with deterministic content. Both the Linux docker runner and the
 // macOS VM runner use this: the underlying actions-runner binary is the same
 // .NET process on both platforms, so the on-disk credentials are identical.
-export function writeRunnerCredentials(
-  runnerDir: string,
+
+export interface RunnerCredentialFiles {
+  /** Contents of `.runner` (JSON, pretty-printed). */
+  dotRunner: string;
+  /** Contents of `.credentials` (JSON, pretty-printed). */
+  dotCredentials: string;
+  /** Contents of `.credentials_rsaparams` (JSON, compact). */
+  dotRsaParams: string;
+}
+
+/**
+ * Build the three runner-credential file contents without writing them to
+ * disk. Used by the machinen runtime to push the files into a VM via
+ * `vm.writeFile` instead of bind-mounting a host directory.
+ */
+export function buildRunnerCredentials(
   runnerName: string,
   serverUrl: string,
-): void {
-  // .runner — tells run.sh who it is and where to connect
+): RunnerCredentialFiles {
   const dotRunner = {
     agentId: 1,
     agentName: runnerName,
@@ -26,9 +39,6 @@ export function writeRunnerCredentials(
     workFolder: "_work",
     ephemeral: true,
   };
-  fs.writeFileSync(path.join(runnerDir, ".runner"), JSON.stringify(dotRunner, null, 2));
-
-  // .credentials — OAuth scheme that run.sh reads to authenticate with the DTU
   const dotCredentials = {
     scheme: "OAuth",
     data: {
@@ -38,23 +48,33 @@ export function writeRunnerCredentials(
       requireFipsCryptography: "False",
     },
   };
-  fs.writeFileSync(path.join(runnerDir, ".credentials"), JSON.stringify(dotCredentials, null, 2));
-
-  // .credentials_rsaparams — RSA key the runner uses for token signing.
-  // Format: RSAParametersSerializable JSON (ISerializable with lowercase keys
-  // matching the RSAParametersSerializable constructor). The DTU mock never
-  // validates signatures, so we use a static pre-generated RSA 2048-bit key.
-  const dotRsaParams = {
-    d: "CQpCI+sO2GD1N/JsHHI9zEhMlu5Fcc8mU4O2bO6iscOsagFjvEnTesJgydC/Go1HuOBlx+GT9EG2h7+juS0z2o5n8Mvt5BBxlK+tqoDOs8VfQ9CSUl3hqYRPeNdBfnA1w8ovLW0wqfPO08FWTLI0urYsnwjZ5BQrBM+D7zYeA0aCsKdo75bKmaEKnmqrtIEhb7hE45XQa32Yt0RPCPi8QcQAY2HLHbdWdZYDj6k/UuDvz9H/xlDzwYq6Yikk2RSMArFzaufxCGS9tBZNEACDPYgnZnEMXRcvsnZ9FYbq81KOSifCmq7Yocq+j3rY5zJCD+PIDY9QJwPxB4PGasRKAQ==",
-    dp: "A0sY1oOz1+3uUMiy+I5xGuHGHOrEQPYspd1xGClBYYsa/Za0UDWS7V0Tn1cbRWfWtNe5vTpxcvwQd6UZBwrtHF6R2zyXFhE++PLPhCe0tH4C5FY9i9jUw9Vo8t44i/s5JUHU2B1mEptXFUA0GcVrLKS8toZSgqELSS2Q/YLRxoE=",
-    dq: "GrLC9dPJ5n3VYw51ghCH7tybUN9/Oe4T8d9v4dLQ34RQEWHwRd4g3U3zkvuhpXFPloUTMmkxS7MF5pS1evrtzkay4QUTDv+28s0xRuAsw5qNTzuFygg8t93MvpvTVZ2TNApW6C7NFvkL9NbxAnU8+I61/3ow7i6a7oYJJ0hWAxE=",
-    exponent: "AQAB",
-    inverseQ:
-      "8DVz9FSvEdt5W4B9OjgakZHwGfnhn2VLDUxrsR5ilC5tPC/IgA8C2xEfKQM1t+K/N3pAYHBYQ6EPgtW4kquBS/Sy102xbRI7GSCnUbRtTpWYPOaCn6EaxBNzwWzbp5vCbCGvFqlSu4+OBYRVe+iCj+gAnkmT/TKPhHHbTjJHvw==",
-    modulus:
-      "x0eoW2DD7xsW5YiorMN8pNHVvZk4ED1SHlA/bmVnRz5FjEDnQloMn0nBgIUHxoNArksknrp/FOVJv5sJHJTiRZkOp+ZmH7d3W3gmw63IxK2C5pV+6xfav9jR2+Wt/6FMYMgG2utBdF95oif1f2XREFovHoXkWms2l0CPLLHVPO44Hh9EEmBmjOeMJEZkulHJ44z9y8e+GZ2nYqO0ZiRWQcRObZ0vlRaGg6PPOl4ltay0BfNksMB3NDtlhkdVkAEFQxEaZZDK9NtkvNljXCioP3TyTAbqNUGsYCA5D+IHGZT9An99J9vUqTFP6TKjqUvy9WNiIzaUksCySA0a4SVBkQ==",
-    p: "8fgAdmWy+sTzAN19fYkWMQqeC7t1BCQMo5z5knfVLg8TtwP9ZGqDtoe+r0bGv3UgVsvvDdP/QwRvRVP+5G9l999Y6b4VbSdUbrfPfOgjpPDmRTQzHDve5jh5xBENQoRXYm7PMgHGmjwuFsE/tKtSGTrvt2Z3qcYAo0IOqLLhYmE=",
-    q: "0tXx4+P7gUWePf92UJLkzhNBClvdnmDbIt52Lui7YCARczbN/asCDJxcMy6Bh3qmIx/bNuOUrfzHkYZHfnRw8AGEK80qmiLLPI6jrUBOGRajmzemGQx0W8FWalEQfGdNIv9R2nsegDRoMq255Zo/qX60xQ6abpp0c6UNhVYSjTE=",
+  return {
+    dotRunner: JSON.stringify(dotRunner, null, 2),
+    dotCredentials: JSON.stringify(dotCredentials, null, 2),
+    dotRsaParams: JSON.stringify(STATIC_RSA_PARAMS),
   };
-  fs.writeFileSync(path.join(runnerDir, ".credentials_rsaparams"), JSON.stringify(dotRsaParams));
+}
+
+const STATIC_RSA_PARAMS = {
+  d: "CQpCI+sO2GD1N/JsHHI9zEhMlu5Fcc8mU4O2bO6iscOsagFjvEnTesJgydC/Go1HuOBlx+GT9EG2h7+juS0z2o5n8Mvt5BBxlK+tqoDOs8VfQ9CSUl3hqYRPeNdBfnA1w8ovLW0wqfPO08FWTLI0urYsnwjZ5BQrBM+D7zYeA0aCsKdo75bKmaEKnmqrtIEhb7hE45XQa32Yt0RPCPi8QcQAY2HLHbdWdZYDj6k/UuDvz9H/xlDzwYq6Yikk2RSMArFzaufxCGS9tBZNEACDPYgnZnEMXRcvsnZ9FYbq81KOSifCmq7Yocq+j3rY5zJCD+PIDY9QJwPxB4PGasRKAQ==",
+  dp: "A0sY1oOz1+3uUMiy+I5xGuHGHOrEQPYspd1xGClBYYsa/Za0UDWS7V0Tn1cbRWfWtNe5vTpxcvwQd6UZBwrtHF6R2zyXFhE++PLPhCe0tH4C5FY9i9jUw9Vo8t44i/s5JUHU2B1mEptXFUA0GcVrLKS8toZSgqELSS2Q/YLRxoE=",
+  dq: "GrLC9dPJ5n3VYw51ghCH7tybUN9/Oe4T8d9v4dLQ34RQEWHwRd4g3U3zkvuhpXFPloUTMmkxS7MF5pS1evrtzkay4QUTDv+28s0xRuAsw5qNTzuFygg8t93MvpvTVZ2TNApW6C7NFvkL9NbxAnU8+I61/3ow7i6a7oYJJ0hWAxE=",
+  exponent: "AQAB",
+  inverseQ:
+    "8DVz9FSvEdt5W4B9OjgakZHwGfnhn2VLDUxrsR5ilC5tPC/IgA8C2xEfKQM1t+K/N3pAYHBYQ6EPgtW4kquBS/Sy102xbRI7GSCnUbRtTpWYPOaCn6EaxBNzwWzbp5vCbCGvFqlSu4+OBYRVe+iCj+gAnkmT/TKPhHHbTjJHvw==",
+  modulus:
+    "x0eoW2DD7xsW5YiorMN8pNHVvZk4ED1SHlA/bmVnRz5FjEDnQloMn0nBgIUHxoNArksknrp/FOVJv5sJHJTiRZkOp+ZmH7d3W3gmw63IxK2C5pV+6xfav9jR2+Wt/6FMYMgG2utBdF95oif1f2XREFovHoXkWms2l0CPLLHVPO44Hh9EEmBmjOeMJEZkulHJ44z9y8e+GZ2nYqO0ZiRWQcRObZ0vlRaGg6PPOl4ltay0BfNksMB3NDtlhkdVkAEFQxEaZZDK9NtkvNljXCioP3TyTAbqNUGsYCA5D+IHGZT9An99J9vUqTFP6TKjqUvy9WNiIzaUksCySA0a4SVBkQ==",
+  p: "8fgAdmWy+sTzAN19fYkWMQqeC7t1BCQMo5z5knfVLg8TtwP9ZGqDtoe+r0bGv3UgVsvvDdP/QwRvRVP+5G9l999Y6b4VbSdUbrfPfOgjpPDmRTQzHDve5jh5xBENQoRXYm7PMgHGmjwuFsE/tKtSGTrvt2Z3qcYAo0IOqLLhYmE=",
+  q: "0tXx4+P7gUWePf92UJLkzhNBClvdnmDbIt52Lui7YCARczbN/asCDJxcMy6Bh3qmIx/bNuOUrfzHkYZHfnRw8AGEK80qmiLLPI6jrUBOGRajmzemGQx0W8FWalEQfGdNIv9R2nsegDRoMq255Zo/qX60xQ6abpp0c6UNhVYSjTE=",
+};
+
+export function writeRunnerCredentials(
+  runnerDir: string,
+  runnerName: string,
+  serverUrl: string,
+): void {
+  const { dotRunner, dotCredentials, dotRsaParams } = buildRunnerCredentials(runnerName, serverUrl);
+  fs.writeFileSync(path.join(runnerDir, ".runner"), dotRunner);
+  fs.writeFileSync(path.join(runnerDir, ".credentials"), dotCredentials);
+  fs.writeFileSync(path.join(runnerDir, ".credentials_rsaparams"), dotRsaParams);
 }

--- a/packages/cli/src/runner/runtime.test.ts
+++ b/packages/cli/src/runner/runtime.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+
+import { selectRuntime, __test_probeFromMap } from "./runtime.ts";
+
+const ok = { supported: true } as const;
+const fail = (reason: string) => ({ supported: false, reason });
+
+describe("selectRuntime", () => {
+  it("prefers machinen for linux when machinen is supported", () => {
+    const probed = __test_probeFromMap({
+      machinen: ok,
+      "macos-vm": fail("not macOS"),
+      docker: ok,
+    });
+    expect(selectRuntime("linux", probed)?.name).toBe("machinen");
+  });
+
+  it("falls back to docker for linux when machinen is unsupported", () => {
+    const probed = __test_probeFromMap({
+      machinen: fail("optional dep did not resolve"),
+      "macos-vm": fail("not macOS"),
+      docker: ok,
+    });
+    expect(selectRuntime("linux", probed)?.name).toBe("docker");
+  });
+
+  it("AGENT_CI_RUNTIME=docker forces docker on an arm64 host with machinen available", () => {
+    const probed = __test_probeFromMap({
+      machinen: ok,
+      "macos-vm": fail("not macOS"),
+      docker: ok,
+    });
+    expect(selectRuntime("linux", probed, "docker")?.name).toBe("docker");
+  });
+
+  it("AGENT_CI_RUNTIME=machinen on a host without machinen falls back to priority order", () => {
+    const probed = __test_probeFromMap({
+      machinen: fail("optional dep did not resolve"),
+      "macos-vm": fail("not macOS"),
+      docker: ok,
+    });
+    expect(selectRuntime("linux", probed, "machinen")?.name).toBe("docker");
+  });
+
+  it("AGENT_CI_RUNTIME=docker on a macOS job does not coerce to docker — returns null so the unsupported-OS skip fires", () => {
+    const probed = __test_probeFromMap({
+      machinen: fail("not arm64 linux"),
+      "macos-vm": fail("tart not installed"),
+      docker: ok,
+    });
+    expect(selectRuntime("macos", probed, "docker")).toBeNull();
+  });
+
+  it("selects macos-vm for macOS jobs when the host supports it", () => {
+    const probed = __test_probeFromMap({
+      machinen: fail("not arm64 linux"),
+      "macos-vm": ok,
+      docker: ok,
+    });
+    expect(selectRuntime("macos", probed)?.name).toBe("macos-vm");
+  });
+
+  it("returns null for windows — no runtime supports it", () => {
+    const probed = __test_probeFromMap({
+      machinen: ok,
+      "macos-vm": ok,
+      docker: ok,
+    });
+    expect(selectRuntime("windows", probed)).toBeNull();
+  });
+
+  it("treats `other` as linux-compatible and selects docker by default", () => {
+    const probed = __test_probeFromMap({
+      machinen: fail("not arm64 linux"),
+      "macos-vm": fail("not macOS"),
+      docker: ok,
+    });
+    expect(selectRuntime("other", probed)?.name).toBe("docker");
+  });
+
+  it("ignores an unknown AGENT_CI_RUNTIME value and uses priority order", () => {
+    const probed = __test_probeFromMap({
+      machinen: ok,
+      "macos-vm": fail("not macOS"),
+      docker: ok,
+    });
+    expect(selectRuntime("linux", probed, "podman")?.name).toBe("machinen");
+  });
+
+  it("treats empty-string override as no override", () => {
+    const probed = __test_probeFromMap({
+      machinen: ok,
+      "macos-vm": fail("not macOS"),
+      docker: ok,
+    });
+    expect(selectRuntime("linux", probed, "")?.name).toBe("machinen");
+  });
+});

--- a/packages/cli/src/runner/runtime.ts
+++ b/packages/cli/src/runner/runtime.ts
@@ -1,0 +1,130 @@
+// Runtime selection.
+//
+// agent-ci ships three runtimes — docker, macos-vm, machinen — and selects
+// one per-job based on the job's `runs-on:` OS family, host capability, and
+// the `AGENT_CI_RUNTIME` env var. Selection follows ADR 0001:
+// docs/adr/0001-machinen-default-on-arm64.md.
+//
+// Priority order: `[machinen, macos-vm, docker]`. The first runtime whose
+// `checkHost()` succeeds AND whose `supportsJob(kind)` returns true wins.
+// `AGENT_CI_RUNTIME` reorders the candidate set (it moves the named runtime
+// to the front) but does not bypass `supportsJob` — setting
+// `AGENT_CI_RUNTIME=docker` on a `runs-on: macos-15` job still skips,
+// because docker does not support macOS.
+
+import type { Job } from "../types.ts";
+import type { JobResult } from "../output/reporter.ts";
+import type { RunStateStore } from "../output/run-state.ts";
+
+import { executeLocalJob } from "./local-job.ts";
+import { executeMacosVmJob } from "./macos-vm/macos-vm-job.ts";
+import { checkMacosVmHost } from "./macos-vm/host-capability.ts";
+import { executeMachinenJob } from "./machinen/machinen-job.ts";
+import { checkMachinenHost } from "./machinen/host-capability.ts";
+import type { RunnerOSKind } from "./runs-on-compat.ts";
+
+export type HostCapability =
+  | { supported: true }
+  | { supported: false; reason: string; hint?: string };
+
+export type RuntimeName = "machinen" | "macos-vm" | "docker";
+
+export interface RuntimeExecuteOpts {
+  pauseOnFailure?: boolean;
+  store?: RunStateStore;
+}
+
+export interface Runtime {
+  name: RuntimeName;
+  checkHost(): HostCapability;
+  supportsJob(kind: RunnerOSKind): boolean;
+  execute(job: Job, opts: RuntimeExecuteOpts): Promise<JobResult>;
+}
+
+const PRIORITY: RuntimeName[] = ["machinen", "macos-vm", "docker"];
+
+const machinen: Runtime = {
+  name: "machinen",
+  checkHost: checkMachinenHost,
+  supportsJob: (kind) => kind === "linux" || kind === "other",
+  execute: (job, opts) => executeMachinenJob(job, opts),
+};
+
+const macosVm: Runtime = {
+  name: "macos-vm",
+  checkHost: checkMacosVmHost,
+  supportsJob: (kind) => kind === "macos",
+  execute: (job) => executeMacosVmJob(job),
+};
+
+const docker: Runtime = {
+  name: "docker",
+  // Docker is the historical default; the local-job code raises a clear
+  // "Docker is not running" error at execute() time if the daemon is
+  // unreachable. We always advertise it as supported so the existing
+  // diagnostic path is preserved.
+  checkHost: () => ({ supported: true }),
+  supportsJob: (kind) => kind === "linux" || kind === "other",
+  execute: (job, opts) => executeLocalJob(job, opts),
+};
+
+const ALL: Record<RuntimeName, Runtime> = {
+  machinen,
+  "macos-vm": macosVm,
+  docker,
+};
+
+export interface ProbedRuntime {
+  runtime: Runtime;
+  host: HostCapability;
+}
+
+/**
+ * Probe every runtime's host capability once. Callers cache the result for
+ * the lifetime of an `agent-ci run` invocation.
+ */
+export function probeRuntimes(): ProbedRuntime[] {
+  return PRIORITY.map((name) => {
+    const runtime = ALL[name];
+    return { runtime, host: runtime.checkHost() };
+  });
+}
+
+/**
+ * Pick the runtime for a job.
+ *
+ * Returns `null` when no runtime in the registry can handle `kind` on this
+ * host — caller is responsible for the unsupported-OS warning + skip.
+ *
+ * `override` (typically `process.env.AGENT_CI_RUNTIME`) moves the named
+ * runtime to the front of the candidate set. It does not bypass
+ * `supportsJob`: an override that names a runtime which doesn't support
+ * `kind` is ignored, and priority order applies.
+ */
+export function selectRuntime(
+  kind: RunnerOSKind,
+  probed: ProbedRuntime[],
+  override?: string | null | undefined,
+): Runtime | null {
+  const candidates = probed.filter((p) => p.runtime.supportsJob(kind) && p.host.supported);
+  if (candidates.length === 0) {
+    return null;
+  }
+  if (override) {
+    const preferred = candidates.find((c) => c.runtime.name === override);
+    if (preferred) {
+      return preferred.runtime;
+    }
+  }
+  return candidates[0].runtime;
+}
+
+/** Test-only: build a probed-runtime list from a partial map. */
+export function __test_probeFromMap(
+  map: Partial<Record<RuntimeName, HostCapability>>,
+): ProbedRuntime[] {
+  return PRIORITY.map((name) => ({
+    runtime: ALL[name],
+    host: map[name] ?? { supported: false, reason: "not probed in test" },
+  }));
+}

--- a/packages/cli/src/runner/timeline-sync.ts
+++ b/packages/cli/src/runner/timeline-sync.ts
@@ -1,0 +1,242 @@
+// Timeline polling — substrate-agnostic.
+//
+// The DTU server writes `timeline.json` (and `outputs.json`) to a host
+// directory as the GHA runner makes progress. Both the docker runtime
+// and the machinen runtime poll those files from the host side; the
+// only thing the substrate (container vs VM) affects is *who* the
+// runner is talking to, not the on-disk shape of the timeline.
+//
+// This module is extracted from local-job.ts so machinen-job.ts can
+// reuse the same fold-and-publish logic without duplicating ~200 lines
+// of timeline-record handling.
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { debugBoot } from "../output/debug.ts";
+import { tailLogFile } from "../output/reporter.ts";
+import { RunStateStore, type StepState } from "../output/run-state.ts";
+
+/**
+ * Mutable state tracked across timeline-poll ticks. The store-sync helper
+ * mutates the fields in place; the polling loop and the rest of the
+ * runtime's execute function read them once the loop finishes.
+ */
+export interface TimelineSyncState {
+  lastSeenAttempt: number;
+  isPaused: boolean;
+  pausedAtMs: number | null;
+  pausedStepName: string | null;
+  isBooting: boolean;
+  lastFailedStep: string | null;
+}
+
+/** Read-only inputs the store-sync helper needs but does not mutate. */
+export interface TimelineSyncContext {
+  pauseOnFailure: boolean;
+  pausedSignalPath: string;
+  signalsDir: string;
+  timelinePath: string;
+  bootStart: number;
+  containerName: string;
+  store: RunStateStore | undefined;
+  /** Called the first time a pause is detected — sets up the Enter-to-retry stdin listener. */
+  onNewPause: () => void;
+}
+
+/** Result of folding the timeline-records list into a render-ready shape. */
+interface BuiltSteps {
+  newSteps: StepState[];
+  totalDurationMs: number | undefined;
+  jobFinished: boolean;
+}
+
+/**
+ * Fold the raw actions-runner timeline records into the `StepState[]` shape
+ * the renderer expects. Mutates `state.lastFailedStep` when a step result is
+ * "failed". Skips duplicate names; the second occurrence (e.g. for a "Post"
+ * step) triggers a synthetic "Post Setup" row at the end.
+ */
+function buildStepsFromTimeline(steps: any[], state: TimelineSyncState): BuiltSteps {
+  const seenNames = new Set<string>();
+  let hasPostSteps = false;
+  let completeJobRecord: any = null;
+
+  const preCountNames = new Set<string>();
+  for (const r of steps) {
+    if (!preCountNames.has(r.name)) {
+      preCountNames.add(r.name);
+    } else {
+      hasPostSteps = true;
+    }
+  }
+
+  let stepIdx = 0;
+  const newSteps: StepState[] = [];
+
+  for (const r of steps) {
+    if (seenNames.has(r.name)) {
+      continue;
+    }
+    seenNames.add(r.name);
+
+    if (r.name === "Complete job") {
+      completeJobRecord = r;
+      continue;
+    }
+    stepIdx++;
+
+    const durationMs =
+      r.startTime && r.finishTime
+        ? new Date(r.finishTime).getTime() - new Date(r.startTime).getTime()
+        : undefined;
+
+    let status: StepState["status"];
+    if (!r.result && r.state !== "completed") {
+      if (r.startTime) {
+        status = state.isPaused && state.pausedStepName === r.name ? "paused" : "running";
+      } else {
+        status = "pending";
+      }
+    } else {
+      const result = (r.result || "").toLowerCase();
+      if (result === "failed") {
+        state.lastFailedStep = r.name;
+        status = "failed";
+      } else if (result === "skipped") {
+        status = "skipped";
+      } else {
+        status = "completed";
+      }
+    }
+
+    newSteps.push({
+      name: r.name,
+      index: stepIdx,
+      status,
+      startedAt: r.startTime,
+      completedAt: r.finishTime,
+      durationMs,
+    });
+  }
+
+  const jobFinished = !!completeJobRecord?.result;
+
+  if (hasPostSteps && jobFinished) {
+    stepIdx++;
+    newSteps.push({ name: "Post Setup", index: stepIdx, status: "completed" });
+  }
+
+  if (completeJobRecord && jobFinished) {
+    stepIdx++;
+    const durationMs =
+      completeJobRecord.startTime && completeJobRecord.finishTime
+        ? new Date(completeJobRecord.finishTime).getTime() -
+          new Date(completeJobRecord.startTime).getTime()
+        : undefined;
+    newSteps.push({
+      name: "Complete job",
+      index: stepIdx,
+      status: "completed",
+      startedAt: completeJobRecord.startTime,
+      completedAt: completeJobRecord.finishTime,
+      durationMs,
+    });
+  }
+
+  let totalDurationMs: number | undefined;
+  if (jobFinished) {
+    const allTimes = steps
+      .filter((r) => r.startTime && r.finishTime)
+      .map((r) => ({
+        start: new Date(r.startTime).getTime(),
+        end: new Date(r.finishTime).getTime(),
+      }));
+    if (allTimes.length > 0) {
+      const earliest = Math.min(...allTimes.map((t) => t.start));
+      const latest = Math.max(...allTimes.map((t) => t.end));
+      const ms = latest - earliest;
+      if (!Number.isNaN(ms) && ms >= 0) {
+        totalDurationMs = ms;
+      }
+    }
+  }
+
+  return { newSteps, totalDurationMs, jobFinished };
+}
+
+/**
+ * One poll tick of the actions-runner timeline.json into the RunStateStore.
+ * Reads the paused-signal file (if `pauseOnFailure` is set) and the timeline
+ * JSON; updates the store and the mutable `state` in place. Errors are
+ * swallowed — this is best-effort and runs every 100ms.
+ */
+export function syncTimelineToStore(state: TimelineSyncState, ctx: TimelineSyncContext): void {
+  try {
+    if (ctx.pauseOnFailure && fs.existsSync(ctx.pausedSignalPath)) {
+      const content = fs.readFileSync(ctx.pausedSignalPath, "utf8").trim();
+      const lines = content.split("\n");
+      state.pausedStepName = lines[0] || null;
+      const attempt = Number.parseInt(lines[1] || "1", 10);
+      const isNewAttempt = attempt !== state.lastSeenAttempt;
+      if (isNewAttempt) {
+        state.lastSeenAttempt = attempt;
+        state.isPaused = true;
+        state.pausedAtMs = Date.now();
+        ctx.onNewPause();
+      }
+
+      const tailLines = tailLogFile(path.join(ctx.signalsDir, "step-output"), 20);
+
+      ctx.store?.updateJob(ctx.containerName, {
+        status: "paused",
+        pausedAtStep: state.pausedStepName || undefined,
+        ...(isNewAttempt && state.pausedAtMs !== null
+          ? { pausedAtMs: new Date(state.pausedAtMs).toISOString(), attempt: state.lastSeenAttempt }
+          : {}),
+        lastOutputLines: tailLines,
+      });
+    } else if (state.isPaused && !fs.existsSync(ctx.pausedSignalPath)) {
+      state.isPaused = false;
+      state.pausedAtMs = null;
+      ctx.store?.updateJob(ctx.containerName, { status: "running", pausedAtMs: undefined });
+    }
+
+    if (!fs.existsSync(ctx.timelinePath)) {
+      return;
+    }
+
+    const records = JSON.parse(fs.readFileSync(ctx.timelinePath, "utf8")) as any[];
+    const steps = records
+      .filter((r) => r.type === "Task" && r.name)
+      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+
+    if (steps.length === 0) {
+      return;
+    }
+
+    if (state.isBooting) {
+      state.isBooting = false;
+      debugBoot(`${ctx.containerName} total: ${Date.now() - ctx.bootStart}ms`);
+      ctx.store?.updateJob(ctx.containerName, {
+        status: state.isPaused ? "paused" : "running",
+        bootDurationMs: Date.now() - ctx.bootStart,
+      });
+    }
+
+    const { newSteps, totalDurationMs, jobFinished } = buildStepsFromTimeline(steps, state);
+
+    ctx.store?.updateJob(ctx.containerName, {
+      steps: newSteps,
+      ...(jobFinished
+        ? {
+            status: state.lastFailedStep ? "failed" : "completed",
+            failedStep: state.lastFailedStep || undefined,
+            durationMs: totalDurationMs,
+          }
+        : {}),
+    });
+  } catch {
+    // Best-effort.
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,10 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.2)
+    optionalDependencies:
+      '@machinen/runtime':
+        specifier: 0.1.1
+        version: 0.1.1
 
   packages/dtu-github-actions:
     dependencies:
@@ -1043,6 +1047,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  '@homebridge/node-pty-prebuilt-multiarch@0.12.0':
+    resolution: {integrity: sha512-hJCGcfOnMeRh2KUdWPlVN/1egnfqI4yxgpDhqHSkF2DLn5fiJNdjEHHlcM1K2w9+QBmRE2D/wfmM4zUOb8aMyQ==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1249,6 +1256,41 @@ packages:
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@machinen/e2fsprogs-arm64-darwin@0.1.1':
+    resolution: {integrity: sha512-YkCnELB6kHt3LRtTF66TFh0sv5GItz3hD4Rl4dbbbZCtiKv93OA9tZdJ3n9KAO1PnbRqfDj/jwSCQFDrM6h78Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@machinen/e2fsprogs-arm64-linux@0.1.1':
+    resolution: {integrity: sha512-DkWLfiOK8TuCaY8bHWz4vFHDVh7a2E7iMtGXCSCiyr9RcM996nbFkcqR9UQkd5PopaNYo5K3KWdaKQKbT13qKQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@machinen/runtime@0.1.1':
+    resolution: {integrity: sha512-zCHjpeUut3z0PwqqJ1IcaurZhqNglhc1szxUNzpgT865hGA3Sayy4PYZQ8779Rg6tk3p8YUz86Zv0sKwln5UWg==}
+
+  '@machinen/squashfs-tools-arm64-darwin@0.1.1':
+    resolution: {integrity: sha512-3z/g2AZ0SK0bLPvDCr0WLtJt4aWYfmq+oOpnA2k0HLrnkm5STgyZdfJHKldjeJJhc1EYiCzxaVK1GXnmXc44Dw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@machinen/squashfs-tools-arm64-linux@0.1.1':
+    resolution: {integrity: sha512-Kmaj5BqFh5dwNlgrddWzMcDJ3WehCDE17PQUS8Mmz/lUhrj6n9vtJEcWdE3o8PhTSelZyCTxMdMGTI1QyH2cgg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@machinen/vmm-arm64-darwin@0.1.1':
+    resolution: {integrity: sha512-mHnZnFp4h0JTyg/7KF+jSPb/T85ro5LTMFhh16DHn0l5YcCN37SUuF50J6Hk9PGNKrSUUUOdCNUuRq4iS3Ygrg==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@machinen/vmm-arm64-linux@0.1.1':
+    resolution: {integrity: sha512-Q9wiSzXnh5mwEgXMLF4ULcOX5d+ysj++fSHiRZA71HsfI/VzYajCWQi+Z35wvdZUPTUCZgEi4OaVD2GsZEL43Q==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -2624,6 +2666,10 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   decompress-tar@4.1.1:
     resolution: {integrity: sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==}
     engines: {node: '>=4'}
@@ -2643,6 +2689,10 @@ packages:
   decompress@4.2.1:
     resolution: {integrity: sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==}
     engines: {node: '>=4'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -2906,6 +2956,10 @@ packages:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -3077,6 +3131,9 @@ packages:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
 
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -3222,6 +3279,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -3701,6 +3761,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   miniflare@4.20260301.1:
     resolution: {integrity: sha512-fqkHx0QMKswRH9uqQQQOU/RoaS3Wjckxy3CUX3YGJr0ZIMu7ObvI+NovdYi6RIsSPthNtq+3TPmRNxjeRiasog==}
     engines: {node: '>=18.0.0'}
@@ -3716,6 +3780,9 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -3746,6 +3813,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -3759,6 +3829,10 @@ packages:
   netmask@2.1.1:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
     engines: {node: '>= 0.4.0'}
+
+  node-abi@3.91.0:
+    resolution: {integrity: sha512-B+S7X/GS3Un6wMICtnsNjQD7oSpVBQrZftHE6GZ1Fe9/k3XOOoqbM5DZZ0GO4x3YiSCQfrM28yj1ppplwgIsfg==}
+    engines: {node: '>=10'}
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
@@ -3975,6 +4049,12 @@ packages:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -4042,6 +4122,10 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -4266,6 +4350,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -4377,6 +4467,10 @@ packages:
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -4539,6 +4633,9 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
@@ -5615,6 +5712,12 @@ snapshots:
       protobufjs: 7.5.4
       yargs: 17.7.2
 
+  '@homebridge/node-pty-prebuilt-multiarch@0.12.0':
+    dependencies:
+      node-addon-api: 7.1.1
+      prebuild-install: 7.1.3
+    optional: true
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -5764,6 +5867,39 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@machinen/e2fsprogs-arm64-darwin@0.1.1':
+    optional: true
+
+  '@machinen/e2fsprogs-arm64-linux@0.1.1':
+    optional: true
+
+  '@machinen/runtime@0.1.1':
+    dependencies:
+      '@homebridge/node-pty-prebuilt-multiarch': 0.12.0
+      debug: 4.4.3
+    optionalDependencies:
+      '@machinen/e2fsprogs-arm64-darwin': 0.1.1
+      '@machinen/e2fsprogs-arm64-linux': 0.1.1
+      '@machinen/squashfs-tools-arm64-darwin': 0.1.1
+      '@machinen/squashfs-tools-arm64-linux': 0.1.1
+      '@machinen/vmm-arm64-darwin': 0.1.1
+      '@machinen/vmm-arm64-linux': 0.1.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  '@machinen/squashfs-tools-arm64-darwin@0.1.1':
+    optional: true
+
+  '@machinen/squashfs-tools-arm64-linux@0.1.1':
+    optional: true
+
+  '@machinen/vmm-arm64-darwin@0.1.1':
+    optional: true
+
+  '@machinen/vmm-arm64-linux@0.1.1':
+    optional: true
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -6969,6 +7105,11 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+    optional: true
+
   decompress-tar@4.1.1:
     dependencies:
       file-type: 5.2.0
@@ -7006,6 +7147,9 @@ snapshots:
       make-dir: 1.3.0
       pify: 2.3.0
       strip-dirs: 2.1.0
+
+  deep-extend@0.6.0:
+    optional: true
 
   deep-is@0.1.4: {}
 
@@ -7389,6 +7533,9 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
+  expand-template@2.0.3:
+    optional: true
+
   expect-type@1.3.0: {}
 
   extend-shallow@2.0.1:
@@ -7573,6 +7720,9 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  github-from-package@0.0.0:
+    optional: true
 
   glob-parent@5.1.2:
     dependencies:
@@ -7794,6 +7944,9 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
+
+  ini@1.3.8:
+    optional: true
 
   inline-style-parser@0.2.7: {}
 
@@ -8384,6 +8537,9 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  mimic-response@3.1.0:
+    optional: true
+
   miniflare@4.20260301.1:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -8408,6 +8564,9 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.14
 
+  minimist@1.2.8:
+    optional: true
+
   minipass@7.1.3: {}
 
   mitt@3.0.1: {}
@@ -8425,6 +8584,9 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0:
+    optional: true
+
   natural-compare@1.4.0: {}
 
   natural-orderby@5.0.0: {}
@@ -8432,6 +8594,11 @@ snapshots:
   neo-async@2.6.2: {}
 
   netmask@2.1.1: {}
+
+  node-abi@3.91.0:
+    dependencies:
+      semver: 7.7.4
+    optional: true
 
   node-addon-api@7.1.1: {}
 
@@ -8666,6 +8833,22 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.91.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+    optional: true
+
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
@@ -8763,6 +8946,14 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+    optional: true
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
@@ -9121,6 +9312,16 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1:
+    optional: true
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+    optional: true
+
   slash@3.0.0: {}
 
   slice-ansi@7.1.2:
@@ -9237,6 +9438,9 @@ snapshots:
       is-natural-number: 4.0.1
 
   strip-final-newline@4.0.0: {}
+
+  strip-json-comments@2.0.1:
+    optional: true
 
   strip-json-comments@3.1.1: {}
 
@@ -9409,6 +9613,11 @@ snapshots:
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
+    optional: true
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
     optional: true
 
   tweetnacl@0.14.5: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,8 +141,8 @@ importers:
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
       '@machinen/runtime':
-        specifier: 0.1.1
-        version: 0.1.1
+        specifier: 0.3.3
+        version: 0.3.3
 
   packages/dtu-github-actions:
     dependencies:
@@ -1257,40 +1257,20 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  '@machinen/e2fsprogs-arm64-darwin@0.1.1':
-    resolution: {integrity: sha512-YkCnELB6kHt3LRtTF66TFh0sv5GItz3hD4Rl4dbbbZCtiKv93OA9tZdJ3n9KAO1PnbRqfDj/jwSCQFDrM6h78Q==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@machinen/e2fsprogs-arm64-linux@0.1.1':
-    resolution: {integrity: sha512-DkWLfiOK8TuCaY8bHWz4vFHDVh7a2E7iMtGXCSCiyr9RcM996nbFkcqR9UQkd5PopaNYo5K3KWdaKQKbT13qKQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@machinen/runtime@0.1.1':
-    resolution: {integrity: sha512-zCHjpeUut3z0PwqqJ1IcaurZhqNglhc1szxUNzpgT865hGA3Sayy4PYZQ8779Rg6tk3p8YUz86Zv0sKwln5UWg==}
-
-  '@machinen/squashfs-tools-arm64-darwin@0.1.1':
-    resolution: {integrity: sha512-3z/g2AZ0SK0bLPvDCr0WLtJt4aWYfmq+oOpnA2k0HLrnkm5STgyZdfJHKldjeJJhc1EYiCzxaVK1GXnmXc44Dw==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@machinen/squashfs-tools-arm64-linux@0.1.1':
-    resolution: {integrity: sha512-Kmaj5BqFh5dwNlgrddWzMcDJ3WehCDE17PQUS8Mmz/lUhrj6n9vtJEcWdE3o8PhTSelZyCTxMdMGTI1QyH2cgg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@machinen/vmm-arm64-darwin@0.1.1':
-    resolution: {integrity: sha512-mHnZnFp4h0JTyg/7KF+jSPb/T85ro5LTMFhh16DHn0l5YcCN37SUuF50J6Hk9PGNKrSUUUOdCNUuRq4iS3Ygrg==}
+  '@machinen/native-arm64-darwin@0.3.3':
+    resolution: {integrity: sha512-8ZNkllnzvOaH+RZ9qCSrjC3EuhLxmWbmvz/+oIFfg56BUH4BEGtA2RslEFWElYnfJAm0AGPFAV7SKHkM4O64ig==}
     cpu: [arm64]
     os: [darwin]
     hasBin: true
 
-  '@machinen/vmm-arm64-linux@0.1.1':
-    resolution: {integrity: sha512-Q9wiSzXnh5mwEgXMLF4ULcOX5d+ysj++fSHiRZA71HsfI/VzYajCWQi+Z35wvdZUPTUCZgEi4OaVD2GsZEL43Q==}
+  '@machinen/native-arm64-linux@0.3.3':
+    resolution: {integrity: sha512-9uJTy4MJZvN9KB8jJBQHsdz9EWq88tXDJSr9030tEf8bK19GV5mVoSe63soR74w8MMMRT/piCbxSWmXLAUNINg==}
     cpu: [arm64]
     os: [linux]
     hasBin: true
+
+  '@machinen/runtime@0.3.3':
+    resolution: {integrity: sha512-lLKb/+G/V5Bab85Ec3d2VIuprGqdTsr5WxcuWqoeKHIheHDBn0d3bksu+q+Si5ecZAAsq5L1Fe8y32Lf2oIFng==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -5900,37 +5880,21 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@machinen/e2fsprogs-arm64-darwin@0.1.1':
+  '@machinen/native-arm64-darwin@0.3.3':
     optional: true
 
-  '@machinen/e2fsprogs-arm64-linux@0.1.1':
+  '@machinen/native-arm64-linux@0.3.3':
     optional: true
 
-  '@machinen/runtime@0.1.1':
+  '@machinen/runtime@0.3.3':
     dependencies:
       '@homebridge/node-pty-prebuilt-multiarch': 0.12.0
       debug: 4.4.3
     optionalDependencies:
-      '@machinen/e2fsprogs-arm64-darwin': 0.1.1
-      '@machinen/e2fsprogs-arm64-linux': 0.1.1
-      '@machinen/squashfs-tools-arm64-darwin': 0.1.1
-      '@machinen/squashfs-tools-arm64-linux': 0.1.1
-      '@machinen/vmm-arm64-darwin': 0.1.1
-      '@machinen/vmm-arm64-linux': 0.1.1
+      '@machinen/native-arm64-darwin': 0.3.3
+      '@machinen/native-arm64-linux': 0.3.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
-
-  '@machinen/squashfs-tools-arm64-darwin@0.1.1':
-    optional: true
-
-  '@machinen/squashfs-tools-arm64-linux@0.1.1':
-    optional: true
-
-  '@machinen/vmm-arm64-darwin@0.1.1':
-    optional: true
-
-  '@machinen/vmm-arm64-linux@0.1.1':
     optional: true
 
   '@manypkg/find-root@1.1.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,10 @@ packages:
   - "packages/dtu-github-actions"
   - "packages/ts-runner"
   - "apps/website"
+
+# @machinen/* are first-party packages co-authored by this repo's
+# maintainers, so the global 7-day minimumReleaseAge supply-chain guard
+# is skipped for them and their nested dependencies. Other packages
+# still observe the policy.
+minimumReleaseAgeExclude:
+  - "@machinen/*"

--- a/scripts/machinen-bake.mjs
+++ b/scripts/machinen-bake.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Bake the machinen rootfs that agent-ci publishes as a GitHub Release
+// asset. Release-only tooling — not used by the CLI at runtime.
+//
+// Boots a debian-arm64 base VM via @machinen/runtime.provision(), apt-installs
+// the package set agent-ci needs, downloads + extracts the GHA runner binary,
+// and writes the result to a tarball machinen.boot() can consume directly.
+// See docs/adr/0004-machinen-rootfs-as-release-asset.md.
+//
+// Usage:
+//   node scripts/machinen-bake.mjs [--out <path>]
+//
+// Output defaults to dist/agent-ci-machinen-runner-arm64.tar.gz at repo root.
+// The release workflow uploads that file to the `machinen-rootfs-latest`
+// GitHub release.
+//
+// Requirements:
+//   - Host is arm64 darwin or arm64 linux (so machinen's VMM bindings load).
+//   - `@machinen/cli` has been run at least once on this host so the base
+//     debian-arm64 assets exist at ~/.machinen/runtime-v<ver>/bases/, or
+//     MACHINEN_ASSETS_DIR points at a directory with them.
+
+import { mkdir, stat } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+
+// Pinned alongside DEFAULT_MACOS_RUNNER_VERSION in
+// packages/cli/src/runner/macos-vm/runner-binary.ts.
+const RUNNER_VERSION = "2.331.0";
+const RUNNER_URL = `https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz`;
+
+// Mirrors what ghcr.io/actions/actions-runner:latest itself ships so
+// workflows see the same baseline regardless of runtime.
+const APT_PACKAGES = ["nodejs", "git", "curl", "ca-certificates", "jq", "unzip"];
+
+// Where the runner binary lands inside the baked rootfs. Matches the
+// upstream actions-runner image convention.
+const GUEST_RUNNER_DIR = "/home/runner";
+
+const args = process.argv.slice(2);
+let outPath = resolve(repoRoot, "dist/agent-ci-machinen-runner-arm64.tar.gz");
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--out" && args[i + 1]) {
+    outPath = resolve(args[++i]);
+  } else if (args[i] === "--help" || args[i] === "-h") {
+    process.stdout.write(
+      "Usage: node scripts/machinen-bake.mjs [--out <path>]\n" +
+        "Default --out: dist/agent-ci-machinen-runner-arm64.tar.gz\n",
+    );
+    process.exit(0);
+  }
+}
+
+await mkdir(dirname(outPath), { recursive: true });
+
+const mod = await import("@machinen/runtime").catch((err) => {
+  process.stderr.write(
+    `failed to load @machinen/runtime: ${err?.message ?? err}\n` +
+      "Run `pnpm install` (the package is an optionalDependency of @redwoodjs/agent-ci).\n",
+  );
+  process.exit(1);
+});
+
+const installCmds = [
+  "set -e",
+  "export DEBIAN_FRONTEND=noninteractive",
+  "apt-get update",
+  `apt-get install -y --no-install-recommends ${APT_PACKAGES.join(" ")}`,
+  `mkdir -p ${GUEST_RUNNER_DIR}`,
+  `curl -fsSL ${RUNNER_URL} -o /tmp/actions-runner.tar.gz`,
+  `tar -xzf /tmp/actions-runner.tar.gz -C ${GUEST_RUNNER_DIR}`,
+  "rm -f /tmp/actions-runner.tar.gz",
+  "apt-get clean",
+  "rm -rf /var/lib/apt/lists/*",
+].join("\n");
+
+process.stderr.write(`machinen-bake: writing ${outPath}\n`);
+const t0 = Date.now();
+
+await mod.provision({
+  out: outPath,
+  install: async (vm) => {
+    const result = await vm.exec(installCmds, { execTimeoutMs: 10 * 60 * 1000 });
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `install hook failed with exit code ${result.exitCode}.\n` +
+          `stderr (tail): ${result.stderr.slice(-2048)}`,
+      );
+    }
+  },
+});
+
+const { size } = await stat(outPath);
+const mb = (size / (1024 * 1024)).toFixed(1);
+process.stderr.write(`machinen-bake: ok in ${Date.now() - t0}ms — ${mb} MB at ${outPath}\n`);


### PR DESCRIPTION
## Problem

agent-ci ships two ways to actually run a GitHub Actions job locally today: a Docker container for `runs-on: ubuntu-*` jobs, and a macOS virtual machine via `tart` for `runs-on: macos-*` jobs. Both are fine but cost something. Docker on macOS runs through Docker Desktop or OrbStack — extra software the user has to install and keep running, plus the boot-time and memory cost of the Linux VM that hosts the containers. The macOS VM path tops out at two virtual machines per host because that's what Apple's Virtualization framework allows.

On Apple Silicon Macs and arm64 Linux there is a faster option: tiny dedicated Linux virtual machines started in milliseconds via the [machinen](https://github.com/redwoodjs/machinen) runtime. Each job gets its own kernel and root filesystem, with no shared Docker daemon and no Virtualization-framework cap. We want to make that available to users without forcing it on them and without breaking anyone who already has the Docker setup working.

## Solution

Add a third way to run jobs — "machinen" — and pick it for a job the same way we already pick between docker and the macOS VM. Make it opt-in for now by gating it behind an environment variable (`AGENT_CI_MACHINEN=1`), so today's users see no change.

1. **Pick a runtime per job.** Replace the hand-written `if (macos) … else docker` with a small registry that asks each runtime "can you run this job, on this host?" and picks the first one that says yes. Priority is machinen, then macOS VM, then docker. Users can force a specific runtime within the same operating-system family by setting `AGENT_CI_RUNTIME`.
2. **Ship a ready-to-boot Linux root filesystem.** agent-ci publishes a `~300 MB` tarball as a release asset on this repository. The first time a user runs a machinen job, agent-ci downloads the asset and caches it. Re-runs do a conditional fetch (only re-download when it changed) and fall back to the cached copy when the network is down. Users who want to ship their own image drop a file at `<repo>/.github/agent-ci.machinen.tar.gz` and agent-ci uses that verbatim.
3. **Bake the asset at release time.** A new workflow (`machinen-rootfs.yml`) runs on a GitHub-hosted Apple Silicon runner, bakes the tarball (Debian + nodejs/git/curl/jq/unzip + the GitHub Actions runner binary), and uploads it to a rolling `machinen-rootfs-latest` release. Re-bake when upstream `actions/runner` ships an update or we add a package.
4. **Run a full GitHub Actions job inside a microVM.** When the machinen runtime is picked for a job, agent-ci boots a tiny Linux VM from the cached image, live-mounts the per-job work directory and a few helper directories from the host into the guest, drops the runner's configuration files in via the runtime's `writeFile` primitive, launches `run.sh` inside the guest, and streams its output back to the host. The guest reaches a per-job mock GitHub API on the host at the user-mode-NAT address `192.168.127.254`. When pause-on-failure is on, a wrapper around each step writes a small "paused" file the host can see, and a `retry` or `abort` written back by the host is seen by the wrapper — same protocol the docker path already uses, just propagated through the live-mounted directory.
5. **Honest about what's gated.** The machinen path doesn't go live for users until they set `AGENT_CI_MACHINEN=1`. The host-capability check returns "not enabled" otherwise, so the runtime selector keeps picking docker exactly as before.

## Technical Summary

Concretely:

- `packages/cli/src/runner/runtime.ts` — new `Runtime` interface (`name`, `checkHost`, `supportsJob`, `execute`), registry, and `selectRuntime()` with priority order `[machinen, macos-vm, docker]`. `AGENT_CI_RUNTIME` re-orders the candidate set; it does **not** bypass `supportsJob` (so `AGENT_CI_RUNTIME=docker` on a `runs-on: macos-15` job still routes through the unsupported-OS skip).
- `packages/cli/src/commands/run.ts` — `executeLocalJob` / `executeMacosVmJob` `if`/`else` replaced with a one-shot `probeRuntimes()` at startup and a per-job `selectRuntime(kind, probed, override)`.
- `packages/cli/src/runner/timeline-sync.ts` — extracted from `local-job.ts` so both runtimes share the same `timeline.json` poll-and-publish logic.
- `packages/cli/src/runner/runner-credentials.ts` — added `buildRunnerCredentials()` returning the three runner-config JSON strings; `writeRunnerCredentials()` delegates to it so machinen can `vm.writeFile` the contents directly.
- `packages/cli/src/runner/machinen/rootfs.ts` — override-or-download, conditional GET (`If-None-Match` + `If-Modified-Since`), cache at `~/.cache/agent-ci/machinen/base.tar.gz`, fall back to cache on network failure, single-flight on cold first use, atomic `.partial` → final rename.
- `packages/cli/src/runner/machinen/image-mapping.ts` — thin resolver around the override / download decision.
- `packages/cli/src/runner/machinen/machinen-job.ts` — full `executeMachinenJob`: starts the per-job ephemeral DTU (mock GitHub API) on the host, boots a VM with `liveMounts` for work / shims / diag / signals (+ signals only when `--pause-on-failure`), installs symlinks (`/home/runner/_work → /mnt/work` etc.) and the git shim via `vm.exec`, writes `.runner` / `.credentials` / `.credentials_rsaparams` via `vm.writeFile`, launches `cd /home/runner && RUNNER_ALLOW_RUNASROOT=1 exec ./run.sh --once` with `execTimeoutMs: null`, streams stdout/stderr into the host-side debug log, polls `timeline.json` via the shared `timeline-sync` module, tears the VM down on completion.
- `packages/cli/src/runner/machinen/host-capability.ts` — gates machinen behind `AGENT_CI_MACHINEN=1` after the arm64 + Linux/Darwin + `require.resolve("@machinen/runtime")` checks pass.
- `scripts/machinen-bake.mjs` + `.github/workflows/machinen-rootfs.yml` — release-time tooling. Calls `@machinen/runtime.provision()` against Debian arm64 with the pinned package list + GHA runner download, uploads to the `machinen-rootfs-latest` rolling release with `gh release upload --clobber`. Workflow chmods machinen's bundled binaries as a workaround for [redwoodjs/machinen#309](https://github.com/redwoodjs/machinen/issues/309).
- `pnpm-workspace.yaml` — adds `@machinen/*` to `minimumReleaseAgeExclude` so pnpm's global 7-day supply-chain guard doesn't block install on first-party packages.
- `packages/cli/package.json` — `@machinen/runtime@0.1.1` as an `optionalDependency` (arm64 darwin/linux only).
- `docs/adr/0001-0004` — full design record (selection, rootfs sourcing, execution model, release-asset distribution).
- Tests: 41 new unit tests across the machinen module + runtime selection; the previously-inlined timeline-sync code is now covered through both runtimes via the existing `local-job` integration paths.

Verified end-to-end on this host:

- `AGENT_CI_MACHINEN=1 agent-ci run --workflow test.yml` → `Status: ✓ 1 passed (1 total) — Duration 2s` (cached rootfs).
- `AGENT_CI_MACHINEN=1 agent-ci run --workflow fail.yml --pause-on-failure` → emits `{"event":"run.paused", "runner":"agent-ci-...", "step":"deliberately fail", "retry_cmd":"agent-ci retry --name ..."}`. Host-written `signals/abort` is picked up by the wrapper inside the guest, the runner shuts down, the VM tears down on its own.
- Default (gate off) runs go through docker exactly as before.

## Test plan

- [ ] `pnpm test` and `pnpm check` pass
- [ ] `/agent-ci-dev` against every workflow in `.github/workflows/` (docker default path)
- [ ] Manual: `AGENT_CI_MACHINEN=1 agent-ci run --workflow ...` on an arm64-darwin host
- [ ] Manual: `AGENT_CI_MACHINEN=1 agent-ci run --workflow ... --pause-on-failure` confirms pause + retry/abort round-trip
- [ ] Once merged: trigger `.github/workflows/machinen-rootfs.yml` to publish the first release asset