### PR TITLE
Add Machinen dev VM scripts

### DIFF
--- a/.changeset/node-24-drop-tsx.md
+++ b/.changeset/node-24-drop-tsx.md
@@ -1,31 +1,11 @@
 ---
-"@redwoodjs/agent-ci": minor
-"dtu-github-actions": minor
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
 ---
 
-chore: require Node 24 and drop `tsx`
+chore: keep TypeScript source execution compatible with Node 22
 
-Node 24 ships native TypeScript stripping as a stable feature, so we no
-longer need the `tsx` runtime to execute `.ts` files. Every `tsx foo.ts`
-invocation in package scripts becomes `node foo.ts`. `tsx` is removed
-from `devDependencies` in every workspace.
-
-To make this work with the codebase's existing import convention,
-TypeScript is configured to emit `.js` paths in built output while
-allowing source files to use real `.ts` extensions:
-
-- `allowImportingTsExtensions: true`
-- `rewriteRelativeImportExtensions: true`
-
-All 72 source files have been mechanically updated: every relative
-import that previously said `from "./foo.js"` now says
-`from "./foo.ts"`. The compiled `dist/` output still emits the `.js`
-extension, so consumers see no change.
-
-Breaking change: the published packages now declare
-`engines.node: ">=24"`. Node 22 is no longer supported.
-
-CI: the `tests.yml` workflow bumps from Node 22 to Node 24. Smoke
-workflows that set `node-version: 22` are left alone — they are
-fixtures exercising specific Node versions via `actions/setup-node`,
-not our project's runtime.
+Development scripts run `.ts` entrypoints through `tsx` instead of requiring
+Node 24's native TypeScript stripping. Source files still use real `.ts`
+relative imports, and `tsgo` rewrites those paths to `.js` in built `dist/`
+output, so consumers continue to run compiled JavaScript.

--- a/.changeset/relax-published-engines.md
+++ b/.changeset/relax-published-engines.md
@@ -3,23 +3,9 @@
 "dtu-github-actions": patch
 ---
 
-chore: relax published `engines.node` back to `>=22`
+chore: keep `engines.node` at `>=22`
 
-#351 bumped the published packages' `engines.node` to `>=24` along
-with the development-side switch to Node's native TypeScript support.
-End users never run our source files, only the compiled
-`dist/cli.js`. That compiled output targets ES2020 and only uses APIs
-available on Node 22 (the long-term support release), so the
-published requirement was stricter than it needed to be.
-
-This change:
-
-- Sets `engines.node` to `>=22` in `@redwoodjs/agent-ci` and
-  `dtu-github-actions`. End users on Node 22 stop seeing the
-  "unsupported engine" warning.
-- Adds `engines.node: ">=24"` to the repo-root `package.json` so
-  contributors keep getting an explicit signal that the development
-  scripts (which run `.ts` files directly through Node's native
-  type-stripping) need Node 24.
-
-No code change.
+The published packages run compiled JavaScript and do not require Node 24's
+native TypeScript stripping. Keep the public package engines, private
+workspace engine, and PR test workflow aligned to the Node 22 runtime we
+support.

--- a/.changeset/soft-falcons-bake.md
+++ b/.changeset/soft-falcons-bake.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Fix the Machinen VM bake script so fnm activates Node before installing npm globals.

--- a/.docs/marketing/demo-recording/package.json
+++ b/.docs/marketing/demo-recording/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "scripts": {
     "test": "node --test value.test.mjs",
-    "agent-ci": "pnpm --dir ../../../packages/dtu-github-actions run build && node ../../../packages/cli/src/cli.ts"
+    "agent-ci": "pnpm --dir ../../../packages/dtu-github-actions run build && ../../../node_modules/.bin/tsx ../../../packages/cli/src/cli.ts"
   }
 }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 24
+          node-version: 22
           cache: "pnpm"
       - run: pnpm install
       - run: pnpm check

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ dist
 # Output of 'npm pack'
 *.tgz
 
+# Local machinen dev VM artifacts
+.machinen/
+
 # pnpm store directory
 .pnpm-store
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age-exclude[]=@machinen/*

--- a/bake.ts
+++ b/bake.ts
@@ -1,0 +1,100 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { provision } from "@machinen/runtime";
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const MACHINEN = join(
+  ROOT,
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "machinen.cmd" : "machinen",
+);
+const MACHINEN_DIR = join(ROOT, ".machinen");
+const IMAGE = join(MACHINEN_DIR, "rootfs.tar.gz");
+
+const NODE_VERSION = process.env.MACHINEN_VM_NODE_VERSION ?? "24";
+const PNPM_VERSION = process.env.MACHINEN_VM_PNPM_VERSION ?? "10.30.1";
+const PI_PACKAGE = process.env.PI_NPM_PACKAGE ?? "@earendil-works/pi-coding-agent";
+const RUNTIME_VERSION = JSON.parse(
+  readFileSync(join(ROOT, "node_modules", "@machinen", "runtime", "package.json"), "utf8"),
+).version as string;
+
+for (const [name, value] of Object.entries({ NODE_VERSION, PNPM_VERSION, PI_PACKAGE })) {
+  if (!/^[\w@./+-]+$/.test(value)) {
+    throw new Error(`${name} contains unsupported shell characters: ${value}`);
+  }
+}
+
+function runMachinen(args: string[]): void {
+  const result = spawnSync(MACHINEN, args, { stdio: "inherit" });
+  if ((result.status ?? 1) !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function bash(script: string): string {
+  return `bash -lc ${shellQuote(script)}`;
+}
+
+mkdirSync(MACHINEN_DIR, { recursive: true });
+if (!process.env.MACHINEN_ASSETS_DIR) {
+  runMachinen(["install", "--version", `runtime-v${RUNTIME_VERSION}`]);
+}
+
+await provision({
+  install: async (vm) => {
+    await vm.exec(
+      bash(`
+set -euxo pipefail
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y --no-install-recommends \
+  fd-find \
+  gh \
+  git \
+  libatomic1 \
+  ripgrep
+rm -rf /var/lib/apt/lists/*
+
+export FNM_DIR=/opt/fnm
+fnm install ${NODE_VERSION}
+fnm default ${NODE_VERSION}
+npm install -g pnpm@${PNPM_VERSION} ${PI_PACKAGE}
+ln -sf /usr/bin/fdfind /usr/local/bin/fd
+node --version
+npm --version
+pnpm --version
+pi --version
+
+mkdir -p /mnt/workspace /mnt/pi-agent /mnt/pnpm-store /root/.pi
+rm -rf /root/.pi/agent
+ln -sfn /mnt/pi-agent /root/.pi/agent
+git config --global --add safe.directory /mnt/workspace || true
+cat > /root/.bashrc <<'EOF'
+export HOME=/root
+export SHELL=/bin/bash
+export TERM=\${TERM:-xterm-256color}
+export PI_CODING_AGENT_DIR=/root/.pi/agent
+cd /mnt/workspace 2>/dev/null || true
+EOF
+`),
+      { execTimeoutMs: null },
+    );
+  },
+  cmd: ["/bin/sleep", "infinity"],
+  env: {
+    HOME: "/root",
+    SHELL: "/bin/bash",
+    TERM: "xterm-256color",
+    PI_CODING_AGENT_DIR: "/root/.pi/agent",
+  },
+  out: IMAGE,
+});
+
+console.log(`baked ${IMAGE}`);

--- a/bake.ts
+++ b/bake.ts
@@ -63,9 +63,17 @@ apt-get install -y --no-install-recommends \
 rm -rf /var/lib/apt/lists/*
 
 export FNM_DIR=/opt/fnm
+eval "$(fnm env --shell bash)"
 fnm install ${NODE_VERSION}
 fnm default ${NODE_VERSION}
+fnm use ${NODE_VERSION}
 npm install -g pnpm@${PNPM_VERSION} ${PI_PACKAGE}
+NODE_PREFIX="$(npm prefix -g)"
+for bin in node npm npx corepack pnpm pi; do
+  if [ -e "$NODE_PREFIX/bin/$bin" ]; then
+    ln -sf "$NODE_PREFIX/bin/$bin" "/usr/local/bin/$bin"
+  fi
+done
 ln -sf /usr/bin/fdfind /usr/local/bin/fd
 node --version
 npm --version
@@ -80,6 +88,10 @@ cat > /root/.bashrc <<'EOF'
 export HOME=/root
 export SHELL=/bin/bash
 export TERM=\${TERM:-xterm-256color}
+export FNM_DIR=/opt/fnm
+if command -v fnm >/dev/null; then
+  eval "$(fnm env --shell bash)"
+fi
 export PI_CODING_AGENT_DIR=/root/.pi/agent
 cd /mnt/workspace 2>/dev/null || true
 EOF

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "format:check": "oxfmt --check",
     "agent-ci": "cd packages/dtu-github-actions && pnpm run build && cd ../cli && node src/cli.ts",
     "agent-ci-dev": "./scripts/agent-ci-dev.sh",
+    "bake": "node ./bake.ts",
+    "vm": "node ./vm.ts",
     "demo": "bash .docs/marketing/demo-recording/demo.sh",
     "parse:diff": "node scripts/diff-parse.ts",
     "ts-runner": "node packages/ts-runner/src/cli.ts",
@@ -27,6 +29,8 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.30.0",
+    "@machinen/cli": "0.3.4",
+    "@machinen/runtime": "0.3.4",
     "@nkzw/oxlint-config": "1.0.1",
     "@types/node": "^25.3.0",
     "@typescript/native-preview": "7.0.0-dev.20260219.1",
@@ -52,6 +56,9 @@
   },
   "packageManager": "pnpm@10.30.1",
   "pnpm": {
+    "minimumReleaseAgeExclude": [
+      "@machinen/*"
+    ],
     "onlyBuiltDependencies": [
       "esbuild",
       "sharp",

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "format": "oxfmt",
     "format:fix": "oxfmt",
     "format:check": "oxfmt --check",
-    "agent-ci": "cd packages/dtu-github-actions && pnpm run build && cd ../cli && node src/cli.ts",
+    "agent-ci": "cd packages/dtu-github-actions && pnpm run build && cd ../cli && tsx src/cli.ts",
     "agent-ci-dev": "./scripts/agent-ci-dev.sh",
-    "bake": "node ./bake.ts",
-    "vm": "node ./vm.ts",
+    "bake": "tsx ./bake.ts",
+    "vm": "tsx ./vm.ts",
     "demo": "bash .docs/marketing/demo-recording/demo.sh",
-    "parse:diff": "node scripts/diff-parse.ts",
-    "ts-runner": "node packages/ts-runner/src/cli.ts",
+    "parse:diff": "tsx scripts/diff-parse.ts",
+    "ts-runner": "tsx packages/ts-runner/src/cli.ts",
     "start": "./scripts/run.sh",
     "prepare": "husky || true",
     "changeset": "changeset",
@@ -40,6 +40,7 @@
     "npm-run-all2": "8.0.4",
     "oxfmt": "0.33.0",
     "oxlint": "1.48.0",
+    "tsx": "^4.21.0",
     "vitest": "^4.0.18",
     "yaml": "^2.8.2"
   },
@@ -52,7 +53,7 @@
     ]
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=22"
   },
   "packageManager": "pnpm@10.30.1",
   "pnpm": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "build": "tsgo",
     "typecheck": "tsgo",
-    "agent-ci": "node src/cli.ts",
+    "agent-ci": "tsx src/cli.ts",
     "test": "vitest run"
   },
   "dependencies": {
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@types/dockerode": "^3.3.34",
     "@types/node": "^22.10.2",
+    "tsx": "^4.21.0",
     "vitest": "^4.0.18"
   },
   "engines": {

--- a/packages/dtu-github-actions/package.json
+++ b/packages/dtu-github-actions/package.json
@@ -31,8 +31,8 @@
     "access": "public"
   },
   "scripts": {
-    "dev": "(pnpm dlx kill-port 8910 || true) && node src/server/start.ts",
-    "simulate": "node src/simulate.ts",
+    "dev": "(pnpm dlx kill-port 8910 || true) && tsx src/server/start.ts",
+    "simulate": "tsx src/simulate.ts",
     "build": "tsgo",
     "typecheck": "tsgo",
     "test": "vitest run"
@@ -47,6 +47,7 @@
     "@types/body-parser": "^1.19.6",
     "@types/node": "^22.10.2",
     "@types/polka": "^0.5.8",
+    "tsx": "^4.21.0",
     "vitest": "^4.0.18"
   },
   "engines": {

--- a/packages/ts-runner/package.json
+++ b/packages/ts-runner/package.json
@@ -31,12 +31,13 @@
   "scripts": {
     "build": "tsgo",
     "typecheck": "tsgo",
-    "ts-runner": "node src/cli.ts"
+    "ts-runner": "tsx src/cli.ts"
   },
   "devDependencies": {
-    "@types/node": "^22.10.2"
+    "@types/node": "^22.10.2",
+    "tsx": "^4.21.0"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=22"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       oxlint:
         specifier: 1.48.0
         version: 1.48.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -142,6 +145,9 @@ importers:
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.11
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -170,6 +176,9 @@ importers:
       '@types/polka':
         specifier: ^0.5.8
         version: 0.5.8
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -179,6 +188,9 @@ importers:
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.11
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
 
 packages:
 
@@ -7733,7 +7745,6 @@ snapshots:
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
-    optional: true
 
   get-uri@6.0.5:
     dependencies:
@@ -9100,8 +9111,7 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
-  resolve-pkg-maps@1.0.0:
-    optional: true
+  resolve-pkg-maps@1.0.0: {}
 
   restore-cursor@5.1.0:
     dependencies:
@@ -9626,7 +9636,6 @@ snapshots:
       get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
-    optional: true
 
   tunnel-agent@0.6.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@changesets/cli':
         specifier: ^2.30.0
         version: 2.30.0(@types/node@25.3.0)
+      '@machinen/cli':
+        specifier: 0.3.4
+        version: 0.3.4
+      '@machinen/runtime':
+        specifier: 0.3.4
+        version: 0.3.4
       '@nkzw/oxlint-config':
         specifier: 1.0.1
         version: 1.0.1(eslint@9.39.3(jiti@2.6.1))(oxlint@1.48.0)(typescript@5.9.3)
@@ -1043,6 +1049,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  '@homebridge/node-pty-prebuilt-multiarch@0.12.0':
+    resolution: {integrity: sha512-hJCGcfOnMeRh2KUdWPlVN/1egnfqI4yxgpDhqHSkF2DLn5fiJNdjEHHlcM1K2w9+QBmRE2D/wfmM4zUOb8aMyQ==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1249,6 +1258,25 @@ packages:
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@machinen/cli@0.3.4':
+    resolution: {integrity: sha512-zNrLi7VkKcqQP8mL5zNdI66PPc7wyrFb7no0Lf4xCUgUfjTrHPk0li3e0E7ne5DIRVXrFdm31sQl3YJYyJRifA==}
+    hasBin: true
+
+  '@machinen/native-arm64-darwin@0.3.4':
+    resolution: {integrity: sha512-CayX6+V0oKtTjLQeNRHyg0GxlnnJ83CyJ/OV0myBsEy1NT+bARim06bqKMM9KN0T0OMpF9MexY40sOxSc8mj4A==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@machinen/native-arm64-linux@0.3.4':
+    resolution: {integrity: sha512-sqBPFx4WON+iujTSkDXTjlIcZv1OmytdLjRbkFWxBZA0GcAxgPNQKuhkbMW2jKqCGvFFF9T7JFHMpFlCAxehPA==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@machinen/runtime@0.3.4':
+    resolution: {integrity: sha512-otBdueajBzrADszWpD2DAaq1AWVfnbI8gAJNsD5MmmcPuoITZjQMZ1sGJ+Z2L9Q8VaJ++p9X4cvkqIy0nVPLuw==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -2628,6 +2656,10 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   decompress-tar@4.1.1:
     resolution: {integrity: sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==}
     engines: {node: '>=4'}
@@ -2647,6 +2679,10 @@ packages:
   decompress@4.2.1:
     resolution: {integrity: sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==}
     engines: {node: '>=4'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -2914,6 +2950,10 @@ packages:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -3085,6 +3125,9 @@ packages:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
 
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -3230,6 +3273,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -3709,6 +3755,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   miniflare@4.20260301.1:
     resolution: {integrity: sha512-fqkHx0QMKswRH9uqQQQOU/RoaS3Wjckxy3CUX3YGJr0ZIMu7ObvI+NovdYi6RIsSPthNtq+3TPmRNxjeRiasog==}
     engines: {node: '>=18.0.0'}
@@ -3724,6 +3774,9 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -3754,6 +3807,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -3767,6 +3823,10 @@ packages:
   netmask@2.1.1:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
     engines: {node: '>= 0.4.0'}
+
+  node-abi@3.92.0:
+    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
+    engines: {node: '>=10'}
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
@@ -3983,6 +4043,12 @@ packages:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -4050,6 +4116,10 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -4274,6 +4344,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -4385,6 +4461,10 @@ packages:
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -4574,6 +4654,9 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
@@ -5647,6 +5730,11 @@ snapshots:
       protobufjs: 7.5.4
       yargs: 17.7.2
 
+  '@homebridge/node-pty-prebuilt-multiarch@0.12.0':
+    dependencies:
+      node-addon-api: 7.1.1
+      prebuild-install: 7.1.3
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -5796,6 +5884,32 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@machinen/cli@0.3.4':
+    dependencies:
+      '@machinen/runtime': 0.3.4
+      debug: 4.4.3
+    optionalDependencies:
+      '@machinen/native-arm64-darwin': 0.3.4
+      '@machinen/native-arm64-linux': 0.3.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@machinen/native-arm64-darwin@0.3.4':
+    optional: true
+
+  '@machinen/native-arm64-linux@0.3.4':
+    optional: true
+
+  '@machinen/runtime@0.3.4':
+    dependencies:
+      '@homebridge/node-pty-prebuilt-multiarch': 0.12.0
+      debug: 4.4.3
+    optionalDependencies:
+      '@machinen/native-arm64-darwin': 0.3.4
+      '@machinen/native-arm64-linux': 0.3.4
+    transitivePeerDependencies:
+      - supports-color
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -7011,6 +7125,10 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   decompress-tar@4.1.1:
     dependencies:
       file-type: 5.2.0
@@ -7048,6 +7166,8 @@ snapshots:
       make-dir: 1.3.0
       pify: 2.3.0
       strip-dirs: 2.1.0
+
+  deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -7436,6 +7556,8 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   extend-shallow@2.0.1:
@@ -7620,6 +7742,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -7841,6 +7965,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -8431,6 +8557,8 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  mimic-response@3.1.0: {}
+
   miniflare@4.20260301.1:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -8455,6 +8583,8 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.14
 
+  minimist@1.2.8: {}
+
   minipass@7.1.3: {}
 
   mitt@3.0.1: {}
@@ -8472,6 +8602,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
   natural-compare@1.4.0: {}
 
   natural-orderby@5.0.0: {}
@@ -8479,6 +8611,10 @@ snapshots:
   neo-async@2.6.2: {}
 
   netmask@2.1.1: {}
+
+  node-abi@3.92.0:
+    dependencies:
+      semver: 7.7.4
 
   node-addon-api@7.1.1: {}
 
@@ -8713,6 +8849,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.92.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
@@ -8810,6 +8961,13 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
@@ -9168,6 +9326,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   slash@3.0.0: {}
 
   slice-ansi@7.1.2:
@@ -9284,6 +9450,8 @@ snapshots:
       is-natural-number: 4.0.1
 
   strip-final-newline@4.0.0: {}
+
+  strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -9459,6 +9627,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
     optional: true
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   tweetnacl@0.14.5: {}
 

--- a/scripts/agent-ci-dev.sh
+++ b/scripts/agent-ci-dev.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# Dev-only wrapper: runs agent-ci against local development code instead of
-# the published package. Uses Node's native TypeScript support (Node >=24).
-# Not intended for end users.
+# Dev-only wrapper: runs agent-ci against local development code (via tsx)
+# instead of the published package. Not intended for end users.
 set -euo pipefail
 
 SOURCE="${BASH_SOURCE[0]}"
@@ -18,4 +17,4 @@ pnpm --silent --dir "$REPO_ROOT/packages/dtu-github-actions" run build 2>/dev/nu
   pnpm --dir "$REPO_ROOT/packages/dtu-github-actions" run build
 
 # Run CLI from the caller's working directory
-exec node "$REPO_ROOT/packages/cli/src/cli.ts" "$@"
+exec "$REPO_ROOT/node_modules/.bin/tsx" "$REPO_ROOT/packages/cli/src/cli.ts" "$@"

--- a/vm.ts
+++ b/vm.ts
@@ -1,0 +1,486 @@
+import { spawnSync, type SpawnSyncOptionsWithStringEncoding } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const MACHINEN = join(
+  ROOT,
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "machinen.cmd" : "machinen",
+);
+const MACHINEN_DIR = join(ROOT, ".machinen");
+const IMAGE = join(MACHINEN_DIR, "rootfs.tar.gz");
+const SNAPSHOT_ROOT = join(MACHINEN_DIR, "snapshots");
+
+const GUEST_WORKSPACE = "/mnt/workspace";
+const GUEST_PI_AGENT = "/mnt/pi-agent";
+const GUEST_PNPM_STORE = "/mnt/pnpm-store";
+const GUEST_GIT_COMMON = "/mnt/git";
+const GUEST_NODE_MODULES = `${GUEST_WORKSPACE}/node_modules`;
+
+const COMMANDS = ["attach", "shell", "snapshot", "stop"] as const;
+type Command = (typeof COMMANDS)[number];
+type Worktree = {
+  branch: string;
+  path: string;
+  gitCommonDir: string;
+  guestGitDir: string;
+};
+type VmEntry = {
+  name: string | null;
+  ports?: Array<{ hostPort: number; guestPort: number }>;
+};
+
+const PORTABLE_PI_SETTINGS = [
+  "defaultProvider",
+  "defaultModel",
+  "defaultThinkingLevel",
+  "quietStartup",
+  "telemetry",
+];
+
+function usage(): never {
+  console.error(`Usage:
+  pnpm vm             Boot or attach to PI in a machinen VM for this worktree
+  pnpm vm shell       Boot or attach to an interactive shell in the VM
+  pnpm vm snapshot    Snapshot this worktree's running VM into .machinen/snapshots/
+  pnpm vm stop        Stop this worktree's running VM
+
+Run this from a linked git worktree, not the main checkout. For example:
+  git worktree add ../agent-ci-my-branch -b my-branch
+  cd ../agent-ci-my-branch
+  pnpm install
+  pnpm vm
+
+Environment:
+  MACHINEN_VM_NO_ATTACH=1             Boot/configure without attaching
+  MACHINEN_VM_PORTS=5173:5173,3000    Forward host:guest ports while booting
+  MACHINEN_VM_SKIP_INSTALL=1          Skip pnpm install inside the VM
+`);
+  process.exit(1);
+}
+
+function command(): Command {
+  const [raw = "attach", extra] = process.argv.slice(2);
+  if (raw === "-h" || raw === "--help" || extra) {
+    usage();
+  }
+  if (!COMMANDS.includes(raw as Command)) {
+    console.error(`Unknown command: ${raw}`);
+    usage();
+  }
+  return raw as Command;
+}
+
+function fail(message: string, code = 1): never {
+  console.error(message);
+  process.exit(code);
+}
+
+function statusCode(result: { status: number | null }): number {
+  return result.status ?? 1;
+}
+
+function run(command: string, args: string[], options: SpawnSyncOptionsWithStringEncoding = {}) {
+  return spawnSync(command, args, { encoding: "utf8", ...options });
+}
+
+function output(command: string, args: string[]): string {
+  const result = run(command, args);
+  if ((result.status ?? 1) !== 0) {
+    fail(
+      result.stderr?.trim() || result.error?.message || `${command} ${args.join(" ")} failed`,
+      statusCode(result),
+    );
+  }
+  return result.stdout.trim();
+}
+
+function git(args: string[]): string {
+  return output("git", ["-C", ROOT, ...args]);
+}
+
+function machinenOutput(args: string[], inheritStderr = false): string {
+  const result = run(MACHINEN, args, inheritStderr ? { stdio: ["ignore", "pipe", "inherit"] } : {});
+  if ((result.status ?? 1) !== 0) {
+    fail(
+      result.stderr?.trim() || result.error?.message || `machinen ${args.join(" ")} failed`,
+      statusCode(result),
+    );
+  }
+  return result.stdout.trim();
+}
+
+function machinen(args: string[]): void {
+  const result = spawnSync(MACHINEN, args, { stdio: "inherit" });
+  if ((result.status ?? 1) !== 0) {
+    process.exit(statusCode(result));
+  }
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function envPair(key: string, value: string): string {
+  return `${key}=${shellQuote(value)}`;
+}
+
+function guestGitExports(worktree: Worktree): string {
+  return [
+    `export ${envPair("GIT_DIR", worktree.guestGitDir)}`,
+    `export ${envPair("GIT_COMMON_DIR", GUEST_GIT_COMMON)}`,
+    `export ${envPair("GIT_WORK_TREE", GUEST_WORKSPACE)}`,
+  ].join("\n");
+}
+
+function piCommand(worktree: Worktree): string {
+  return `cd ${GUEST_WORKSPACE} && env HOME=/root SHELL=/bin/bash TERM=xterm-256color PI_CODING_AGENT_DIR=/root/.pi/agent ${envPair("GIT_DIR", worktree.guestGitDir)} ${envPair("GIT_COMMON_DIR", GUEST_GIT_COMMON)} ${envPair("GIT_WORK_TREE", GUEST_WORKSPACE)} pi`;
+}
+
+function vmList(): VmEntry[] {
+  return JSON.parse(machinenOutput(["list", "--json"])).vms ?? [];
+}
+
+function runningVm(name: string): VmEntry | undefined {
+  return vmList().find((vm) => vm.name === name);
+}
+
+function vmSh(name: string, script: string): void {
+  machinen(["exec", name, "--", "bash", "-lc", shellQuote(script)]);
+}
+
+function currentWorktree(): Worktree {
+  const gitDir = resolve(ROOT, git(["rev-parse", "--absolute-git-dir"]));
+  const commonDir = resolve(ROOT, git(["rev-parse", "--git-common-dir"]));
+
+  if (gitDir === commonDir) {
+    fail(`pnpm vm must be run from a linked git worktree, not the main checkout.
+
+Create one first, then run pnpm vm there. For example:
+  git worktree add ../agent-ci-my-branch -b my-branch
+  cd ../agent-ci-my-branch
+  pnpm install
+  pnpm vm`);
+  }
+
+  const branch = git(["branch", "--show-current"]);
+  if (!branch) {
+    fail("pnpm vm needs a named branch. Detached HEAD worktrees are not supported.");
+  }
+
+  const gitDirFromCommon = relative(commonDir, gitDir);
+  if (gitDirFromCommon.startsWith("..")) {
+    fail(`Could not map worktree git dir ${gitDir} under ${commonDir}.`);
+  }
+
+  return {
+    branch,
+    path: ROOT,
+    gitCommonDir: commonDir,
+    guestGitDir: join(GUEST_GIT_COMMON, gitDirFromCommon),
+  };
+}
+
+function hostGitHubToken(): string {
+  const envToken =
+    process.env.GH_TOKEN || process.env.GITHUB_TOKEN || process.env.AGENT_CI_GITHUB_TOKEN;
+  if (envToken?.trim()) {
+    return envToken.trim();
+  }
+
+  const result = run("gh", ["auth", "token"]);
+  if ((result.status ?? 1) !== 0 || !result.stdout.trim()) {
+    fail(
+      result.stderr?.trim() ||
+        result.error?.message ||
+        "Could not read a GitHub token. Run `gh auth login` on the host first.",
+      statusCode(result),
+    );
+  }
+  return result.stdout.trim();
+}
+
+function readJson(path: string): Record<string, unknown> {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function copyIfExists(source: string, dest: string): void {
+  if (existsSync(source)) {
+    copyFileSync(source, dest);
+  }
+}
+
+function copyDirIfExists(source: string, dest: string): void {
+  if (existsSync(source)) {
+    rmSync(dest, { recursive: true, force: true });
+    cpSync(source, dest, { recursive: true, dereference: true });
+  }
+}
+
+function ensurePiAgent(vmStateDir: string): string {
+  const source = resolve(process.env.PI_AGENT_SOURCE?.trim() || join(homedir(), ".pi", "agent"));
+  const dest = join(vmStateDir, "pi-agent");
+  const auth = join(source, "auth.json");
+  if (!existsSync(auth)) {
+    fail(`${auth} not found. Run \`pi\` and /login on the host, then rerun \`pnpm vm\`.`);
+  }
+
+  for (const dir of [
+    dest,
+    join(dest, "sessions"),
+    join(dest, "skills"),
+    join(dest, "extensions"),
+  ]) {
+    mkdirSync(dir, { recursive: true });
+  }
+  chmodSync(dest, 0o700);
+  chmodSync(join(dest, "sessions"), 0o700);
+
+  copyFileSync(auth, join(dest, "auth.json"));
+  chmodSync(join(dest, "auth.json"), 0o600);
+
+  const sourceSettings = readJson(join(source, "settings.json"));
+  const portableSettings = Object.fromEntries(
+    PORTABLE_PI_SETTINGS.flatMap((key) =>
+      sourceSettings[key] === undefined ? [] : [[key, sourceSettings[key]]],
+    ),
+  );
+  writeFileSync(join(dest, "settings.json"), `${JSON.stringify(portableSettings, null, 2)}\n`);
+  copyIfExists(join(source, "keybindings.json"), join(dest, "keybindings.json"));
+  copyDirIfExists(join(source, "skills"), join(dest, "skills"));
+  copyDirIfExists(join(source, "extensions"), join(dest, "extensions"));
+
+  const ghToken = join(dest, "gh-token");
+  writeFileSync(ghToken, `${hostGitHubToken()}\n`, { mode: 0o600 });
+  chmodSync(ghToken, 0o600);
+  return dest;
+}
+
+function ensureImage(): void {
+  if (existsSync(IMAGE)) {
+    return;
+  }
+
+  console.error(`${IMAGE} not found — running bake first…`);
+  const result = spawnSync(process.execPath, [join(ROOT, "bake.ts")], { stdio: "inherit" });
+  if ((result.status ?? 1) !== 0) {
+    process.exit(statusCode(result));
+  }
+}
+
+function ensureHostMounts(vmStateDir: string): void {
+  for (const dir of ["node_modules", "pnpm-store"]) {
+    mkdirSync(join(vmStateDir, dir), { recursive: true });
+  }
+}
+
+function parsePortForward(): string[] {
+  const raw = process.env.MACHINEN_VM_PORTS || process.env.MACHINEN_VM_PORT;
+  if (!raw?.trim()) {
+    return [];
+  }
+
+  return raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const parts = entry.split(":");
+      if (parts.length > 2) {
+        fail(`Invalid MACHINEN_VM_PORTS entry: ${entry}`);
+      }
+      const [host, guest = host] = parts;
+      if (!/^\d+$/.test(host) || !/^\d+$/.test(guest)) {
+        fail(`Invalid MACHINEN_VM_PORTS entry: ${entry}`);
+      }
+      const hostPort = Number(host);
+      const guestPort = Number(guest);
+      if (hostPort < 1 || hostPort > 65535 || guestPort < 1 || guestPort > 65535) {
+        fail(`Invalid MACHINEN_VM_PORTS entry: ${entry}`);
+      }
+      return `${hostPort}:${guestPort}`;
+    });
+}
+
+function bootVm(name: string, worktree: Worktree, vmStateDir: string, piAgent: string): void {
+  const args = [
+    "boot",
+    IMAGE,
+    "--name",
+    name,
+    "--cwd",
+    GUEST_WORKSPACE,
+    "--mount-live",
+    `${worktree.path}:${GUEST_WORKSPACE}:rw`,
+    "--mount-live",
+    `${join(vmStateDir, "node_modules")}:${GUEST_NODE_MODULES}:rw`,
+    "--mount-live",
+    `${join(vmStateDir, "pnpm-store")}:${GUEST_PNPM_STORE}:rw`,
+    "--mount-live",
+    `${worktree.gitCommonDir}:${GUEST_GIT_COMMON}:rw`,
+    "--mount-live",
+    `${piAgent}:${GUEST_PI_AGENT}:rw`,
+    "--detach",
+    "--json",
+  ];
+
+  for (const port of parsePortForward()) {
+    args.push("-p", port);
+  }
+
+  console.error(`booting ${name} — worktree=${worktree.path}`);
+  machinenOutput(args, true);
+}
+
+function configureVm(name: string, worktree: Worktree): void {
+  const installDeps =
+    process.env.MACHINEN_VM_SKIP_INSTALL === "1"
+      ? ""
+      : `
+cd ${GUEST_WORKSPACE}
+if [ ! -f node_modules/.modules.yaml ]; then
+  pnpm install --frozen-lockfile
+fi
+`;
+
+  vmSh(
+    name,
+    `set -euo pipefail
+mkdir -p /root/.pi ${GUEST_WORKSPACE} ${GUEST_PI_AGENT} ${GUEST_PNPM_STORE} ${GUEST_GIT_COMMON} ${GUEST_NODE_MODULES}
+rm -rf /root/.pi/agent
+ln -sfn ${GUEST_PI_AGENT} /root/.pi/agent
+cat > /root/.agent-ci-vm-env <<'EOF'
+${guestGitExports(worktree)}
+EOF
+if ! grep -qxF '. /root/.agent-ci-vm-env' /root/.bashrc; then
+  printf '\n. /root/.agent-ci-vm-env\n' >> /root/.bashrc
+fi
+. /root/.agent-ci-vm-env
+git config --global --add safe.directory ${GUEST_WORKSPACE} || true
+git -C ${GUEST_WORKSPACE} status --short >/dev/null
+pnpm config set --global store-dir ${GUEST_PNPM_STORE}
+if ! command -v gh >/dev/null; then
+  echo "gh is not installed in this VM image. Remove .machinen/rootfs.tar.gz and rerun pnpm vm." >&2
+  exit 1
+fi
+GH_TOKEN_FILE=${GUEST_PI_AGENT}/gh-token
+if [ -s "$GH_TOKEN_FILE" ]; then
+  trap 'rm -f "$GH_TOKEN_FILE"' EXIT
+  rm -rf /root/.config/gh
+  mkdir -p /root/.config/gh
+  gh auth login --hostname github.com --git-protocol https --with-token < "$GH_TOKEN_FILE"
+  gh auth setup-git --hostname github.com
+  rm -f "$GH_TOKEN_FILE"
+  trap - EXIT
+fi
+gh auth status --hostname github.com >/dev/null
+${installDeps}`,
+  );
+}
+
+function printReady(name: string, worktree: string, vmStateDir: string, vm?: VmEntry): void {
+  const portLines = (vm?.ports ?? [])
+    .map((port) => `  http://localhost:${port.hostPort} -> guest:${port.guestPort}`)
+    .join("\n");
+
+  console.error(`
+${name} is ready.
+
+PI.dev starts directly when you attach.
+
+  attach PI:    pnpm vm
+  attach shell: pnpm vm shell
+  snapshot:     pnpm vm snapshot
+  stop VM:      pnpm vm stop
+
+Worktree:       ${worktree} -> ${GUEST_WORKSPACE}
+Git metadata:   mounted at ${GUEST_GIT_COMMON}
+node_modules:   ${join(vmStateDir, "node_modules")} -> ${GUEST_NODE_MODULES}
+pnpm store:     ${join(vmStateDir, "pnpm-store")} -> ${GUEST_PNPM_STORE}${portLines ? `\nPorts:\n${portLines}` : ""}
+`);
+}
+
+function timestamp(): string {
+  return new Date().toISOString().replaceAll(":", "-").replaceAll(".", "-");
+}
+
+function snapshotVm(name: string, branch: string): never {
+  if (!runningVm(name)) {
+    fail(`${name} is not running. Start it first with \`pnpm vm\` from this worktree.`);
+  }
+
+  const outDir = join(SNAPSHOT_ROOT, branch, timestamp());
+  mkdirSync(dirname(outDir), { recursive: true });
+  machinen(["snapshot", name, outDir, "--keep-alive"]);
+  console.error(`snapshot written to ${outDir}`);
+  process.exit(0);
+}
+
+function stopVm(name: string): never {
+  if (!runningVm(name)) {
+    console.error(`${name} is not running.`);
+    process.exit(0);
+  }
+
+  machinen(["stop", name]);
+  process.exit(0);
+}
+
+function attachVm(name: string, shell: string): never {
+  const result = spawnSync(MACHINEN, ["attach", name, "--shell", shell], { stdio: "inherit" });
+  process.exit(statusCode(result));
+}
+
+const cmd = command();
+mkdirSync(MACHINEN_DIR, { recursive: true });
+
+const worktree = currentWorktree();
+const vmName = process.env.MACHINEN_VM_NAME?.trim() || worktree.branch;
+const vmStateDir = join(MACHINEN_DIR, "vms", worktree.branch);
+
+if (cmd === "snapshot") {
+  snapshotVm(vmName, worktree.branch);
+}
+if (cmd === "stop") {
+  stopVm(vmName);
+}
+
+ensureHostMounts(vmStateDir);
+let vmEntry = runningVm(vmName);
+if (!vmEntry) {
+  ensureImage();
+}
+
+const piAgent = ensurePiAgent(vmStateDir);
+if (vmEntry) {
+  console.error(`${vmName} is already running — ensuring PI.dev is configured…`);
+} else {
+  bootVm(vmName, worktree, vmStateDir, piAgent);
+  vmEntry = runningVm(vmName);
+}
+
+configureVm(vmName, worktree);
+printReady(vmName, worktree.path, vmStateDir, vmEntry ?? runningVm(vmName));
+
+if (process.env.MACHINEN_VM_NO_ATTACH === "1") {
+  process.exit(0);
+}
+
+attachVm(vmName, cmd === "shell" ? "/bin/bash -i" : piCommand(worktree));


### PR DESCRIPTION
## Problem

There was no easy way to start a Machinen VM for working on this repo. A developer had to bake the image, mount the repo, copy PI login data, and keep VM-only dependencies away from the host checkout by hand.

A recent dev-only TypeScript change also made local scripts require Node 24. That was stricter than needed, because the published packages still run compiled JavaScript on Node 22.

## Solution

This PR adds `bake.ts` and `vm.ts`. `pnpm vm` can boot or attach to a worktree-specific VM, mount the repo, set up PI and GitHub auth, keep `node_modules` and the pnpm store inside VM-owned folders, and snapshot or stop the VM.

It also restores `tsx` for local TypeScript scripts and keeps the repo, package engines, and PR test workflow on Node 22.

## Validation

- `fnm exec --using v22.22.2 pnpm check`
- `fnm exec --using v22.22.2 pnpm --filter @redwoodjs/agent-ci... -r build`
- `pnpm agent-ci-dev run --all -q -p --json`

The full agent-ci run passed. One unrelated Docker container-name conflict paused a smoke job, and the retry passed.
