### PR TITLE
Fix deep sub-path action references

### DIFF
--- a/.changeset/deep-subpath-actions.md
+++ b/.changeset/deep-subpath-actions.md
@@ -1,0 +1,8 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Fix remote actions referenced through deep sub-paths (for example `owner/repo/.github/actions/name@ref`) by passing the parent repository and action path separately to the runner.
+
+Closes #362.

--- a/packages/cli/src/workflow/workflow-parser.test.ts
+++ b/packages/cli/src/workflow/workflow-parser.test.ts
@@ -2029,6 +2029,25 @@ jobs:
     expect(ref.Path).toBe("");
   });
 
+  it("splits deep remote action sub-paths into repository name and path", async () => {
+    const filePath = writeWorkflowTree(`
+name: Deep Remote Action Test
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shunkakinoki/actions/.github/actions/setup-bun@3397de0ac01b638fa41d3b2fb18ece4ee71c08d8
+`);
+    const steps = await parseWorkflowSteps(filePath, "test");
+    const ref = (steps[0] as any).Reference;
+
+    expect(ref.RepositoryType).toBe("GitHub");
+    expect(ref.Name).toBe("shunkakinoki/actions");
+    expect(ref.Ref).toBe("3397de0ac01b638fa41d3b2fb18ece4ee71c08d8");
+    expect(ref.Path).toBe(".github/actions/setup-bun");
+  });
+
   it("passes through with: inputs for local actions", async () => {
     const filePath = writeWorkflowTree(`
 name: Local Action Inputs Test

--- a/packages/cli/src/workflow/workflow-parser.ts
+++ b/packages/cli/src/workflow/workflow-parser.ts
@@ -889,6 +889,17 @@ function buildStepEnv(
   return { ...baseEnv, ...resolvedStep };
 }
 
+function splitRemoteActionReference(name: string): { name: string; path: string } {
+  const parts = name.split("/");
+  if (parts.length <= 2) {
+    return { name, path: "" };
+  }
+  return {
+    name: parts.slice(0, 2).join("/"),
+    path: parts.slice(2).join("/"),
+  };
+}
+
 export async function parseWorkflowSteps(
   filePath: string,
   taskName: string,
@@ -1020,20 +1031,29 @@ export async function parseWorkflowSteps(
           ...(condition !== undefined ? { condition } : {}),
         };
       } else if ("uses" in step) {
-        // Basic support for 'uses' steps
-        // Parse uses string: owner/repo@ref or ./.github/actions/foo (local)
+        // Basic support for 'uses' steps.
+        // Parse uses string: owner/repo[/path]@ref or ./.github/actions/foo (local).
+        // The runner expects remote sub-actions to be split into the parent
+        // repository name plus a separate path; otherwise it extracts the repo
+        // tarball under _actions/owner/repo/path/ref and then looks for
+        // action.yml at the wrong directory level.
         const uses = step.uses.toString();
         const isLocalAction = uses.startsWith("./");
         let name = uses;
         let ref = "";
+        let actionPath = "";
 
         if (!isLocalAction && uses.indexOf("@") >= 0) {
-          const parts = uses.split("@");
-          name = parts[0];
-          ref = parts[1];
+          const at = uses.lastIndexOf("@");
+          const rawName = uses.slice(0, at);
+          ref = uses.slice(at + 1);
+          const split = splitRemoteActionReference(rawName);
+          name = split.name;
+          actionPath = split.path;
         }
 
-        const isCheckout = !isLocalAction && name.trim().toLowerCase() === "actions/checkout";
+        const isCheckout =
+          !isLocalAction && actionPath === "" && name.trim().toLowerCase() === "actions/checkout";
         const stepWith = rawStep.with || {};
         const condition = parseStepIf(rawStep.if);
 
@@ -1048,7 +1068,7 @@ export async function parseWorkflowSteps(
             Name: isLocalAction ? "" : name,
             Ref: isLocalAction ? "" : ref,
             RepositoryType: isLocalAction ? "self" : "GitHub",
-            Path: isLocalAction ? uses : "",
+            Path: isLocalAction ? uses : actionPath,
           },
           Inputs: {
             // with: values from @actions/workflow-parser are expression objects; call toString() on each.


### PR DESCRIPTION
## Problem

Some GitHub Actions live inside a deeper folder in another repo, like `owner/repo/.github/actions/name@ref`. Agent CI treated that whole path as the repo name. The runner then downloaded the right repo, but looked for `action.yml` in the wrong place and failed before the job could start.

Closes #362.

## Solution

The workflow parser now splits remote action references into two parts: the real repo name and the action folder path. The runner can download `owner/repo` and then open the action from the deeper folder. I also added a regression test using the `shunkakinoki/actions/.github/actions/setup-bun` shape from the issue.

## Verification

- `pnpm --dir packages/cli test src/workflow/workflow-parser.test.ts`
- `pnpm check`
- `pnpm test`
- `pnpm agent-ci-dev run --all -q -p --json`
