### PR TITLE
Fix stale log artifacts on reused runners

### DIFF
--- a/.changeset/fresh-run-log-numbers.md
+++ b/.changeset/fresh-run-log-numbers.md
@@ -1,0 +1,8 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Avoid reusing runner numbers while stable log directories still exist, and clear stale per-run timeline/log artifacts when a runner name is reused, so old `timeline.json` records cannot be merged into a fresh run and reported as a false failure.
+
+Closes #341.

--- a/packages/cli/src/output/logger.test.ts
+++ b/packages/cli/src/output/logger.test.ts
@@ -7,10 +7,12 @@ describe("Logger utilities", () => {
   let tmpDir: string;
   let logsDir: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-ci-logger-test-"));
     logsDir = path.join(tmpDir, "logs-root");
     vi.resetModules();
+    const { setLogsDirectory } = await import("./logs-directory.ts");
+    setLogsDirectory(logsDir);
   });
 
   afterEach(() => {
@@ -57,6 +59,33 @@ describe("Logger utilities", () => {
       });
       expect(getNextLogNum("agent-ci")).toBe(16);
     });
+
+    it("does not reuse a run number while a stable log dir still exists (issue #341)", async () => {
+      const { setWorkingDirectory } = await import("./working-directory.ts");
+      const { setLogsDirectory } = await import("./logs-directory.ts");
+      const { getNextLogNum } = await import("./logger.ts");
+      setWorkingDirectory(tmpDir);
+      setLogsDirectory(logsDir);
+
+      // Reproduction for #341: workspace pruning removed `<workDir>/runs/agent-ci-15-j1`,
+      // but the stable log dir still has timeline.json. Reusing 15 would make
+      // the DTU merge a fresh passing timeline into stale failed records.
+      const staleLogDir = path.join(logsDir, "agent-ci-15-j1");
+      fs.mkdirSync(staleLogDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(staleLogDir, "timeline.json"),
+        JSON.stringify([
+          {
+            id: "old-task",
+            type: "Task",
+            name: "Check API.md is up to date",
+            result: "Failed",
+          },
+        ]),
+      );
+
+      expect(getNextLogNum("agent-ci")).toBe(16);
+    });
   });
 
   describe("createLogContext", () => {
@@ -88,6 +117,29 @@ describe("Logger utilities", () => {
       expect(ctx.name).toBe("agent-ci-redwoodjssdk-42");
       expect(ctx.runDir).toBe(path.join(tmpDir, "runs", "agent-ci-redwoodjssdk-42"));
       expect(ctx.logDir).toBe(path.join(logsDir, "agent-ci-redwoodjssdk-42"));
+    });
+
+    it("clears stale per-run log artifacts when a preferred log name is reused", async () => {
+      const { setWorkingDirectory } = await import("./working-directory.ts");
+      const { setLogsDirectory } = await import("./logs-directory.ts");
+      const { createLogContext } = await import("./logger.ts");
+      setWorkingDirectory(tmpDir);
+      setLogsDirectory(logsDir);
+
+      const staleLogDir = path.join(logsDir, "agent-ci-redwoodjssdk-42");
+      fs.mkdirSync(path.join(staleLogDir, "steps"), { recursive: true });
+      fs.writeFileSync(path.join(staleLogDir, "timeline.json"), "[]");
+      fs.writeFileSync(path.join(staleLogDir, "outputs.json"), "{}");
+      fs.writeFileSync(path.join(staleLogDir, "metadata.json"), "{}");
+      fs.writeFileSync(path.join(staleLogDir, "steps", "old.log"), "stale");
+
+      const ctx = createLogContext("agent-ci", "agent-ci-redwoodjssdk-42");
+
+      expect(ctx.logDir).toBe(staleLogDir);
+      expect(fs.existsSync(path.join(staleLogDir, "timeline.json"))).toBe(false);
+      expect(fs.existsSync(path.join(staleLogDir, "outputs.json"))).toBe(false);
+      expect(fs.existsSync(path.join(staleLogDir, "metadata.json"))).toBe(false);
+      expect(fs.existsSync(path.join(staleLogDir, "steps"))).toBe(false);
     });
 
     it("auto-increments when no preferredName given", async () => {

--- a/packages/cli/src/output/logger.ts
+++ b/packages/cli/src/output/logger.ts
@@ -12,28 +12,46 @@ export function ensureLogDirs(): void {
   fs.mkdirSync(getRunsDir(), { recursive: true });
 }
 
-export function getNextLogNum(prefix: string): number {
-  const runsDir = getRunsDir();
-  if (!fs.existsSync(runsDir)) {
-    return 1;
+function runNumberFromDirName(prefix: string, name: string): number | null {
+  if (!name.startsWith(`${prefix}-`)) {
+    return null;
   }
 
-  const items = fs.readdirSync(runsDir, { withFileTypes: true });
-  const nums = items
-    .filter((item) => item.isDirectory() && item.name.startsWith(`${prefix}-`))
-    .map((item) => {
-      // Extract the trailing numeric run counter from a name like:
-      //   agent-ci-redwoodjssdk-14        → 14
-      //   agent-ci-redwoodjssdk-15-j1     → 15
-      //   agent-ci-redwoodjssdk-15-j1-m2  → 15
-      // Strategy: strip any -j<N>, -m<N>, -r<N> suffixes first, then grab the last number.
-      const baseName = item.name
-        .replace(/-j\d+(-m\d+)?(-r\d+)?$/, "")
-        .replace(/-m\d+(-r\d+)?$/, "")
-        .replace(/-r\d+$/, "");
-      const match = baseName.match(/-(\d+)$/);
-      return match ? parseInt(match[1], 10) : 0;
-    });
+  // Extract the trailing numeric run counter from a name like:
+  //   agent-ci-redwoodjssdk-14        → 14
+  //   agent-ci-redwoodjssdk-15-j1     → 15
+  //   agent-ci-redwoodjssdk-15-j1-m2  → 15
+  // Strategy: strip any -j<N>, -m<N>, -r<N> suffixes first, then grab the last number.
+  const baseName = name
+    .replace(/-j\d+(-m\d+)?(-r\d+)?$/, "")
+    .replace(/-m\d+(-r\d+)?$/, "")
+    .replace(/-r\d+$/, "");
+  const match = baseName.match(/-(\d+)$/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+function collectRunNums(dir: string, prefix: string): number[] {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((item) => item.isDirectory())
+    .map((item) => runNumberFromDirName(prefix, item.name))
+    .filter((num): num is number => num !== null);
+}
+
+export function getNextLogNum(prefix: string): number {
+  const nums = [
+    ...collectRunNums(getRunsDir(), prefix),
+    // Stable log dirs outlive temporary run dirs. Count them too so a pruned
+    // `<workDir>/runs/agent-ci-N-*` cannot be reused while
+    // `<logsDir>/agent-ci-N-*/timeline.json` still exists. Otherwise the DTU
+    // appends the new run's timeline to stale records and the result builder can
+    // replay an old failure as the current run's outcome. See issue #341.
+    ...collectRunNums(getLogsDirectory(), prefix),
+  ];
 
   return nums.length > 0 ? Math.max(...nums) + 1 : 1;
 }
@@ -63,6 +81,23 @@ function allocateRunDir(prefix: string): { num: number; name: string; runDir: st
   }
 }
 
+function resetPerRunLogArtifacts(logDir: string): void {
+  // A stable log dir may outlive the temporary run dir. If a runner name is
+  // ever reused, stale timeline/output/step files must not be visible to the
+  // new run. Debug/output logs are opened with truncating streams elsewhere,
+  // but remove them here too so the directory is clean from the start.
+  for (const entry of [
+    "timeline.json",
+    "outputs.json",
+    "metadata.json",
+    "output.log",
+    "debug.log",
+  ]) {
+    fs.rmSync(path.join(logDir, entry), { force: true });
+  }
+  fs.rmSync(path.join(logDir, "steps"), { recursive: true, force: true });
+}
+
 export function createLogContext(prefix: string, preferredName?: string) {
   ensureLogDirs();
 
@@ -85,6 +120,7 @@ export function createLogContext(prefix: string, preferredName?: string) {
   // See issue #312.
   const logDir = path.join(getLogsDirectory(), name);
   fs.mkdirSync(logDir, { recursive: true });
+  resetPerRunLogArtifacts(logDir);
 
   return {
     num,


### PR DESCRIPTION
## Problem

Agent CI kept stable log folders after the temporary run folder was cleaned up. That meant a new run could reuse the same runner name while an old `timeline.json` was still there. The old failed step could then get mixed into the new run and make a passing workflow look failed.

## Solution

The logger now checks both the temporary run folders and the stable log folders before picking the next runner number. It also clears old per-run files, like `timeline.json` and step logs, when a log folder name is reused. The tests cover the stale-log case from #341 so it should not come back.
