### PR TITLE
Serialize parallel package installs

### DIFF
--- a/.changeset/parallel-installs-shim.md
+++ b/.changeset/parallel-installs-shim.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Closes #370. Add runner package-manager install shims that serialize shared warm `node_modules` writes during parallel local Agent CI jobs and, for non-workspace projects, reuse a lockfile-keyed ready marker for duplicate project installs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## Unreleased
 
+- Added runner package-manager install shims so parallel local Agent CI jobs serialize writes to the shared warm `node_modules` mount and, for non-workspace projects, reuse duplicate lockfile-keyed project installs instead of requiring repo-specific install lock scripts.
 - Hardened opt-in Rust orchestration so matrix legs are keyed by schedule key, matrix `needs` results are aggregated, reusable workflows and workflow-call outputs are expanded, worker failures preserve sibling outcomes, DTU cleanup/security is enforced, cyclic dependencies error during planning, pull request branch filters use the actual branch, detached pause handling is covered directly, nested ephemeral DTU servers advertise the container IP to sibling runners, nested runner containers join the parent Docker network, Rust cleanup removes nested containers attached to per-job networks, and the Rust smoke parity gate exercises the expanded smoke suite with per-workflow timeouts, duration summaries, heartbeats, status ledgers, failure diagnostics, and timeout cleanup.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,6 +33,8 @@ Existing "run actions locally" tools either re-implement steps in a compatibilit
 
 Agent CI replaces GitHub's cloud cache with **local bind-mounts**. `node_modules`, the pnpm store, Playwright browsers, and the runner tool cache all live on your host filesystem and are mounted directly into the container — no upload, no download, no tar/untar. The first run warms the cache; every subsequent run starts with hot dependencies instantly.
 
+When local jobs run in parallel, Agent CI also shims common package-manager installs (`npm ci`, `npm install`, `pnpm install`, `yarn install`, and `bun install`) inside runner containers. The shim serializes writes to the shared warm `node_modules` mount and, for non-workspace projects, skips duplicate project installs once the lockfile-keyed cache is ready, so you can keep job parallelism without adding a repo-specific install lock script.
+
 ### Pause on failure
 
 Step 6 failed. Fix the file. Retry just that step. Green. No checkout, no reinstall, no waiting.

--- a/packages/cli/src/docker/container-config.test.ts
+++ b/packages/cli/src/docker/container-config.test.ts
@@ -25,9 +25,36 @@ describe("buildContainerEnv", () => {
     expect(env).toContain("GITHUB_REPOSITORY=org/repo");
     expect(env).toContain("AGENT_CI_LOCAL=true");
     expect(env).toContain("AGENT_CI_HEAD_SHA=abc123");
+    expect(env).toContain("AGENT_CI_LOCKFILE_HASH=no-lockfile");
+    expect(env).toContain("AGENT_CI_PACKAGE_MANAGER=unknown");
+    expect(env).toContain(
+      "AGENT_CI_ORIGINAL_PATH=/home/runner/externals/node24/bin:/home/runner/externals/node20/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    );
+    expect(env).toContain("BASH_ENV=/tmp/agent-ci-shims/bash-env");
+    expect(env).toContain(
+      "PATH=/tmp/agent-ci-shims:/home/runner/externals/node24/bin:/home/runner/externals/node20/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    );
     expect(env).toContain("FORCE_COLOR=1");
     // Should NOT include root-mode vars for standard container
     expect(env).not.toContain("RUNNER_ALLOW_RUNASROOT=1");
+  });
+
+  it("accepts warm install metadata for package-manager shims", async () => {
+    const { buildContainerEnv } = await import("./container-config.ts");
+    const env = buildContainerEnv({
+      containerName: "runner-1",
+      registrationToken: "tok",
+      repoUrl: "http://dtu:3000/org/repo",
+      dockerApiUrl: "http://dtu:3000",
+      githubRepo: "org/repo",
+      dtuHost: "host.docker.internal",
+      useDirectContainer: false,
+      lockfileHash: "abc123def456",
+      packageManager: "npm",
+    });
+
+    expect(env).toContain("AGENT_CI_LOCKFILE_HASH=abc123def456");
+    expect(env).toContain("AGENT_CI_PACKAGE_MANAGER=npm");
   });
 
   it("adds root-mode env vars for direct container injection", async () => {

--- a/packages/cli/src/docker/container-config.ts
+++ b/packages/cli/src/docker/container-config.ts
@@ -44,6 +44,8 @@ export interface ContainerEnvOpts {
   headSha?: string;
   dtuHost: string;
   useDirectContainer: boolean;
+  lockfileHash?: string;
+  packageManager?: string | null;
 }
 
 export interface ContainerBindsOpts {
@@ -88,6 +90,8 @@ export function buildContainerEnv(opts: ContainerEnvOpts): string[] {
     headSha,
     dtuHost,
     useDirectContainer,
+    lockfileHash,
+    packageManager,
   } = opts;
 
   return [
@@ -101,11 +105,15 @@ export function buildContainerEnv(opts: ContainerEnvOpts): string[] {
     `AGENT_CI_LOCAL_SYNC=true`,
     `AGENT_CI_HEAD_SHA=${headSha || "HEAD"}`,
     `AGENT_CI_DTU_HOST=${dtuHost}`,
+    `AGENT_CI_LOCKFILE_HASH=${lockfileHash ?? "no-lockfile"}`,
+    `AGENT_CI_PACKAGE_MANAGER=${packageManager ?? "unknown"}`,
     `ACTIONS_CACHE_URL=${dockerApiUrl}/`,
     `ACTIONS_RESULTS_URL=${dockerApiUrl}/`,
     `ACTIONS_RUNTIME_TOKEN=mock_cache_token_123`,
     `RUNNER_TOOL_CACHE=/opt/hostedtoolcache`,
-    `PATH=/home/runner/externals/node24/bin:/home/runner/externals/node20/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`,
+    `AGENT_CI_ORIGINAL_PATH=/home/runner/externals/node24/bin:/home/runner/externals/node20/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`,
+    `BASH_ENV=/tmp/agent-ci-shims/bash-env`,
+    `PATH=/tmp/agent-ci-shims:/home/runner/externals/node24/bin:/home/runner/externals/node20/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`,
     // Force colour output in all child processes (pnpm, Node, etc.)
     `FORCE_COLOR=1`,
     // Custom containers may run as root and lack libicu — configure accordingly

--- a/packages/cli/src/runner/directory-setup.ts
+++ b/packages/cli/src/runner/directory-setup.ts
@@ -21,6 +21,7 @@ export interface RunDirectories {
   warmModulesDir: string;
   workspaceDir: string;
   repoSlug: string;
+  lockfileHash: string;
   detectedPM: PackageManager | null;
 }
 
@@ -129,6 +130,7 @@ export function createRunDirectories(opts: CreateRunDirectoriesOpts): RunDirecto
     warmModulesDir,
     workspaceDir,
     repoSlug,
+    lockfileHash,
     detectedPM,
   };
 }

--- a/packages/cli/src/runner/local-job.ts
+++ b/packages/cli/src/runner/local-job.ts
@@ -23,6 +23,7 @@ import { RunStateStore, type StepState } from "../output/run-state.ts";
 
 import { writeJobMetadata } from "./metadata.ts";
 import { writeGitShim } from "./git-shim.ts";
+import { writePackageManagerShims } from "./package-manager-shim.ts";
 import { prepareWorkspace } from "./workspace.ts";
 import { createRunDirectories } from "./directory-setup.ts";
 import { writeDetachedMarker } from "../launcher.ts";
@@ -783,6 +784,7 @@ export async function executeLocalJob(
     // immediately. On Linux, prepareWorkspace (rsync) is slow enough that the
     // container entrypoint would race ahead and find an empty shims dir.
     writeGitShim(dirs.shimsDir, job.realHeadSha);
+    writePackageManagerShims(dirs.shimsDir);
 
     // Prepare workspace files in parallel with container setup
     const workspacePrepStart = Date.now();
@@ -889,6 +891,8 @@ export async function executeLocalJob(
       headSha: job.headSha,
       dtuHost,
       useDirectContainer,
+      lockfileHash: dirs.lockfileHash,
+      packageManager: dirs.detectedPM,
     });
 
     const containerBinds = buildContainerBinds({

--- a/packages/cli/src/runner/package-manager-shim.test.ts
+++ b/packages/cli/src/runner/package-manager-shim.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync, execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileP = promisify(execFile);
+
+describe("writePackageManagerShims", () => {
+  let tmpDir: string;
+  let shimsDir: string;
+  let binDir: string;
+  let repoDir: string;
+  let toolCacheDir: string;
+  let callsFile: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-ci-pm-shim-"));
+    shimsDir = path.join(tmpDir, "shims");
+    binDir = path.join(tmpDir, "bin");
+    repoDir = path.join(tmpDir, "repo");
+    toolCacheDir = path.join(tmpDir, "toolcache");
+    callsFile = path.join(tmpDir, "calls.log");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(repoDir, { recursive: true });
+    fs.mkdirSync(toolCacheDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeFakeNpm(scriptBody: string): string {
+    const realNpm = path.join(binDir, "npm-real");
+    fs.writeFileSync(realNpm, `#!/usr/bin/env bash\nset -euo pipefail\n${scriptBody}\n`, {
+      mode: 0o755,
+    });
+    return realNpm;
+  }
+
+  function shimEnv(realNpm: string, agentCiLocal = "true"): NodeJS.ProcessEnv {
+    return {
+      ...process.env,
+      AGENT_CI_LOCAL: agentCiLocal,
+      AGENT_CI_LOCKFILE_HASH: "lockhash",
+      AGENT_CI_ORIGINAL_PATH: binDir,
+      AGENT_CI_REAL_NPM: realNpm,
+      GITHUB_REPOSITORY: "org/repo",
+      RUNNER_TOOL_CACHE: toolCacheDir,
+    };
+  }
+
+  it("writes executable shims for common package managers", async () => {
+    const { writePackageManagerShims } = await import("./package-manager-shim.ts");
+
+    writePackageManagerShims(shimsDir);
+
+    for (const pm of ["npm", "pnpm", "yarn", "bun"]) {
+      const stat = fs.statSync(path.join(shimsDir, pm));
+      expect(stat.mode & 0o111).not.toBe(0);
+    }
+    expect(fs.readFileSync(path.join(shimsDir, "bash-env"), "utf8")).toContain(
+      'pnpm() { /tmp/agent-ci-shims/pnpm "$@"; }',
+    );
+  });
+
+  it("reuses a warm node_modules marker instead of repeating npm ci", async () => {
+    const { writePackageManagerShims } = await import("./package-manager-shim.ts");
+    writePackageManagerShims(shimsDir);
+    const realNpm = writeFakeNpm(
+      `echo "real:$*" >> "${callsFile}"\nmkdir -p node_modules\ntouch node_modules/.package-lock.json`,
+    );
+    const npmShim = path.join(shimsDir, "npm");
+
+    execFileSync(npmShim, ["ci"], { cwd: repoDir, env: shimEnv(realNpm) });
+    const secondOutput = execFileSync(npmShim, ["ci"], {
+      cwd: repoDir,
+      env: shimEnv(realNpm),
+      encoding: "utf8",
+    });
+
+    expect(fs.readFileSync(callsFile, "utf8").trim().split("\n")).toEqual(["real:ci"]);
+    expect(secondOutput).toContain("Reusing warm node_modules");
+  });
+
+  it("serializes concurrent npm ci calls so only one writes the shared node_modules", async () => {
+    const { writePackageManagerShims } = await import("./package-manager-shim.ts");
+    writePackageManagerShims(shimsDir);
+    const activeFile = path.join(tmpDir, "active");
+    const realNpm = writeFakeNpm(
+      `if [ -f "${activeFile}" ]; then echo overlap >> "${callsFile}"; fi\n` +
+        `touch "${activeFile}"\n` +
+        `sleep 0.2\n` +
+        `mkdir -p node_modules\n` +
+        `touch node_modules/.package-lock.json\n` +
+        `rm -f "${activeFile}"\n` +
+        `echo "real:$*" >> "${callsFile}"`,
+    );
+    const npmShim = path.join(shimsDir, "npm");
+    const env = shimEnv(realNpm);
+
+    await Promise.all([
+      execFileP(npmShim, ["ci"], { cwd: repoDir, env }),
+      execFileP(npmShim, ["ci"], { cwd: repoDir, env }),
+    ]);
+
+    expect(fs.readFileSync(callsFile, "utf8").trim().split("\n")).toEqual(["real:ci"]);
+  });
+
+  it("serializes but does not skip workspace installs because they write links outside root node_modules", async () => {
+    const { writePackageManagerShims } = await import("./package-manager-shim.ts");
+    writePackageManagerShims(shimsDir);
+    fs.writeFileSync(path.join(repoDir, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+    const realNpm = writeFakeNpm(
+      `echo "real:$*" >> "${callsFile}"\nmkdir -p node_modules\ntouch node_modules/.modules.yaml`,
+    );
+    const npmShim = path.join(shimsDir, "npm");
+
+    execFileSync(npmShim, ["ci"], { cwd: repoDir, env: shimEnv(realNpm) });
+    execFileSync(npmShim, ["ci"], { cwd: repoDir, env: shimEnv(realNpm) });
+
+    expect(fs.readFileSync(callsFile, "utf8").trim().split("\n")).toEqual(["real:ci", "real:ci"]);
+  });
+
+  it("finds package managers that setup actions add to the current PATH", async () => {
+    const { writePackageManagerShims } = await import("./package-manager-shim.ts");
+    writePackageManagerShims(shimsDir);
+    const pnpmBin = path.join(binDir, "pnpm");
+    fs.writeFileSync(
+      pnpmBin,
+      `#!/usr/bin/env bash\nset -euo pipefail\necho "real-pnpm:$*" >> "${callsFile}"\nmkdir -p node_modules\ntouch node_modules/.modules.yaml\n`,
+      { mode: 0o755 },
+    );
+    const pnpmShim = path.join(shimsDir, "pnpm");
+
+    execFileSync(pnpmShim, ["install"], {
+      cwd: repoDir,
+      env: {
+        ...shimEnv(""),
+        AGENT_CI_REAL_NPM: undefined,
+        PATH: `${shimsDir}:${binDir}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    expect(fs.readFileSync(callsFile, "utf8").trim()).toBe("real-pnpm:install");
+  });
+
+  it("passes install commands through unchanged outside local Agent CI", async () => {
+    const { writePackageManagerShims } = await import("./package-manager-shim.ts");
+    writePackageManagerShims(shimsDir);
+    const realNpm = writeFakeNpm(`echo "real:$*" >> "${callsFile}"`);
+    const npmShim = path.join(shimsDir, "npm");
+
+    execFileSync(npmShim, ["ci"], { cwd: repoDir, env: shimEnv(realNpm, "false") });
+    execFileSync(npmShim, ["ci"], { cwd: repoDir, env: shimEnv(realNpm, "false") });
+
+    expect(fs.readFileSync(callsFile, "utf8").trim().split("\n")).toEqual(["real:ci", "real:ci"]);
+  });
+});

--- a/packages/cli/src/runner/package-manager-shim.ts
+++ b/packages/cli/src/runner/package-manager-shim.ts
@@ -1,0 +1,179 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const PACKAGE_MANAGERS = ["npm", "pnpm", "yarn", "bun"] as const;
+
+const SHIM_SCRIPT = `#!/usr/bin/env bash
+set -uo pipefail
+
+pm="$(basename "$0")"
+upper_pm="$(printf '%s' "$pm" | tr '[:lower:]-' '[:upper:]_')"
+real_var="AGENT_CI_REAL_\${upper_pm}"
+real="\${!real_var:-}"
+
+if [ -z "$real" ]; then
+  search_path="$PATH:\${AGENT_CI_ORIGINAL_PATH:-}"
+  IFS=':' read -r -a path_parts <<< "$search_path"
+  for dir in "\${path_parts[@]}"; do
+    candidate="$dir/$pm"
+    if [ -x "$candidate" ] && [ "$candidate" != "$0" ]; then
+      real="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ -z "$real" ]; then
+  echo "[Agent CI Shim] Could not find the real $pm binary" >&2
+  exit 127
+fi
+
+is_install_command=false
+project_install=false
+
+has_global_flag() {
+  for arg in "$@"; do
+    case "$arg" in
+      -g|--global|--location=global)
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
+has_package_arg() {
+  for arg in "$@"; do
+    case "$arg" in
+      --)
+        shift
+        [ "$#" -gt 0 ] && return 0
+        return 1
+        ;;
+      -*)
+        ;;
+      *)
+        return 0
+        ;;
+    esac
+    shift || true
+  done
+  return 1
+}
+
+if [ "$#" -gt 0 ] && ! has_global_flag "$@"; then
+  subcommand="$1"
+  shift
+  case "$pm:$subcommand" in
+    npm:ci)
+      is_install_command=true
+      project_install=true
+      ;;
+    npm:install|npm:i|pnpm:install|pnpm:i|yarn:install|bun:install)
+      is_install_command=true
+      if ! has_package_arg "$@"; then
+        project_install=true
+      fi
+      ;;
+  esac
+  set -- "$subcommand" "$@"
+fi
+
+if [ "\${AGENT_CI_LOCAL:-}" != "true" ] || [ "$is_install_command" != "true" ]; then
+  exec "$real" "$@"
+fi
+
+repo_key="\${GITHUB_REPOSITORY:-unknown-repo}"
+repo_key="$(printf '%s' "$repo_key" | sed 's#[^A-Za-z0-9._-]#_#g')"
+lockfile_hash="\${AGENT_CI_LOCKFILE_HASH:-no-lockfile}"
+state_dir="\${RUNNER_TOOL_CACHE:-/opt/hostedtoolcache}/agent-ci-installs/\${repo_key}/\${lockfile_hash}"
+lock_dir="\${state_dir}/install.lock"
+command_hash="$(printf '%s\n' "$pm" "$@" | sha256sum | awk '{ print $1 }')"
+ready_file="node_modules/.agent-ci-\${pm}-\${command_hash}.ready"
+
+has_install_sentinel() {
+  [ -f node_modules/.modules.yaml ] || \
+    [ -f node_modules/.package-lock.json ] || \
+    [ -f node_modules/.yarn-integrity ] || \
+    [ -d node_modules/.cache ]
+}
+
+is_workspace_project() {
+  [ -f pnpm-workspace.yaml ] || \
+    ([ -f package.json ] && grep -q '"workspaces"' package.json)
+}
+
+can_reuse_project_install=true
+if is_workspace_project; then
+  can_reuse_project_install=false
+fi
+
+if [ "$project_install" = "true" ] && [ "$can_reuse_project_install" = "true" ] && [ -f "$ready_file" ] && has_install_sentinel; then
+  echo "[Agent CI Shim] Reusing warm node_modules for: $pm $*"
+  exit 0
+fi
+
+mkdir -p "$state_dir"
+
+while ! mkdir "$lock_dir" 2>/dev/null; do
+  if [ -f "$lock_dir/created-at" ]; then
+    created_at="$(cat "$lock_dir/created-at" 2>/dev/null || echo 0)"
+    now="$(date +%s)"
+    if [ $((now - created_at)) -gt 600 ]; then
+      rm -rf "$lock_dir"
+      continue
+    fi
+  fi
+  sleep 1
+done
+
+release_lock() {
+  rm -rf "$lock_dir"
+}
+trap release_lock EXIT
+
+date +%s > "$lock_dir/created-at"
+
+if [ "$project_install" = "true" ] && [ "$can_reuse_project_install" = "true" ] && [ -f "$ready_file" ] && has_install_sentinel; then
+  echo "[Agent CI Shim] Reusing warm node_modules for: $pm $*"
+  exit 0
+fi
+
+echo "[Agent CI Shim] Serializing shared node_modules install: $pm $*"
+set +e
+"$real" "$@"
+status=$?
+set -e
+
+if [ "$status" -eq 0 ] && [ "$project_install" = "true" ] && [ "$can_reuse_project_install" = "true" ] && has_install_sentinel; then
+  touch "$ready_file"
+fi
+
+exit "$status"
+`;
+
+/**
+ * Write package-manager shims into the runner shims directory.
+ *
+ * The runner prepends this directory to PATH and points BASH_ENV at the
+ * generated function file so run steps still resolve the shim after setup
+ * actions prepend their own tool paths. Inside local Agent CI containers,
+ * these shims serialize package-manager install commands that write the shared
+ * warm node_modules bind mount, and they skip duplicate project installs after a
+ * ready marker proves the same command already populated the lockfile-keyed
+ * cache. Non-install commands and non-Agent-CI environments pass through to the
+ * real package-manager binary.
+ */
+export function writePackageManagerShims(shimsDir: string): void {
+  fs.mkdirSync(shimsDir, { recursive: true, mode: 0o777 });
+  for (const pm of PACKAGE_MANAGERS) {
+    fs.writeFileSync(path.join(shimsDir, pm), SHIM_SCRIPT, { mode: 0o755 });
+  }
+
+  const bashEnv = PACKAGE_MANAGERS.map((pm) => `${pm}() { /tmp/agent-ci-shims/${pm} "$@"; }`).join(
+    "\n",
+  );
+  fs.writeFileSync(path.join(shimsDir, "bash-env"), `${bashEnv}\n`, { mode: 0o644 });
+}
+
+export const __test_packageManagerShimScript = SHIM_SCRIPT;


### PR DESCRIPTION
## Problem

Parallel Agent CI jobs can run install commands at the same time. Those jobs share the same warm `node_modules` folder, so two installs can try to write the same files together. That can break local runs with confusing install errors, even though parallel jobs should make the run faster.

## Solution

Agent CI now adds small package-manager shims inside each runner container. They serialize common install commands before those commands write to the shared warm `node_modules` folder. For non-workspace projects, a later job can also reuse a ready install instead of doing the same install again.

Closes #370.

## Technical Summary

- Put the lock inside Agent CI instead of asking every downstream repo to add its own install wrapper.
- Use `PATH` plus `BASH_ENV` so bash run steps still hit the shim after setup actions add their own package-manager paths.
- Serialize workspace installs, but do not skip them. Workspace package links can live outside the root `node_modules`, so skipping would leave monorepos half-installed.
- Keep non-Agent-CI behavior as pass-through, so the shim only changes local Agent CI runner containers.
