### PR TITLE
Add explicit node_modules prewarm

### DIFF
--- a/.changeset/prewarm-through-step.md
+++ b/.changeset/prewarm-through-step.md
@@ -1,0 +1,6 @@
+---
+"@redwoodjs/agent-ci": patch
+"dtu-github-actions": patch
+---
+
+Closes #370. Add `agent-ci run --prewarm-through <workflow:job:step-id>` and `AGENT_CI_PREWARM_THROUGH` so a disposable job can warm shared `node_modules` through an explicit workflow step before parallel jobs begin. Agent CI now warns with an actionable prewarm command when cold parallel install jobs look likely, including a structured `diagnostic` event in `--json` mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## Unreleased
 
+- Added `agent-ci run --prewarm-through <workflow:job:step-id>` (or `AGENT_CI_PREWARM_THROUGH`) so a disposable job can warm shared `node_modules` through an explicit workflow step before parallel jobs begin. Agent CI now warns with an actionable prewarm command when cold parallel install jobs look likely, including a structured `diagnostic` event in `--json` mode.
 - Hardened opt-in Rust orchestration so matrix legs are keyed by schedule key, matrix `needs` results are aggregated, reusable workflows and workflow-call outputs are expanded, worker failures preserve sibling outcomes, DTU cleanup/security is enforced, cyclic dependencies error during planning, pull request branch filters use the actual branch, detached pause handling is covered directly, nested ephemeral DTU servers advertise the container IP to sibling runners, nested runner containers join the parent Docker network, Rust cleanup removes nested containers attached to per-job networks, and the Rust smoke parity gate exercises the expanded smoke suite with per-workflow timeouts, duration summaries, heartbeats, status ledgers, failure diagnostics, and timeout cleanup.

--- a/crates/agent-ci/src/cli.rs
+++ b/crates/agent-ci/src/cli.rs
@@ -22,6 +22,9 @@ Options:
       --json                    Emit NDJSON event stream on stdout (also enabled by AGENT_CI_JSON=1)
       --no-matrix               Collapse all matrix combinations into a single job (uses first value of each key)
   -j, --jobs <N>                Maximum jobs to run at once
+      --prewarm-through <workflow:job:step-id>
+                                Run one disposable job through a step id before parallel jobs
+                                Or set: AGENT_CI_PREWARM_THROUGH env var
       --github-token [<token>]  GitHub token for fetching remote reusable workflows
                                 (auto-resolves via `gh auth token` if no value given)
                                 Or set: AGENT_CI_GITHUB_TOKEN env var
@@ -79,6 +82,7 @@ pub struct RunArgs {
     pub json: bool,
     pub no_matrix: bool,
     pub max_jobs: Option<u32>,
+    pub prewarm_through: Option<String>,
     pub github_token: GithubTokenFlag,
     pub commit_status: bool,
     pub cli_vars: Vec<(String, String)>,
@@ -209,6 +213,9 @@ fn parse_run_args(args: &[String]) -> Result<RunArgs, String> {
                 let raw = take_next(args, &mut index, arg)?;
                 parsed.max_jobs = Some(parse_positive_u32(&raw, "--jobs")?);
             }
+            "--prewarm-through" => {
+                parsed.prewarm_through = Some(take_next(args, &mut index, arg)?);
+            }
             "--commit-status" => parsed.commit_status = true,
             "--var" => {
                 let raw = take_next(args, &mut index, arg)?;
@@ -233,6 +240,8 @@ fn parse_run_args(args: &[String]) -> Result<RunArgs, String> {
                     parsed.workflow = Some(value.to_owned());
                 } else if let Some(value) = arg.strip_prefix("--jobs=") {
                     parsed.max_jobs = Some(parse_positive_u32(value, "--jobs")?);
+                } else if let Some(value) = arg.strip_prefix("--prewarm-through=") {
+                    parsed.prewarm_through = Some(value.to_owned());
                 } else if let Some(value) = arg.strip_prefix("--var=") {
                     parsed.cli_vars.push(parse_var_flag(value)?);
                 } else if let Some(value) = arg.strip_prefix("--var-file=") {
@@ -362,6 +371,8 @@ mod tests {
             "--github-token",
             "ghp_token",
             "--commit-status",
+            "--prewarm-through",
+            ".github/workflows/ci.yml:test:install",
             "--var",
             "FOO=bar",
             "--var-file=vars.json",
@@ -378,6 +389,7 @@ mod tests {
                 json: true,
                 no_matrix: true,
                 max_jobs: None,
+                prewarm_through: Some(".github/workflows/ci.yml:test:install".to_owned()),
                 github_token: GithubTokenFlag::Value("ghp_token".to_owned()),
                 commit_status: true,
                 cli_vars: vec![("FOO".to_owned(), "bar".to_owned())],

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,6 +33,8 @@ Existing "run actions locally" tools either re-implement steps in a compatibilit
 
 Agent CI replaces GitHub's cloud cache with **local bind-mounts**. `node_modules`, the pnpm store, Playwright browsers, and the runner tool cache all live on your host filesystem and are mounted directly into the container — no upload, no download, no tar/untar. The first run warms the cache; every subsequent run starts with hot dependencies instantly.
 
+For workflows with several independent jobs, use `--prewarm-through <workflow:job:step-id>` to warm `node_modules` once before the real jobs start in parallel. The selected step must have a stable `id`. Agent CI runs a disposable copy of that job from the beginning through the selected step, then runs the real workflows normally. This avoids parallel cold installs writing to the same shared `node_modules` mount without patching package-manager tools. You can also set `AGENT_CI_PREWARM_THROUGH` in `.env.agent-ci` to make this automatic for a repo; Agent CI warns when cold parallel install jobs look likely and no prewarm setting is present.
+
 ### Pause on failure
 
 Step 6 failed. Fix the file. Retry just that step. Green. No checkout, no reinstall, no waiting.
@@ -107,19 +109,49 @@ npx @redwoodjs/agent-ci retry --name <runner-name>
 
 Run GitHub Actions workflow jobs locally.
 
-| Flag                       | Short | Description                                                                                                                                                  |
-| -------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--workflow <path>`        | `-w`  | Path to the workflow file                                                                                                                                    |
-| `--all`                    | `-a`  | Discover and run all relevant workflows for the current branch                                                                                               |
-| `--pause-on-failure`       | `-p`  | Pause on step failure for interactive debugging                                                                                                              |
-| `--quiet`                  | `-q`  | Suppress animated rendering (also enabled by `AI_AGENT=1`)                                                                                                   |
-| `--json`                   |       | Emit NDJSON event stream on stdout (also enabled by `AGENT_CI_JSON=1`); see [Agent output mode](#agent-output-mode-ndjson-event-stream)                      |
-| `--no-matrix`              |       | Collapse all matrix combinations into a single job (uses first value of each key)                                                                            |
-| `--jobs <N>`               | `-j`  | Maximum jobs to run at once                                                                                                                                  |
-| `--github-token [<token>]` |       | GitHub token for fetching remote reusable workflows (auto-resolves via `gh auth token` if no value given). Also available as `AGENT_CI_GITHUB_TOKEN` env var |
-| `--commit-status`          |       | Post a GitHub commit status after the run (requires `--github-token`)                                                                                        |
-| `--var KEY=VALUE`          |       | Provide a workflow variable (`${{ vars.KEY }}`); repeat for multiple                                                                                         |
-| `--var-file <path\|->`     |       | Load workflow variables from a JSON file, or use `-` to read JSON from stdin                                                                                 |
+| Flag                                       | Short | Description                                                                                                                                                                         |
+| ------------------------------------------ | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--workflow <path>`                        | `-w`  | Path to the workflow file                                                                                                                                                           |
+| `--all`                                    | `-a`  | Discover and run all relevant workflows for the current branch                                                                                                                      |
+| `--pause-on-failure`                       | `-p`  | Pause on step failure for interactive debugging                                                                                                                                     |
+| `--quiet`                                  | `-q`  | Suppress animated rendering (also enabled by `AI_AGENT=1`)                                                                                                                          |
+| `--json`                                   |       | Emit NDJSON event stream on stdout (also enabled by `AGENT_CI_JSON=1`); see [Agent output mode](#agent-output-mode-ndjson-event-stream)                                             |
+| `--no-matrix`                              |       | Collapse all matrix combinations into a single job (uses first value of each key)                                                                                                   |
+| `--jobs <N>`                               | `-j`  | Maximum jobs to run at once                                                                                                                                                         |
+| `--prewarm-through <workflow:job:step-id>` |       | If warm `node_modules` is cold, run one disposable job through the selected step `id` before starting the real jobs in parallel. Also configurable with `AGENT_CI_PREWARM_THROUGH`. |
+| `--github-token [<token>]`                 |       | GitHub token for fetching remote reusable workflows (auto-resolves via `gh auth token` if no value given). Also available as `AGENT_CI_GITHUB_TOKEN` env var                        |
+| `--commit-status`                          |       | Post a GitHub commit status after the run (requires `--github-token`)                                                                                                               |
+| `--var KEY=VALUE`                          |       | Provide a workflow variable (`${{ vars.KEY }}`); repeat for multiple                                                                                                                |
+| `--var-file <path\|->`                     |       | Load workflow variables from a JSON file, or use `-` to read JSON from stdin                                                                                                        |
+
+#### Prewarm `node_modules` before parallel jobs
+
+If several first-wave jobs run dependency installs, a cold local run can make those jobs write to the same warm `node_modules` mount at the same time. Agent CI warns when this looks likely and no prewarm setting is present.
+
+Add a stable `id` to the install step you want to use as the prewarm boundary:
+
+```yaml
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v4
+      - id: install
+        run: pnpm install --frozen-lockfile
+```
+
+Then run:
+
+```bash
+agent-ci run --all --prewarm-through .github/workflows/ci.yml:test:install
+```
+
+To make this automatic for the repo, put the same selector in `.env.agent-ci`:
+
+```env
+AGENT_CI_PREWARM_THROUGH=.github/workflows/ci.yml:test:install
+```
+
+The CLI flag wins over the env setting. If the lockfile-keyed warm `node_modules` cache is already ready, Agent CI skips the disposable prewarm job.
 
 ### `agent-ci retry`
 
@@ -205,14 +237,15 @@ Only `AGENT_CI_*`-prefixed keys from `.env.agent-ci` are applied to the CLI proc
 
 ### General
 
-| Variable                | Default                         | Description                                                                                                                                                                                                                                                                                  |
-| ----------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GITHUB_REPO`           | auto-detected from `git remote` | Override the `owner/repo` used when emulating the GitHub API. Useful when the remote URL can't be detected automatically.                                                                                                                                                                    |
-| `AI_AGENT`              | unset                           | Set to `1` to enable quiet mode (suppress animated rendering). Same effect as `--quiet`.                                                                                                                                                                                                     |
-| `AGENT_CI_JSON`         | unset                           | Set to `1` to emit the NDJSON event stream on stdout. Same effect as `--json`.                                                                                                                                                                                                               |
-| `AGENT_CI_DETACHED`     | unset                           | Set to `1` to force `--pause-on-failure` to use the detached launcher even on a TTY (for manual verification of the pause-then-exit-77 flow). The launcher uses this same env var internally to mark its worker child (with the worker's log path as the value), so do not set it to a path. |
-| `DEBUG`                 | unset                           | Enable verbose debug logging. See [Debugging](#debugging) for supported namespaces.                                                                                                                                                                                                          |
-| `AGENT_CI_GITHUB_TOKEN` | unset                           | GitHub token for fetching remote reusable workflows. Alternative to the `--github-token` CLI flag.                                                                                                                                                                                           |
+| Variable                   | Default                         | Description                                                                                                                                                                                                                                                                                  |
+| -------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GITHUB_REPO`              | auto-detected from `git remote` | Override the `owner/repo` used when emulating the GitHub API. Useful when the remote URL can't be detected automatically.                                                                                                                                                                    |
+| `AI_AGENT`                 | unset                           | Set to `1` to enable quiet mode (suppress animated rendering). Same effect as `--quiet`.                                                                                                                                                                                                     |
+| `AGENT_CI_JSON`            | unset                           | Set to `1` to emit the NDJSON event stream on stdout. Same effect as `--json`.                                                                                                                                                                                                               |
+| `AGENT_CI_DETACHED`        | unset                           | Set to `1` to force `--pause-on-failure` to use the detached launcher even on a TTY (for manual verification of the pause-then-exit-77 flow). The launcher uses this same env var internally to mark its worker child (with the worker's log path as the value), so do not set it to a path. |
+| `DEBUG`                    | unset                           | Enable verbose debug logging. See [Debugging](#debugging) for supported namespaces.                                                                                                                                                                                                          |
+| `AGENT_CI_GITHUB_TOKEN`    | unset                           | GitHub token for fetching remote reusable workflows. Alternative to the `--github-token` CLI flag.                                                                                                                                                                                           |
+| `AGENT_CI_PREWARM_THROUGH` | unset                           | Persistent default for `--prewarm-through <workflow:job:step-id>`. The CLI flag wins when both are set.                                                                                                                                                                                      |
 
 ### Docker
 
@@ -366,7 +399,7 @@ these events:
 | `job.finish`  | `ts`, `job`, `runner`, `status`                                                | `workflow`, `durationMs`            |
 | `step.start`  | `ts`, `job`, `runner`, `step`, `index`                                         |                                     |
 | `step.finish` | `ts`, `job`, `runner`, `step`, `index`, `status` (`passed`/`failed`/`skipped`) | `durationMs`                        |
-| `diagnostic`  | `ts`, `level` (`info`/`warning`/`error`), `message`                            |                                     |
+| `diagnostic`  | `ts`, `level` (`info`/`warning`/`error`), `message`                            | `code`, `details`                   |
 
 Example:
 
@@ -376,6 +409,7 @@ Example:
 {"event":"step.start","ts":"…","job":"lint","runner":"agent-ci-1-job","step":"eslint","index":1}
 {"event":"step.finish","ts":"…","job":"lint","runner":"agent-ci-1-job","step":"eslint","index":1,"status":"passed","durationMs":4123}
 {"event":"job.finish","ts":"…","job":"lint","runner":"agent-ci-1-job","workflow":"ci.yml","status":"passed","durationMs":8000}
+{"event":"diagnostic","ts":"…","level":"warning","code":"prewarm_recommended","message":"cold node_modules may be shared by 2 parallel install jobs","details":{"selector":".github/workflows/ci.yml:test:install","candidateCount":2}}
 {"event":"run.finish","ts":"…","status":"passed","durationMs":18210}
 ```
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -79,6 +79,11 @@ function printUsage() {
     "      --no-matrix               Collapse all matrix combinations into a single job (uses first value of each key)",
   );
   console.log("  -j, --jobs <N>                Maximum jobs to run at once");
+  console.log("      --prewarm-through <workflow:job:step-id>");
+  console.log(
+    "                                Run one disposable job through a step id before parallel jobs",
+  );
+  console.log("                                Or set: AGENT_CI_PREWARM_THROUGH env var");
   console.log(
     "      --github-token [<token>]  GitHub token for fetching remote reusable workflows",
   );

--- a/packages/cli/src/commands/run-prewarm.test.ts
+++ b/packages/cli/src/commands/run-prewarm.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  findPrewarmInstallCandidates,
+  formatPrewarmWarning,
+  parsePrewarmThroughSpec,
+  prewarmDiagnosticEvent,
+  prewarmSelectorForCandidates,
+  truncateStepsThroughId,
+} from "./run.ts";
+
+describe("parsePrewarmThroughSpec", () => {
+  it("parses workflow path, job id, and step id", () => {
+    expect(parsePrewarmThroughSpec(".github/workflows/ci.yml:test:install")).toEqual({
+      workflowPath: ".github/workflows/ci.yml",
+      jobId: "test",
+      stepId: "install",
+    });
+  });
+
+  it("allows colons in the workflow portion by splitting from the right", () => {
+    expect(parsePrewarmThroughSpec("third-party:workflows/ci.yml:test:install")).toEqual({
+      workflowPath: "third-party:workflows/ci.yml",
+      jobId: "test",
+      stepId: "install",
+    });
+  });
+});
+
+describe("truncateStepsThroughId", () => {
+  it("keeps steps through the selected step id", () => {
+    const steps = [
+      { ContextName: "checkout", Name: "Checkout" },
+      { ContextName: "install", Name: "Install" },
+      { ContextName: "test", Name: "Test" },
+    ];
+
+    expect(truncateStepsThroughId(steps, "install")).toEqual(steps.slice(0, 2));
+  });
+
+  it("throws when the selected step id is missing", () => {
+    expect(() => truncateStepsThroughId([{ ContextName: "checkout" }], "install")).toThrow(
+      "Prewarm step 'install' not found",
+    );
+  });
+});
+
+describe("findPrewarmInstallCandidates", () => {
+  function writeWorkflow(content: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-ci-prewarm-test-"));
+    const file = path.join(dir, "ci.yml");
+    fs.writeFileSync(file, content);
+    return file;
+  }
+
+  it("finds first-wave jobs with likely install commands", () => {
+    const workflowPath = writeWorkflow(`
+name: CI
+on: [push]
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    steps:
+      - id: install
+        run: pnpm install --frozen-lockfile
+  b:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm ci
+  later:
+    needs: a
+    runs-on: ubuntu-latest
+    steps:
+      - id: install
+        run: yarn install
+`);
+
+    expect(findPrewarmInstallCandidates(workflowPath)).toEqual([
+      {
+        workflowPath,
+        jobId: "a",
+        stepId: "install",
+        command: "pnpm install --frozen-lockfile",
+      },
+      { workflowPath, jobId: "b", stepId: undefined, command: "npm ci" },
+    ]);
+  });
+});
+
+const warningCandidates = [
+  {
+    workflowPath: ".github/workflows/ci.yml",
+    jobId: "test",
+    stepId: "install",
+    command: "pnpm install",
+  },
+  {
+    workflowPath: ".github/workflows/ci.yml",
+    jobId: "lint",
+    command: "pnpm install",
+  },
+];
+
+describe("formatPrewarmWarning", () => {
+  it("gives an actionable prewarm command and env setting", () => {
+    const warning = formatPrewarmWarning(warningCandidates);
+
+    expect(warning).toContain("cold node_modules may be shared by 2 parallel install jobs");
+    expect(warning).toContain(
+      "agent-ci run --all --prewarm-through .github/workflows/ci.yml:test:install",
+    );
+    expect(warning).toContain("AGENT_CI_PREWARM_THROUGH=.github/workflows/ci.yml:test:install");
+  });
+});
+
+describe("prewarmSelectorForCandidates", () => {
+  it("prefers a candidate with a real step id", () => {
+    expect(prewarmSelectorForCandidates(warningCandidates)).toBe(
+      ".github/workflows/ci.yml:test:install",
+    );
+  });
+});
+
+describe("prewarmDiagnosticEvent", () => {
+  it("builds a structured agent warning", () => {
+    const event = prewarmDiagnosticEvent(warningCandidates);
+
+    expect(event.event).toBe("diagnostic");
+    expect(event.level).toBe("warning");
+    expect(event.code).toBe("prewarm_recommended");
+    expect(event.message).toContain("--prewarm-through .github/workflows/ci.yml:test:install");
+    expect(event.details).toMatchObject({
+      selector: ".github/workflows/ci.yml:test:install",
+      candidateCount: 2,
+    });
+  });
+});

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import fs from "node:fs";
 import os from "node:os";
 import type Docker from "dockerode";
+import { parse as parseYaml } from "yaml";
 
 import { config, loadMachineSecrets, resolveRepoSlug } from "../config.ts";
 import { loadVarFiles } from "../workflow-vars.ts";
@@ -87,6 +88,7 @@ import {
   isForceDetachedRequested,
   runDetachedLauncher,
   shouldLaunchDetached,
+  type DiagnosticEvent,
   type LogEvent,
 } from "../launcher.ts";
 
@@ -99,9 +101,164 @@ type ParsedRunArgs = {
   githubToken?: string;
   commitStatus: boolean;
   maxJobs?: number;
+  prewarmThrough?: string;
   cliVars: Record<string, string>;
   varFiles: string[];
 };
+
+export type PrewarmThroughSpec = {
+  workflowPath: string;
+  jobId: string;
+  stepId: string;
+};
+
+export function parsePrewarmThroughSpec(raw: string): PrewarmThroughSpec {
+  const parts = raw.split(":");
+  if (parts.length < 3) {
+    exitWithError("[Agent CI] Error: --prewarm-through expects <workflow-path>:<job-id>:<step-id>");
+  }
+  const stepId = parts.pop()!.trim();
+  const jobId = parts.pop()!.trim();
+  const workflowPath = parts.join(":").trim();
+  if (!workflowPath || !jobId || !stepId) {
+    exitWithError("[Agent CI] Error: --prewarm-through expects <workflow-path>:<job-id>:<step-id>");
+  }
+  return { workflowPath, jobId, stepId };
+}
+
+export type PrewarmInstallCandidate = {
+  workflowPath: string;
+  jobId: string;
+  stepId?: string;
+  command: string;
+};
+
+function isLikelyInstallCommand(script: string): boolean {
+  return /(^|[\s;&|()])(?:npm\s+(?:ci|install|i)|pnpm\s+(?:install|i)|yarn\s+install|bun\s+install)(?:\s|$)/m.test(
+    script,
+  );
+}
+
+function jobNeedsAreEmpty(needs: unknown): boolean {
+  return needs === undefined || (Array.isArray(needs) && needs.length === 0);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+type InstallRunStep = {
+  id?: unknown;
+  run: string;
+};
+
+function isInstallRunStep(step: unknown): step is InstallRunStep {
+  return isRecord(step) && typeof step.run === "string" && isLikelyInstallCommand(step.run);
+}
+
+export function findPrewarmInstallCandidates(workflowPath: string): PrewarmInstallCandidate[] {
+  let rawYaml: unknown;
+  try {
+    rawYaml = parseYaml(fs.readFileSync(workflowPath, "utf8"));
+  } catch {
+    return [];
+  }
+  if (!isRecord(rawYaml) || !isRecord(rawYaml.jobs)) {
+    return [];
+  }
+
+  const candidates: PrewarmInstallCandidate[] = [];
+  for (const [jobId, job] of Object.entries(rawYaml.jobs)) {
+    if (!isRecord(job) || !jobNeedsAreEmpty(job.needs)) {
+      continue;
+    }
+    const steps = Array.isArray(job.steps) ? job.steps : [];
+    const installStep = steps.find(isInstallRunStep);
+    if (!installStep) {
+      continue;
+    }
+    candidates.push({
+      workflowPath,
+      jobId,
+      stepId: typeof installStep.id === "string" ? installStep.id : undefined,
+      command:
+        installStep.run
+          .split("\n")
+          .find((line) => line.trim())
+          ?.trim() ?? "install",
+    });
+  }
+  return candidates;
+}
+
+export function prewarmSelectorForCandidates(candidates: PrewarmInstallCandidate[]): string {
+  const example = candidates.find((candidate) => candidate.stepId) ?? candidates[0];
+  return example.stepId
+    ? `${example.workflowPath}:${example.jobId}:${example.stepId}`
+    : `${example.workflowPath}:${example.jobId}:install`;
+}
+
+export function formatPrewarmWarning(candidates: PrewarmInstallCandidate[]): string {
+  const example = candidates.find((candidate) => candidate.stepId) ?? candidates[0];
+  const selector = prewarmSelectorForCandidates(candidates);
+  const stepIdHint = example.stepId
+    ? ""
+    : "\nAdd a stable `id: install` to the install step you want Agent CI to prewarm through.\n";
+  return [
+    `[Agent CI] Warning: cold node_modules may be shared by ${candidates.length} parallel install jobs.`,
+    "If more than one job writes node_modules at the same time, package managers can race and fail.",
+    stepIdHint.trim(),
+    "To prewarm the shared dependency tree explicitly, run:",
+    "",
+    `  agent-ci run --all --prewarm-through ${selector}`,
+    "",
+    "Or persist this in .env.agent-ci:",
+    "",
+    `  AGENT_CI_PREWARM_THROUGH=${selector}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function prewarmDiagnosticEvent(candidates: PrewarmInstallCandidate[]): DiagnosticEvent {
+  return {
+    event: "diagnostic",
+    ts: new Date().toISOString(),
+    level: "warning",
+    message: formatPrewarmWarning(candidates),
+    code: "prewarm_recommended",
+    details: {
+      selector: prewarmSelectorForCandidates(candidates),
+      candidateCount: candidates.length,
+      candidates: candidates.map((candidate) => ({
+        workflowPath: candidate.workflowPath,
+        jobId: candidate.jobId,
+        stepId: candidate.stepId,
+        command: candidate.command,
+      })),
+    },
+  };
+}
+
+function emitJsonDiagnostic(event: DiagnosticEvent): void {
+  if (!isJsonMode()) {
+    return;
+  }
+  process.stdout.write(formatEvent(event) + "\n");
+}
+
+export function truncateStepsThroughId<T extends { ContextName?: string } | null | undefined>(
+  steps: T[],
+  stepId: string,
+): NonNullable<T>[] {
+  const idx = steps.findIndex((step) => step?.ContextName === stepId);
+  if (idx === -1) {
+    throw new Error(
+      `[Agent CI] Prewarm step '${stepId}' not found. Add a stable 'id: ${stepId}' to the target step.`,
+    );
+  }
+  return steps.slice(0, idx + 1).filter((step): step is NonNullable<T> => step != null);
+}
 
 function exitWithError(msg: string): never {
   console.error(msg);
@@ -178,6 +335,10 @@ function parseRunArgs(args: string[]): ParsedRunArgs {
       parsed.maxJobs = parseJobsFlag(args[++i]);
     } else if (arg.startsWith("--jobs=")) {
       parsed.maxJobs = parseJobsFlag(arg.slice("--jobs=".length));
+    } else if (arg === "--prewarm-through" && args[i + 1]) {
+      parsed.prewarmThrough = args[++i];
+    } else if (arg.startsWith("--prewarm-through=")) {
+      parsed.prewarmThrough = arg.slice("--prewarm-through=".length);
     } else if (arg === "--commit-status") {
       parsed.commitStatus = true;
     } else if (arg === "--var" && args[i + 1]) {
@@ -210,6 +371,11 @@ function parseRunArgs(args: string[]): ParsedRunArgs {
   if (!parsed.githubToken && process.env.AGENT_CI_GITHUB_TOKEN) {
     parsed.githubToken = process.env.AGENT_CI_GITHUB_TOKEN;
   }
+
+  if (!parsed.prewarmThrough && process.env.AGENT_CI_PREWARM_THROUGH) {
+    parsed.prewarmThrough = process.env.AGENT_CI_PREWARM_THROUGH;
+  }
+
   return parsed;
 }
 
@@ -389,6 +555,7 @@ export default async function runCmd(args: string[]): Promise<void> {
     noMatrix: parsed.noMatrix,
     githubToken: parsed.githubToken,
     maxJobs: parsed.maxJobs,
+    prewarmThrough: parsed.prewarmThrough,
     vars: workflowVars,
   };
 
@@ -420,6 +587,143 @@ export default async function runCmd(args: string[]): Promise<void> {
   const workflowPath = resolveWorkflowArgPath(parsed.workflow, repoRoot);
   const results = await runWorkflows({ workflowPaths: [workflowPath], ...runWorkflowsOpts });
   await finalizeRun({ results, parsed, repoRoot, startedAt });
+}
+
+// ─── runPrewarmThrough ──────────────────────────────────────────────────────
+// Optional warm-cache primer. Runs one disposable copy of a real workflow job
+// from the beginning through a user-selected step id, so setup actions and the
+// install command are exactly the repo's own workflow steps.
+async function isWarmNodeModulesForWorkflow(workflowPath: string): Promise<boolean> {
+  const repoRoot = resolveRepoRootFromWorkflow(workflowPath);
+  config.GITHUB_REPO ??= await resolveRepoSlug(repoRoot);
+  const repoSlug = config.GITHUB_REPO.replace("/", "-");
+  let lockfileHash = "no-lockfile";
+  try {
+    lockfileHash = computeLockfileHash(repoRoot);
+  } catch {}
+  const warmModulesDir = path.resolve(
+    getWorkingDirectory(),
+    "cache",
+    "warm-modules",
+    repoSlug,
+    lockfileHash,
+  );
+  return isWarmNodeModules(warmModulesDir);
+}
+
+async function warnIfPrewarmLikelyNeeded(workflowPaths: string[]): Promise<void> {
+  if (workflowPaths.length === 0 || (await isWarmNodeModulesForWorkflow(workflowPaths[0]))) {
+    return;
+  }
+  const candidates = workflowPaths.flatMap(findPrewarmInstallCandidates);
+  if (candidates.length < 2) {
+    return;
+  }
+  const diagnostic = prewarmDiagnosticEvent(candidates);
+  process.stderr.write(`${diagnostic.message}\n`);
+  emitJsonDiagnostic(diagnostic);
+}
+
+async function runPrewarmThrough(options: {
+  spec: PrewarmThroughSpec;
+  sha?: string;
+  pauseOnFailure: boolean;
+  store: RunStateStore;
+  githubToken?: string;
+  vars?: Record<string, string>;
+  workflowPaths: string[];
+}): Promise<void> {
+  const repoRootForArg = resolveRepoRoot();
+  const workflowPath = resolveWorkflowArgPath(options.spec.workflowPath, repoRootForArg);
+  if (!options.workflowPaths.includes(workflowPath)) {
+    options.store.addWorkflow(workflowPath);
+  }
+  if (!fs.existsSync(workflowPath)) {
+    throw new Error(`[Agent CI] Prewarm workflow not found: ${workflowPath}`);
+  }
+
+  const repoRoot = resolveRepoRootFromWorkflow(workflowPath);
+  config.GITHUB_REPO ??= await resolveRepoSlug(repoRoot);
+  if (await isWarmNodeModulesForWorkflow(workflowPath)) {
+    debugCli("[Agent CI] Prewarm skipped — warm node_modules already exists.");
+    return;
+  }
+
+  const kind = classifyRunsOn(parseJobRunsOn(workflowPath, options.spec.jobId));
+  if (isUnsupportedOS(kind)) {
+    throw new Error(
+      `[Agent CI] Prewarm job '${options.spec.jobId}' targets unsupported runs-on kind '${kind}'.`,
+    );
+  }
+
+  const [explicitHead, dirtySha, headSlug] = await Promise.all([
+    options.sha ? resolveHeadSha(repoRoot, options.sha) : Promise.resolve(undefined),
+    options.sha ? Promise.resolve(undefined) : computeDirtySha(repoRoot),
+    resolveHeadSha(repoRoot, "HEAD"),
+  ]);
+  const { headSha, shaRef } = explicitHead ?? { headSha: undefined, shaRef: undefined };
+  const realHeadSha = headSha ?? dirtySha ?? headSlug.headSha;
+  const baseSha = await resolveBaseSha(repoRoot, realHeadSha);
+  const [owner, name] = config.GITHUB_REPO.split("/");
+
+  const requiredRefs = extractSecretRefs(workflowPath, options.spec.jobId);
+  const secrets = loadMachineSecrets(repoRoot, requiredRefs);
+  if (options.githubToken && !secrets["GITHUB_TOKEN"]) {
+    secrets["GITHUB_TOKEN"] = options.githubToken;
+  }
+  validateSecrets(workflowPath, options.spec.jobId, secrets, path.join(repoRoot, ".env.agent-ci"));
+  validateVars(workflowPath, options.spec.jobId, options.vars ?? {});
+
+  const steps = truncateStepsThroughId(
+    await parseWorkflowSteps(
+      workflowPath,
+      options.spec.jobId,
+      secrets,
+      undefined,
+      undefined,
+      undefined,
+      options.vars,
+    ),
+    options.spec.stepId,
+  );
+
+  debugCli(
+    `[Agent CI] Prewarming node_modules through ${path.basename(workflowPath)}:${options.spec.jobId}:${options.spec.stepId}...`,
+  );
+  const result = await executeLocalJob(
+    {
+      deliveryId: `prewarm-${Date.now()}`,
+      eventType: "workflow_job",
+      githubJobId: Math.floor(Math.random() * 1000000).toString(),
+      githubRepo: config.GITHUB_REPO,
+      githubToken: "mock_token",
+      headSha,
+      baseSha,
+      realHeadSha,
+      repoRoot,
+      shaRef,
+      env: { AGENT_CI_LOCAL: "true" },
+      repository: {
+        name,
+        full_name: config.GITHUB_REPO,
+        owner: { login: owner },
+        default_branch: "main",
+      },
+      runnerName: `agent-ci-prewarm-${getNextLogNum("agent-ci")}-j1`,
+      steps,
+      services: await parseWorkflowServices(workflowPath, options.spec.jobId),
+      container: (await parseWorkflowContainer(workflowPath, options.spec.jobId)) ?? undefined,
+      workflowPath,
+      taskId: `prewarm:${options.spec.jobId}:${options.spec.stepId}`,
+    },
+    { pauseOnFailure: options.pauseOnFailure, store: options.store },
+  );
+
+  if (!result.succeeded) {
+    throw new Error(
+      `[Agent CI] Prewarm failed for ${path.basename(workflowPath)}:${options.spec.jobId}:${options.spec.stepId}`,
+    );
+  }
 }
 
 // ─── prefetchRunnerImages ──────────────────────────────────────────────────
@@ -633,9 +937,18 @@ async function runWorkflows(options: {
   noMatrix?: boolean;
   githubToken?: string;
   maxJobs?: number;
+  prewarmThrough?: string;
   vars?: Record<string, string>;
 }): Promise<JobResult[]> {
-  const { workflowPaths, sha, pauseOnFailure, noMatrix = false, githubToken, vars } = options;
+  const {
+    workflowPaths,
+    sha,
+    pauseOnFailure,
+    noMatrix = false,
+    githubToken,
+    vars,
+    prewarmThrough,
+  } = options;
 
   // Pre-flight: scan all workflows for required vars before doing any setup
   // work. Catches missing vars up front instead of mid-run.
@@ -882,6 +1195,20 @@ async function runWorkflows(options: {
   }
   pruneStaleWorkspaces(getWorkingDirectory(), 24 * 60 * 60 * 1000);
   await prefetchRunnerImages(workflowPaths);
+
+  if (prewarmThrough) {
+    await runPrewarmThrough({
+      spec: parsePrewarmThroughSpec(prewarmThrough),
+      sha,
+      pauseOnFailure,
+      store,
+      githubToken,
+      vars,
+      workflowPaths,
+    });
+  } else {
+    await warnIfPrewarmLikelyNeeded(workflowPaths);
+  }
 
   // Global concurrency limiter shared across all workflows. Without this,
   // --all mode launches every workflow in parallel — leading to 20+

--- a/packages/cli/src/launcher.test.ts
+++ b/packages/cli/src/launcher.test.ts
@@ -136,6 +136,8 @@ describe("formatEvent / parseLogEvent — #289 lifecycle events", () => {
       ts: "2026-04-28T00:00:02.000Z",
       level: "warning" as const,
       message: "could not resolve workflow path; falling back to default",
+      code: "prewarm_recommended",
+      details: { selector: ".github/workflows/ci.yml:test:install" },
     };
     expect(parseLogEvent(formatEvent(e))).toEqual(e);
   });

--- a/packages/cli/src/launcher.ts
+++ b/packages/cli/src/launcher.ts
@@ -104,6 +104,8 @@ export interface DiagnosticEvent {
   ts: string;
   level: "info" | "warning" | "error";
   message: string;
+  code?: string;
+  details?: Record<string, unknown>;
 }
 
 export type LogEvent =


### PR DESCRIPTION
## Problem

Parallel Agent CI jobs can all run dependency installs at the same time. They share one warm `node_modules` folder, so a cold run can have several jobs writing the same files together. That can cause confusing install failures, but turning off parallel jobs gives up a lot of speed.

## Solution

This PR adds an explicit prewarm option. A project can tell Agent CI to run one disposable job through a chosen step `id`, such as an install step, before the real jobs start in parallel. That warms `node_modules` once without patching package managers or guessing which command installs dependencies.

Closes #370.

## Technical Summary

- Use `--prewarm-through <workflow:job:step-id>` so the repo owner chooses the exact workflow job and step boundary.
- Support `AGENT_CI_PREWARM_THROUGH` in `.env.agent-ci` for persistent repo-local opt-in.
- Warn when cold `node_modules` plus multiple first-wave install jobs look risky and no prewarm setting is present.
- Emit that warning as a structured `diagnostic` NDJSON event in `--json` mode for agent harnesses.
- Run the real workflow steps from the beginning through that selected step. This preserves setup actions before install.
- Skip prewarm when the lockfile-keyed warm `node_modules` cache is already ready.
- Keep the real workflow jobs unchanged. They still run normally after prewarm, so Agent CI does not rewrite or skip user steps.
- Mirror the new flag in Rust CLI parsing and help text so TypeScript and Rust CLI output stay aligned.
