### PR TITLE
Fix deferred native release formatting

### DIFF
--- a/.github/workflows/native-binaries.yml
+++ b/.github/workflows/native-binaries.yml
@@ -92,4 +92,3 @@ jobs:
             dist/${{ env.archive }}
             dist/${{ env.archive }}.sha256
           if-no-files-found: error
-

--- a/packages/agent-ci-darwin-arm64/package.json
+++ b/packages/agent-ci-darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@redwoodjs/agent-ci-darwin-arm64",
-  "private": true,
   "version": "0.16.1",
+  "private": true,
   "description": "macOS arm64 native binary for @redwoodjs/agent-ci.",
   "license": "FSL-1.1-MIT",
   "repository": {

--- a/packages/agent-ci-darwin-x64/package.json
+++ b/packages/agent-ci-darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@redwoodjs/agent-ci-darwin-x64",
-  "private": true,
   "version": "0.16.1",
+  "private": true,
   "description": "macOS x64 native binary for @redwoodjs/agent-ci.",
   "license": "FSL-1.1-MIT",
   "repository": {

--- a/packages/agent-ci-linux-arm64/package.json
+++ b/packages/agent-ci-linux-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@redwoodjs/agent-ci-linux-arm64",
-  "private": true,
   "version": "0.16.1",
+  "private": true,
   "description": "Linux arm64 native binary for @redwoodjs/agent-ci.",
   "license": "FSL-1.1-MIT",
   "repository": {

--- a/packages/agent-ci-linux-x64/package.json
+++ b/packages/agent-ci-linux-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@redwoodjs/agent-ci-linux-x64",
-  "private": true,
   "version": "0.16.1",
+  "private": true,
   "description": "Linux x64 native binary for @redwoodjs/agent-ci.",
   "license": "FSL-1.1-MIT",
   "repository": {


### PR DESCRIPTION
## Problem

The release workflow on `main` was failing before Changesets could make a fresh release PR. A few files from the native release deferral commit did not match the repo formatter.

That left the old Changesets PR stale, which caused merge conflicts.

## Solution

This PR applies the formatter output to those files. The release workflow should now be able to get past the format check and create a new Changesets release PR from current `main`.

## Technical Summary

- Keep the native packages private and ignored for release.
- Only change formatting: package key order and one trailing blank line.
- Do not change release behavior or native binary publishing behavior.
