### PR TITLE
chore: version packages

### DIFF
--- a/.changeset/local-ci-rename.md
+++ b/.changeset/local-ci-rename.md
@@ -1,7 +1,0 @@
----
-"run-local-ci": minor
-"@redwoodjs/agent-ci": minor
-"dtu-github-actions": minor
----
-
-Rename Agent CI to Local CI. The canonical package is now `run-local-ci` and the canonical executable is `local-ci`. The old `@redwoodjs/agent-ci` package forwards to Local CI, while `AGENT_CI_*`, `.env.agent-ci`, and `.github/agent-ci*` remain supported compatibility aliases throughout the `0.x` release line.

--- a/.changeset/private-images-auth.md
+++ b/.changeset/private-images-auth.md
@@ -1,6 +1,0 @@
----
-"run-local-ci": minor
-"dtu-github-actions": minor
----
-
-Support private job and service container images with workflow registry credentials, and reuse images that are already cached locally. Closes #384.

--- a/.release-closes.json
+++ b/.release-closes.json
@@ -1,7 +1,7 @@
 [
   {
-    "issue": 378,
-    "pr": 380,
-    "changeset": "private-modules-snapshots.md"
+    "issue": 384,
+    "pr": 385,
+    "changeset": "private-images-auth.md"
   }
 ]

--- a/packages/agent-ci-compat/CHANGELOG.md
+++ b/packages/agent-ci-compat/CHANGELOG.md
@@ -1,0 +1,13 @@
+# @redwoodjs/agent-ci
+
+## 0.18.0
+
+### Minor Changes
+
+- 417bd26: Rename Agent CI to Local CI. The canonical package is now `run-local-ci` and the canonical executable is `local-ci`. The old `@redwoodjs/agent-ci` package forwards to Local CI, while `AGENT_CI_*`, `.env.agent-ci`, and `.github/agent-ci*` remain supported compatibility aliases throughout the `0.x` release line.
+
+### Patch Changes
+
+- Updated dependencies [417bd26]
+- Updated dependencies [417bd26]
+  - run-local-ci@0.18.0

--- a/packages/agent-ci-compat/package.json
+++ b/packages/agent-ci-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redwoodjs/agent-ci",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Compatibility package for local-ci.",
   "license": "FSL-1.1-MIT",
   "repository": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Local CI
 
+## 0.18.0
+
+### Minor Changes
+
+- 417bd26: Rename Agent CI to Local CI. The canonical package is now `run-local-ci` and the canonical executable is `local-ci`. The old `@redwoodjs/agent-ci` package forwards to Local CI, while `AGENT_CI_*`, `.env.agent-ci`, and `.github/agent-ci*` remain supported compatibility aliases throughout the `0.x` release line.
+- 417bd26: Support private job and service container images with workflow registry credentials, and reuse images that are already cached locally. Refs #384.
+
+### Patch Changes
+
+- Updated dependencies [417bd26]
+- Updated dependencies [417bd26]
+  - dtu-github-actions@0.18.0
+
 ## 0.17.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "run-local-ci",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Run GitHub Actions locally — pause on failure, retry in place, and keep caches on your machine.",
   "keywords": [
     "act-alternative",

--- a/packages/dtu-github-actions/CHANGELOG.md
+++ b/packages/dtu-github-actions/CHANGELOG.md
@@ -1,5 +1,12 @@
 # dtu-github-actions
 
+## 0.18.0
+
+### Minor Changes
+
+- 417bd26: Rename Agent CI to Local CI. The canonical package is now `run-local-ci` and the canonical executable is `local-ci`. The old `@redwoodjs/agent-ci` package forwards to Local CI, while `AGENT_CI_*`, `.env.agent-ci`, and `.github/agent-ci*` remain supported compatibility aliases throughout the `0.x` release line.
+- 417bd26: Support private job and service container images with workflow registry credentials, and reuse images that are already cached locally. Refs #384.
+
 ## 0.17.1
 
 ### Patch Changes

--- a/packages/dtu-github-actions/package.json
+++ b/packages/dtu-github-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtu-github-actions",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Digital Twin Universe - GitHub Actions Mock and Simulation",
   "keywords": [
     "ci",


### PR DESCRIPTION
## Problem

The Local CI rename is merged, but npm still serves the reserved placeholder instead of the working package. The package versions and changelogs need to be prepared before publishing.

## Solution

Version `run-local-ci`, `@redwoodjs/agent-ci`, and `dtu-github-actions` together as 0.18.0. This release makes Local CI the canonical package while keeping the old Agent CI package working as a compatibility wrapper.

## Technical Summary

- Consume the rename and private-image changesets.
- Keep all three public packages on the fixed 0.18.0 version.
- Generate canonical and compatibility-package changelogs before npm publication.
